### PR TITLE
[Asset] 오프라인 에셋 스캐너(ScanWorkspace) 통합 및 Import 파이프라인 고도화

### DIFF
--- a/Editor/Include/SimpleEditor/Asset/ImportPresetManager.h
+++ b/Editor/Include/SimpleEditor/Asset/ImportPresetManager.h
@@ -7,9 +7,15 @@
 #include "SimpleEngine/Core/Functional/Function.h"
 #include "SimpleEngine/Core/Reflection/TypeId.h"
 
+#include <concepts>
+
 
 namespace se::editor
 {
+// forward declaration
+class IPipelineTranslator;
+
+
 /**
  * Translator 타입별 기본 ImportProfile을 관리하는 매니저
  *
@@ -25,6 +31,16 @@ public:
      * @param initializer ImportProfile에 기본 설정을 채우는 콜백
      */
     void RegisterPreset(const TypeId& translator_type, Function<void(ImportProfile&)> initializer);
+
+    /**
+     * 템플릿 인자 T를 통해 Translator 타입을 자동으로 추론하여 프리셋 초기화 함수를 등록합니다.
+     * @tparam T 등록할 Translator 클래스 타입 (IPipelineTranslator를 상속받아야 함)
+     * @param initializer ImportProfile에 기본 설정을 채우는 콜백
+     */
+    template <typename T, typename Fn>
+        requires std::derived_from<T, IPipelineTranslator>
+        && std::invocable<Fn, ImportProfile&>
+    void RegisterPreset(Fn&& initializer);
 
     /**
      * Translator 타입에 맞는 기본 ImportProfile을 생성하여 반환합니다.
@@ -44,4 +60,12 @@ public:
 private:
     HashMap<TypeId, Function<void(ImportProfile&)>> preset_map;
 };
+
+template <typename T, typename Fn>
+    requires std::derived_from<T, IPipelineTranslator>
+    && std::invocable<Fn, ImportProfile&>
+void ImportPresetManager::RegisterPreset(Fn&& initializer)
+{
+    RegisterPreset(TypeId::Get<T>(), std::forward<Fn>(initializer));
+}
 } // namespace se::editor

--- a/Editor/Include/SimpleEditor/Asset/ImportPresetManager.h
+++ b/Editor/Include/SimpleEditor/Asset/ImportPresetManager.h
@@ -35,8 +35,9 @@ public:
     [[nodiscard]] ImportProfile GetDefaultProfile(const TypeId& translator_type) const;
 
     /**
-     * 소스 파일 확장자로부터 적절한 Translator TypeId를 찾아 기본 프로파일을 반환합니다.
-     * 이 메서드는 등록된 모든 프리셋을 순회하지 않고, 호출자가 Translator TypeId를 이미 알고 있는 경우에 사용합니다.
+     * 주어진 Translator TypeId에 대한 기본 프리셋 등록 여부를 확인합니다.
+     * @param translator_type Translator의 TypeId
+     * @return 해당 TypeId에 대한 프리셋이 등록되어 있으면 true, 아니면 false
      */
     [[nodiscard]] bool HasPreset(const TypeId& translator_type) const;
 

--- a/Editor/Include/SimpleEditor/Asset/ImportPresetManager.h
+++ b/Editor/Include/SimpleEditor/Asset/ImportPresetManager.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "SimpleEditor/EditorCommon.h"
+#include "SimpleEditor/Asset/ImportProfile.h"
+
+#include "SimpleEngine/Core/Container/HashMap.h"
+#include "SimpleEngine/Core/Functional/Function.h"
+#include "SimpleEngine/Core/Reflection/TypeId.h"
+
+
+namespace se::editor
+{
+/**
+ * Translator 타입별 기본 ImportProfile을 관리하는 매니저
+ *
+ * 각 Translator(예: AssimpTranslator)에 대해 기본 ImportSettings를 미리 등록해 두면,
+ * EnsureMetaFile()에서 새 .meta 파일 생성 시 빈 프로파일 대신 적절한 기본값을 사용할 수 있습니다.
+ */
+class SE_EDITOR_API ImportPresetManager
+{
+public:
+    /**
+     * Translator 타입에 대한 기본 프리셋 초기화 함수를 등록합니다.
+     * @param translator_type Translator의 TypeId (예: TypeId::Get<AssimpTranslator>())
+     * @param initializer ImportProfile에 기본 설정을 채우는 콜백
+     */
+    void RegisterPreset(const TypeId& translator_type, Function<void(ImportProfile&)> initializer);
+
+    /**
+     * Translator 타입에 맞는 기본 ImportProfile을 생성하여 반환합니다.
+     * 등록된 프리셋이 없으면 빈 ImportProfile을 반환합니다.
+     * @param translator_type Translator의 TypeId
+     * @return 기본값이 채워진 ImportProfile
+     */
+    [[nodiscard]] ImportProfile GetDefaultProfile(const TypeId& translator_type) const;
+
+    /**
+     * 소스 파일 확장자로부터 적절한 Translator TypeId를 찾아 기본 프로파일을 반환합니다.
+     * 이 메서드는 등록된 모든 프리셋을 순회하지 않고, 호출자가 Translator TypeId를 이미 알고 있는 경우에 사용합니다.
+     */
+    [[nodiscard]] bool HasPreset(const TypeId& translator_type) const;
+
+private:
+    HashMap<TypeId, Function<void(ImportProfile&)>> preset_map;
+};
+} // namespace se::editor

--- a/Editor/Include/SimpleEditor/Asset/ImportProfile.h
+++ b/Editor/Include/SimpleEditor/Asset/ImportProfile.h
@@ -5,6 +5,7 @@
 #include "SimpleEditor/Asset/ImportSettings/ImportSettingsBase.h"
 
 #include "SimpleEngine/Core/Container/HashMap.h"
+#include "SimpleEngine/Core/Input/KeyCode.h"
 #include "SimpleEngine/Core/Reflection/TypeId.h"
 #include "SimpleEngine/Core/Reflection/TypeRegistry.h"
 
@@ -30,13 +31,28 @@ public:
      * @param settings 저장할 설정 객체
      */
     template <typename T>
-        requires std::derived_from<T, ImportSettingsBase>
-    void Set(const T& settings)
+        requires std::derived_from<std::remove_cvref_t<T>, ImportSettingsBase>
+    void Set(T&& settings)
     {
-        // 내부적으로 복사본을 만들어 shared_ptr로 관리
+        using PureType = std::remove_cvref_t<T>;
         settings_map.Insert(
+            TypeId::Get<PureType>(),
+            std::make_shared<PureType>(std::forward<T>(settings))
+        );
+    }
+
+    /**
+     * 특정 타입의 임포트 설정을 In-place로 생성하여 저장합니다.
+     * @tparam T ImportSettingsBase를 상속받은 구체적인 설정 클래스
+     * @param args 생성자에 전달할 인자
+     */
+    template <typename T, typename... Args>
+        requires std::derived_from<T, ImportSettingsBase>
+    void Emplace(Args&&... args)
+    {
+        settings_map.Emplace(
             TypeId::Get<T>(),
-            std::make_shared<T>(settings)
+            std::make_shared<T>(std::forward<Args>(args)...)
         );
     }
 

--- a/Editor/Include/SimpleEditor/Asset/ImportProfile.h
+++ b/Editor/Include/SimpleEditor/Asset/ImportProfile.h
@@ -103,10 +103,12 @@ public:
                     void* raw = info_opt->constructor();
                     ImportSettingsBase* settings = static_cast<ImportSettingsBase*>(raw);
 
+                    ar.BeginObject();
                     if (info_opt->serialize)
                     {
                         info_opt->serialize(ar, settings);
                     }
+                    ar.EndObject();
 
                     config.settings_map.Insert(type_id, std::shared_ptr<ImportSettingsBase>(settings));
                 }
@@ -121,8 +123,7 @@ public:
             for (auto& [type_id, settings_ptr] : config.settings_map)
             {
                 ar.BeginMapKey();
-                TypeId id_copy = type_id;
-                ar << id_copy;
+                ar << type_id;
                 ar.EndMapKey();
 
                 ar.BeginMapValue();
@@ -130,7 +131,9 @@ public:
                 const Optional info_opt = registry.Find(type_id);
                 if (info_opt.HasValue() && info_opt->serialize && settings_ptr)
                 {
+                    ar.BeginObject();
                     info_opt->serialize(ar, settings_ptr.get());
+                    ar.EndObject();
                 }
                 ar.EndMapValue();
             }

--- a/Editor/Include/SimpleEditor/Asset/ImportProfile.h
+++ b/Editor/Include/SimpleEditor/Asset/ImportProfile.h
@@ -43,6 +43,7 @@ public:
 
     /**
      * 특정 타입의 임포트 설정을 In-place로 생성하여 저장합니다.
+     *
      * @tparam T ImportSettingsBase를 상속받은 구체적인 설정 클래스
      * @param args 생성자에 전달할 인자
      */

--- a/Editor/Include/SimpleEditor/Asset/MetaFileContent.h
+++ b/Editor/Include/SimpleEditor/Asset/MetaFileContent.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "SimpleEditor/Asset/ImportProfile.h"
+
+#include "SimpleEngine/Asset/AssetMetadata.h"
+#include "SimpleEngine/Core/Reflection/Annotations.h"
+
+
+namespace se::editor
+{
+/**
+ * .meta 파일의 전체 내용을 표현하는 구조체
+ * Core의 AssetMetadata(DTO)와 Editor의 ImportProfile을 조합하여, TOML .meta 파일로 직렬화합니다.
+ */
+struct SE_ANNOTATION(=meta::SerializeOnly) MetaFileContent
+{
+    /** 소스 파일의 메타데이터 (GUID, 해시, 수정시간 등) */
+    SE_ANNOTATION(=meta::Property)
+    asset::AssetMetadata metadata;
+
+    /** 임포트 설정 (Translator별 설정값) */
+    SE_ANNOTATION(=meta::Property)
+    ImportProfile import_settings;
+};
+} // namespace se::editor
+
+SE_DECLARE_REFLECTION(se::editor::MetaFileContent)

--- a/Editor/Include/SimpleEditor/Asset/MetaFileContent.h
+++ b/Editor/Include/SimpleEditor/Asset/MetaFileContent.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "SimpleEditor/Asset/ImportProfile.h"
+#include "SimpleEditor/Asset/Pipeline/ProcessorEntry.h"
 
 #include "SimpleEngine/Asset/AssetMetadata.h"
 #include "SimpleEngine/Core/Reflection/Annotations.h"
@@ -21,6 +22,10 @@ struct SE_ANNOTATION(=meta::SerializeOnly) MetaFileContent
     /** 임포트 설정 (Translator별 설정값) */
     SE_ANNOTATION(=meta::Property)
     ImportProfile import_settings;
+
+    /** 파이프라인 Processor 실행 목록 (순서 보존) */
+    SE_ANNOTATION(=meta::Property)
+    Array<ProcessorEntry> processor_stack;
 };
 } // namespace se::editor
 

--- a/Editor/Include/SimpleEditor/Asset/MetaFileManager.h
+++ b/Editor/Include/SimpleEditor/Asset/MetaFileManager.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "SimpleEditor/EditorCommon.h"
+#include "SimpleEditor/Asset/MetaFileContent.h"
+
+#include "SimpleEngine/Core/Container/Optional.h"
+#include "SimpleEngine/Core/Types/Path.h"
+
+
+namespace se::editor
+{
+/**
+ * .meta 파일의 읽기/쓰기를 담당하는 정적 유틸리티 클래스
+ *
+ * 모든 .meta 파일은 TOML 포맷으로 저장되며,
+ * MetaFileContent 구조체를 통해 직렬화/역직렬화됩니다.
+ *
+ * .meta 파일 경로 규칙: source_path + ".meta"
+ *   예: "Assets/Models/character.fbx" -> "Assets/Models/character.fbx.meta"
+ */
+struct SE_EDITOR_API MetaFileManager
+{
+    MetaFileManager() = delete;
+
+    /**
+     * .meta 파일을 읽어 MetaFileContent로 반환합니다.
+     * @param source_path 소스 파일 경로 (예: "Assets/character.fbx")
+     * @return 성공 시 MetaFileContent, 실패 시 NullOpt
+     */
+    [[nodiscard]] static Optional<MetaFileContent> Load(const Path& source_path);
+
+    /**
+     * MetaFileContent를 .meta 파일에 저장합니다.
+     * .tmp 확장자로 임시 파일에 먼저 쓴 뒤, 원자적 Rename으로 교체합니다.
+     * @param source_path 소스 파일 경로
+     * @param content 저장할 내용
+     * @return 저장 성공 여부
+     */
+    static bool Save(const Path& source_path, const MetaFileContent& content);
+
+    /**
+     * 소스 파일에 대응하는 .meta 파일이 존재하는지 확인합니다.
+     * @param source_path 소스 파일 경로
+     * @return .meta 파일 존재 여부
+     */
+    [[nodiscard]] static bool HasMeta(const Path& source_path);
+
+    /**
+     * 소스 파일에 대응하는 .meta 파일을 삭제합니다.
+     * @param source_path 소스 파일 경로
+     */
+    static void DeleteMeta(const Path& source_path);
+
+    /**
+     * 소스 파일 경로로부터 .meta 파일 경로를 계산합니다.
+     * @param source_path 소스 파일 경로
+     * @return .meta 파일 경로 (source_path + ".meta")
+     */
+    [[nodiscard]] static Path GetMetaPath(const Path& source_path);
+};
+} // namespace se::editor

--- a/Editor/Include/SimpleEditor/Asset/MetaFileManager.h
+++ b/Editor/Include/SimpleEditor/Asset/MetaFileManager.h
@@ -57,5 +57,12 @@ struct SE_EDITOR_API MetaFileManager
      * @return .meta 파일 경로 (source_path + ".meta")
      */
     [[nodiscard]] static Path GetMetaPath(const Path& source_path);
+
+    /**
+     * .meta 파일 경로에서 원본 소스 파일 경로를 역산합니다.
+     * @param meta_path .meta 파일 경로 (예: "Assets/Models/character.fbx.meta")
+     * @return 소스 파일 경로 (예: "Assets/Models/character.fbx")
+     */
+    [[nodiscard]] static Path GetSourcePath(const Path& meta_path);
 };
 } // namespace se::editor

--- a/Editor/Include/SimpleEditor/Asset/Pipeline/AssetImporter.h
+++ b/Editor/Include/SimpleEditor/Asset/Pipeline/AssetImporter.h
@@ -8,6 +8,7 @@
 #include "SimpleEditor/Asset/Pipeline/Translators/IPipelineTranslator.h"
 
 #include "SimpleEngine/Core/Container/Array.h"
+#include "SimpleEngine/Core/Container/HashMap.h"
 #include "SimpleEngine/Core/Container/HashSet.h"
 #include "SimpleEngine/Core/Error/Expected.h"
 #include "SimpleEngine/Core/Types/Path.h"
@@ -94,6 +95,8 @@ private:
     };
 
     Array<TranslatorEntry> translators;
+    HashMap<String, Array<usize>> extension_to_translator_indices;
+
     Array<std::unique_ptr<IPipelineFactory>> factories;
 };
 
@@ -101,9 +104,17 @@ template <typename Translator, typename ... Args>
     requires std::derived_from<Translator, IPipelineTranslator>
 void AssetImporter::RegisterTranslator(Args&&... args)
 {
+    const usize new_index = translators.Len();
+    auto instance = std::make_unique<Translator>(std::forward<Args>(args)...);
+
+    for (const StringView& ext : instance->GetSupportedExtensions())
+    {
+        extension_to_translator_indices[String(ext).ToLower()].Push(new_index);
+    }
+
     translators.Push({
         .type_id = TypeId::Get<Translator>(),
-        .translator = std::make_unique<Translator>(std::forward<Args>(args)...),
+        .translator = std::move(instance),
     });
 }
 

--- a/Editor/Include/SimpleEditor/Asset/Pipeline/AssetImporter.h
+++ b/Editor/Include/SimpleEditor/Asset/Pipeline/AssetImporter.h
@@ -84,8 +84,16 @@ private:
     [[nodiscard]] static Array<PipelineBaseNode*> SortNodesByDependency(const PipelineNodeContainer& container);
 
 private:
-    Array<TypeId> translator_type_ids;
-    Array<std::unique_ptr<IPipelineTranslator>> translators;
+    struct TranslatorEntry
+    {
+        /** Translator의 TypeId */
+        TypeId type_id;
+
+        /** 실제 Translator의 Instance */
+        std::unique_ptr<IPipelineTranslator> translator;
+    };
+
+    Array<TranslatorEntry> translators;
     Array<std::unique_ptr<IPipelineFactory>> factories;
 };
 
@@ -93,8 +101,10 @@ template <typename Translator, typename ... Args>
     requires std::derived_from<Translator, IPipelineTranslator>
 void AssetImporter::RegisterTranslator(Args&&... args)
 {
-    translators.Push(std::make_unique<Translator>(std::forward<Args>(args)...));
-    translator_type_ids.Push(TypeId::Get<Translator>());
+    translators.Push({
+        .type_id = TypeId::Get<Translator>(),
+        .translator = std::make_unique<Translator>(std::forward<Args>(args)...),
+    });
 }
 
 template <typename Factory, typename ... Args>

--- a/Editor/Include/SimpleEditor/Asset/Pipeline/AssetImporter.h
+++ b/Editor/Include/SimpleEditor/Asset/Pipeline/AssetImporter.h
@@ -53,6 +53,13 @@ public:
      */
     [[nodiscard]] bool CanImport(const Path& file_path) const;
 
+    /**
+     * 파일에 대응하는 Translator의 TypeId를 반환합니다.
+     * @param file_path 소스 파일 경로
+     * @return Translator의 TypeId, 없으면 NullOpt
+     */
+    [[nodiscard]] Optional<TypeId> FindTranslatorTypeId(const Path& file_path) const;
+
     /** 등록된 모든 Translator가 지원하는 확장자를 반환합니다. */
     [[nodiscard]] HashSet<StringView> GetAllSupportedExtensions() const;
 
@@ -77,6 +84,7 @@ private:
     [[nodiscard]] static Array<PipelineBaseNode*> SortNodesByDependency(const PipelineNodeContainer& container);
 
 private:
+    Array<TypeId> translator_type_ids;
     Array<std::unique_ptr<IPipelineTranslator>> translators;
     Array<std::unique_ptr<IPipelineFactory>> factories;
 };
@@ -86,6 +94,7 @@ template <typename Translator, typename ... Args>
 void AssetImporter::RegisterTranslator(Args&&... args)
 {
     translators.Push(std::make_unique<Translator>(std::forward<Args>(args)...));
+    translator_type_ids.Push(TypeId::Get<Translator>());
 }
 
 template <typename Factory, typename ... Args>

--- a/Editor/Include/SimpleEditor/Asset/Pipeline/PipelineProcessorStack.h
+++ b/Editor/Include/SimpleEditor/Asset/Pipeline/PipelineProcessorStack.h
@@ -32,6 +32,12 @@ public:
         processors.Push(std::make_unique<T>(std::forward<Args>(args)...));
     }
 
+    /** 이미 생성된 프로세서 인스턴스를 Stack 끝에 추가합니다. */
+    void AddProcessor(std::unique_ptr<IPipelineProcessor> processor)
+    {
+        processors.Push(std::move(processor));
+    }
+
     /** Stack에 있는 모든 프로세서를 순차적으로 실행하여 노드를 가공합니다. */
     void ExecuteStack(PipelineNodeContainer& container) const
     {

--- a/Editor/Include/SimpleEditor/Asset/Pipeline/ProcessorEntry.h
+++ b/Editor/Include/SimpleEditor/Asset/Pipeline/ProcessorEntry.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "SimpleEditor/EditorCommon.h"
+
+#include "SimpleEngine/Core/Reflection/TypeId.h"
+#include "SimpleEngine/Core/Reflection/Annotations.h"
+
+
+namespace se::editor
+{
+/**
+ * 파이프라인에서 실행될 개별 Processor의 직렬화 가능한 데이터 Wrapper
+ */
+struct SE_ANNOTATION(=meta::SerializeOnly) ProcessorEntry
+{
+    /** Processor의 구체 타입 (예: TypeId::Get<StaticMeshOptimizer>()) */
+    SE_ANNOTATION(=meta::Property)
+    TypeId processor_type;
+
+    /** 파이프라인 실행 시 이 Processor를 건너뛸 여부 */
+    SE_ANNOTATION(=meta::Property)
+    bool enabled = true;
+};
+} // namespace se::editor
+
+SE_DECLARE_REFLECTION(se::editor::ProcessorEntry);

--- a/Editor/Source/Asset/EditorAssetSubsystem.cpp
+++ b/Editor/Source/Asset/EditorAssetSubsystem.cpp
@@ -295,8 +295,8 @@ bool EditorAssetSubsystem::CookAsset(const Path& file_path)
     const uint64 file_mtime = FileSystem::LastWriteTime(file_path).ValueOrDefault();
     const uint64 file_size = static_cast<uint64>(FileSystem::FileSize(file_path).ValueOrDefault());
 
-    auto& registry = asset_subsystem->GetRegistry();
-    auto& ddc = asset_subsystem->GetDDC();
+    asset::AssetRegistry& registry = asset_subsystem->GetRegistry();
+    asset::DerivedDataCache& ddc = asset_subsystem->GetDDC();
 
     // MetaFileContent 갱신 준비
     MetaFileContent updated_content = std::move(meta_content_opt).ValueOrDefault();

--- a/Editor/Source/Asset/EditorAssetSubsystem.cpp
+++ b/Editor/Source/Asset/EditorAssetSubsystem.cpp
@@ -305,9 +305,17 @@ Optional<MetaFileContent> EditorAssetSubsystem::EnsureMetaFile(const Path& sourc
 {
     ZoneScopedN("EditorAssetSubsystem::EnsureMetaFile");
 
-    if (Optional existing_content = MetaFileManager::Load(source_path))
+    // .meta가 있는지 확인
+    if (MetaFileManager::HasMeta(source_path))
     {
-        return existing_content;
+        // 있다면 Load
+        if (Optional existing_content = MetaFileManager::Load(source_path))
+        {
+            return existing_content;
+        }
+
+        ConsoleLog(ELogLevel::Error, "EnsureMetaFile: .meta exists but failed to load for {}. Aborting to prevent data loss.", source_path);
+        return NullOpt;
     }
 
     // 새 MetaFileContent 생성
@@ -374,8 +382,20 @@ bool EditorAssetSubsystem::CookAsset(const Path& file_path)
                 continue;
             }
 
-            IPipelineProcessor* raw = static_cast<IPipelineProcessor*>(info_opt->constructor());
-            stack.AddProcessor(std::unique_ptr<IPipelineProcessor>(raw));
+            if (!Implements<IPipelineProcessor>(info_opt->type_id))
+            {
+                ConsoleLog(
+                    ELogLevel::Warning,
+                    "CookAsset: Processor type does not implement IPipelineProcessor (Skipping): {}",
+                    entry.processor_type.GetName()
+                );
+                continue;
+            }
+
+            void* raw = info_opt->constructor();
+            IPipelineProcessor* processor = CastFromRaw<IPipelineProcessor>(raw, info_opt->type_id);
+
+            stack.AddProcessor(std::unique_ptr<IPipelineProcessor>(processor));
         }
 
         stack_opt.Emplace(std::move(stack));

--- a/Editor/Source/Asset/EditorAssetSubsystem.cpp
+++ b/Editor/Source/Asset/EditorAssetSubsystem.cpp
@@ -103,8 +103,6 @@ void EditorAssetSubsystem::ScanWorkspace(const Path& root_path, bool is_hot_star
         return;
     }
 
-    asset::AssetRegistry& registry = asset_subsystem->GetRegistry();
-
     // === 디렉토리 순회, 파일 분류 ===
     struct OrphanMeta
     {
@@ -225,15 +223,16 @@ void EditorAssetSubsystem::ScanWorkspace(const Path& root_path, bool is_hot_star
             }
         }
 
-        // 이동 매칭 실패 시 새 .meta 생성
+        // 새로운 파일인 경우, .meta 파일 생성
         if (!content_opt.HasValue())
         {
             content_opt = EnsureMetaFile(file_path);
-        }
 
-        if (!content_opt.HasValue())
-        {
-            continue;
+            // EnsureMetaFile이 실패한 경우 (로그는 내부에서 남김)
+            if (!content_opt.HasValue())
+            {
+                continue;
+            }
         }
 
         const asset::AssetMetadata& meta = content_opt->metadata;
@@ -242,7 +241,8 @@ void EditorAssetSubsystem::ScanWorkspace(const Path& root_path, bool is_hot_star
 
         if (is_new || is_dirty)
         {
-            // TODO: BackgroundWorker::PushCookTask(file_path) 호출하여 백그라운드 굽기
+            // TODO: BackgroundWorker::PushCookTask(file_path) 호출하여 백그라운드에서 DDC 굽기
+            // 이후 RegisterFromMeta로 Registry에 등록
             if (is_new)
             {
                 ++new_count;
@@ -257,6 +257,7 @@ void EditorAssetSubsystem::ScanWorkspace(const Path& root_path, bool is_hot_star
             ++clean_count;
         }
 
+        // AssetRegistry에 각 Sub-asset을 등록 (없으면 무시)
         RegisterFromMeta(file_path, meta);
     }
 
@@ -264,6 +265,8 @@ void EditorAssetSubsystem::ScanWorkspace(const Path& root_path, bool is_hot_star
     uint32 orphaned_count = 0;
     if (is_hot_start)
     {
+        asset::AssetRegistry& registry = asset_subsystem->GetRegistry();
+
         Array<Path> orphaned;
         registry.VisitAllPaths([&found_files, &orphaned](const Path& registered_path)
         {

--- a/Editor/Source/Asset/EditorAssetSubsystem.cpp
+++ b/Editor/Source/Asset/EditorAssetSubsystem.cpp
@@ -1,3 +1,5 @@
+// ReSharper disable CppMemberFunctionMayBeStatic
+// ReSharper disable CppMemberFunctionMayBeConst
 #include "Asset/EditorAssetSubsystem.h"
 
 #include "SimpleEditor/Asset/MetaFileContent.h"
@@ -59,7 +61,7 @@ bool EditorAssetSubsystem::Initialize()
     // TODO: [VPath] 스캔 대상 스킴을 설정 파일에서 읽도록 변경
     VFS::Get().VisitMounts([&](StringView scheme, const Path& physical_path, int32)
     {
-        if (scheme != "Assets")
+        if (!scheme.Contains("Assets"))
         {
             return;
         }
@@ -97,53 +99,59 @@ void EditorAssetSubsystem::ScanDirectory(const Path& root_path)
 
     if (!root_path.Exists() || !root_path.IsDirectory())
     {
-        ConsoleLog(ELogLevel::Warning, "ScanDirectory: Invalid directory: {}", root_path.ToString());
+        ConsoleLog(ELogLevel::Warning, "ScanDirectory: Invalid directory: {}", root_path);
         return;
     }
 
     uint32 scanned_count = 0;
-    for (const DirectoryEntry& entry : FileSystem::ReadDir(root_path))
+
+    Array<Path> stack;
+    stack.Push(root_path);
+    while (const Optional dir = stack.Pop())
     {
-        const Path entry_path = entry.GetPath();
-
-        // 디렉토리는 재귀적으로 스캔
-        if (entry.IsDirectory())
+        for (const DirectoryEntry& entry : FileSystem::ReadDir(*dir))
         {
-            ScanDirectory(entry_path);
-            continue;
-        }
+            const Path entry_path = entry.GetPath();
 
-        // 일반 파일이 아닌 경우 스킵
-        if (!entry.IsFile())
-        {
-            continue;
-        }
+            // 디렉토리는 재귀적으로 스캔
+            if (entry.IsDirectory())
+            {
+                stack.Push(entry_path);
+                continue;
+            }
 
-        // .meta 파일 자체는 스킵
-        const Optional ext = entry_path.Extension();
-        if (ext == ".meta")
-        {
-            continue;
-        }
+            // 일반 파일이 아닌 경우 스킵
+            if (!entry.IsFile())
+            {
+                continue;
+            }
 
-        // Import 불가능한 파일은 스킵
-        if (!importer->CanImport(entry_path))
-        {
-            continue;
-        }
+            // .meta 파일 자체는 스킵
+            const Optional ext = entry_path.Extension();
+            if (ext == ".meta")
+            {
+                continue;
+            }
 
-        // .meta 파일 보장
-        if (!EnsureMetaFile(entry_path))
-        {
-            continue;
-        }
+            // Import 불가능한 파일은 스킵
+            if (!importer->CanImport(entry_path))
+            {
+                continue;
+            }
 
-        // Registry에 등록
-        RegisterFromMeta(entry_path);
-        ++scanned_count;
+            // .meta 파일 보장
+            if (!EnsureMetaFile(entry_path))
+            {
+                continue;
+            }
+
+            // Registry에 등록
+            RegisterFromMeta(entry_path);
+            ++scanned_count;
+        }
     }
 
-    ConsoleLog(ELogLevel::Info, "ScanDirectory: Registered {} assets from: {}", scanned_count, root_path.ToString());
+    ConsoleLog(ELogLevel::Info, "ScanDirectory: Registered {} assets from: {}", scanned_count, root_path);
 }
 
 bool EditorAssetSubsystem::EnsureMetaFile(const Path& source_path)
@@ -170,11 +178,11 @@ bool EditorAssetSubsystem::EnsureMetaFile(const Path& source_path)
 
     if (!MetaFileManager::Save(source_path, content))
     {
-        ConsoleLog(ELogLevel::Error, "Failed to create .meta for: {}", source_path.ToString());
+        ConsoleLog(ELogLevel::Error, "Failed to create .meta for: {}", source_path);
         return false;
     }
 
-    ConsoleLog(ELogLevel::Info, "Created .meta for: {}", source_path.ToString());
+    ConsoleLog(ELogLevel::Info, "Created .meta for: {}", source_path);
     return true;
 }
 
@@ -185,11 +193,12 @@ void EditorAssetSubsystem::RegisterFromMeta(const Path& source_path)
     const Optional content_opt = MetaFileManager::Load(source_path);
     if (!content_opt.HasValue())
     {
+        ConsoleLog(ELogLevel::Error, "RegisterFromMeta: No .meta file for: {}", source_path);
         return;
     }
 
     const asset::AssetMetadata& meta = content_opt->metadata;
-    auto& registry = asset_subsystem->GetRegistry();
+    asset::AssetRegistry& registry = asset_subsystem->GetRegistry();
 
     // Sub-asset 목록이 비어있으면 아직 Import가 안 된 상태이므로 스킵
     if (meta.sub_assets.IsEmpty())
@@ -198,16 +207,19 @@ void EditorAssetSubsystem::RegisterFromMeta(const Path& source_path)
     }
 
     // 각 Sub-asset을 Registry에 등록
-    for (const auto& sub : meta.sub_assets)
+    for (const asset::SubAssetMeta& sub : meta.sub_assets)
     {
         const asset::AssetId asset_id{ sub.guid };
-        const asset::AssetPath asset_path{ source_path, sub.name };
+        // TODO: [VPath] 물리 경로 대신 VPath를 AssetPath에 사용하도록 마이그레이션
+        asset::AssetPath asset_path{ source_path, sub.name };
 
-        registry.RegisterAsset(asset_id, sub.type, asset_path, meta);
+        asset::AssetMetadata sub_meta = meta;
+        sub_meta.guid = sub.guid;
+
+        registry.RegisterAsset(asset_id, sub.type, std::move(asset_path), std::move(sub_meta));
     }
 }
 
-// ReSharper disable once CppMemberFunctionMayBeConst
 bool EditorAssetSubsystem::CookAsset(const Path& file_path)
 {
     ZoneScopedN("EditorAssetSubsystem::CookAsset");
@@ -241,12 +253,11 @@ bool EditorAssetSubsystem::CookAsset(const Path& file_path)
 
     // MetaFileContent 갱신 준비
     MetaFileContent updated_content = std::move(meta_content_opt).ValueOrDefault();
-    updated_content.metadata = {
-        .source_hash = source_hash,
-        .source_mtime = file_mtime,
-        .source_size = file_size,
-        .cache_version = current_cache_version,
-    };
+    updated_content.metadata.source_hash = source_hash;
+    updated_content.metadata.source_mtime = file_mtime;
+    updated_content.metadata.source_size = file_size;
+    updated_content.metadata.cache_version = current_cache_version;
+    updated_content.metadata.sub_assets.Clear();
 
     // Primary GUID 보장
     if (!updated_content.metadata.guid.IsValid())
@@ -273,11 +284,14 @@ bool EditorAssetSubsystem::CookAsset(const Path& file_path)
         updated_content.metadata.sub_assets.Push({
             .name = name,
             .guid = asset_id.GetGuid(),
-            .type = asset_type
+            .type = asset_type,
         });
 
         // Registry 등록
-        registry.RegisterAsset(asset_id, asset_type, asset_path, updated_content.metadata);
+        asset::AssetMetadata sub_meta = updated_content.metadata;
+        sub_meta.guid = asset_id.GetGuid();
+
+        registry.RegisterAsset(asset_id, asset_type, std::move(asset_path), std::move(sub_meta));
 
         // DDC 굽기 (직렬화)
         if (!source_hash.IsEmpty())
@@ -295,15 +309,171 @@ bool EditorAssetSubsystem::CookAsset(const Path& file_path)
 
         // AssetCache 등록은 Callback 후 자동으로 이루어짐
         // [AssetSubsystem::LoadInternal 참고]
+        // TODO: [Phase 5] AssetDependency 추적 — import 결과의 의존 파일 목록을 DependencyGraph에 등록
+        // TODO: [Phase 7] Hot-reload 시 AssetCache::FindOrCreate + ExchangeAsset으로 메모리 교체
     }
 
     // .meta 파일 갱신 (Sub-asset 정보 기록)
     if (!MetaFileManager::Save(file_path, updated_content))
     {
-        ConsoleLog(ELogLevel::Warning, "CookAsset: Failed to update .meta for: {}", file_path.ToString());
+        ConsoleLog(ELogLevel::Warning, "CookAsset: Failed to update .meta for: {}", file_path);
     }
 
     ConsoleLog(ELogLevel::Info, "Successfully cooked {} assets from: {}", result.GetCount(), file_path);
     return true;
+}
+
+void EditorAssetSubsystem::ScanAndReconcile(const Path& root_path)
+{
+    ZoneScopedN("EditorAssetSubsystem::ScanAndReconcile");
+
+    auto& registry = asset_subsystem->GetRegistry();
+
+    // 파일 시스템에서 발견된 Import 가능 파일을 추적
+    HashSet<Path> found_files;
+
+    // 반복적 DFS로 디렉토리 순회 (깊은 계층 구조에서 스택 오버플로 방지)
+    Array<Path> stack;
+    stack.Push(root_path);
+
+    uint32 new_count = 0;
+    uint32 dirty_count = 0;
+
+    while (const Optional dir = stack.Pop())
+    {
+        for (const DirectoryEntry& entry : FileSystem::ReadDir(*dir))
+        {
+            if (entry.IsDirectory())
+            {
+                stack.Push(entry.GetPath());
+                continue;
+            }
+
+            if (!entry.IsFile())
+            {
+                continue;
+            }
+
+            const Path file_path = entry.GetPath();
+
+            // .meta 파일 자체는 스킵
+            if (file_path.Extension() == ".meta")
+            {
+                continue;
+            }
+
+            // Import 불가능한 파일은 스킵
+            if (!importer->CanImport(file_path))
+            {
+                continue;
+            }
+
+            found_files.Insert(file_path);
+
+            if (!MetaFileManager::HasMeta(file_path))
+            {
+                // 새 파일: .meta 생성 -> Registry 등록
+                // TODO: [Phase 6] CookAsset을 Background thread로 dispatch
+                EnsureMetaFile(file_path);
+                RegisterFromMeta(file_path);
+                ++new_count;
+                continue;
+            }
+
+            // 기존 파일: 변경 여부 확인
+            const Optional content_opt = MetaFileManager::Load(file_path);
+            if (!content_opt.HasValue())
+            {
+                continue;
+            }
+
+            if (IsAssetDirty(file_path, content_opt->metadata))
+            {
+                // TODO: [Phase 6] Dirty 에셋을 Background thread cook queue에 추가
+                ConsoleLog(ELogLevel::Info, "Dirty asset detected: {}", file_path);
+                ++dirty_count;
+            }
+
+            // Registry에 등록 (아직 없다면 — Sub-asset이 비어있으면 RegisterFromMeta가 스킵)
+            RegisterFromMeta(file_path);
+        }
+    }
+
+    // 삭제된 파일 감지: Registry에 있지만 파일 시스템에 없는 에셋 제거
+    Array<Path> orphaned;
+    registry.VisitAllPaths([&found_files, &orphaned](const Path& registered_path)
+    {
+        if (!found_files.Contains(registered_path))
+        {
+            orphaned.Push(registered_path);
+        }
+    });
+
+    for (const Path& path : orphaned)
+    {
+        ConsoleLog(ELogLevel::Warning, "Asset file deleted (offline): {}", path);
+        registry.UnregisterByPath(path);
+        MetaFileManager::DeleteMeta(path);
+    }
+
+    ConsoleLog(
+        ELogLevel::Info,
+        "ScanAndReconcile: new={}, dirty={}, orphaned={} in: {}",
+        new_count, dirty_count, orphaned.Len(), root_path
+    );
+}
+
+bool EditorAssetSubsystem::IsAssetDirty(const Path& source_path, const asset::AssetMetadata& meta) const
+{
+    // Quick reject: mtime이 동일하면 변경 없음
+    const uint64 current_mtime = FileSystem::LastWriteTime(source_path).ValueOrDefault();
+    if (current_mtime == meta.source_mtime)
+    {
+        return false;
+    }
+
+    // mtime이 다르면 size 비교 (size가 달라지면 확실히 변경됨)
+    const uint64 current_size = static_cast<uint64>(FileSystem::FileSize(source_path).ValueOrDefault());
+    if (current_size != meta.source_size)
+    {
+        return true;
+    }
+
+    // mtime 변경 + size 동일 -> SHA256 해시로 최종 확인
+    // (git branch 전환, touch 등으로 mtime만 바뀐 경우 불필요한 reimport 방지)
+    const String current_hash = SHA256::HashFile(source_path);
+    return current_hash != meta.source_hash;
+}
+
+void EditorAssetSubsystem::SaveRegistrySnapshot()
+{
+    ZoneScopedN("EditorAssetSubsystem::SaveRegistrySnapshot");
+
+    const asset::AssetRegistry& registry = asset_subsystem->GetRegistry();
+    const Path snapshot_path = GetRegistrySnapshotPath();
+
+    if (registry.SaveToFile(snapshot_path))
+    {
+        ConsoleLog(ELogLevel::Info, "Registry snapshot saved: {}", snapshot_path);
+    }
+}
+
+bool EditorAssetSubsystem::LoadRegistrySnapshot()
+{
+    ZoneScopedN("EditorAssetSubsystem::LoadRegistrySnapshot");
+
+    const Path snapshot_path = GetRegistrySnapshotPath();
+    if (!snapshot_path.Exists())
+    {
+        return false;
+    }
+
+    return asset_subsystem->GetRegistry().LoadFromFile(snapshot_path);
+}
+
+Path EditorAssetSubsystem::GetRegistrySnapshotPath()
+{
+    // TODO: [VPath] VFS를 통해 프로젝트 빌드 디렉토리를 resolve하도록 변경
+    return Path{ "Build" } / "registry.bin";
 }
 } // namespace se::editor

--- a/Editor/Source/Asset/EditorAssetSubsystem.cpp
+++ b/Editor/Source/Asset/EditorAssetSubsystem.cpp
@@ -1,5 +1,7 @@
 #include "Asset/EditorAssetSubsystem.h"
 
+#include "SimpleEditor/Asset/MetaFileContent.h"
+#include "SimpleEditor/Asset/MetaFileManager.h"
 #include "SimpleEditor/Asset/Pipeline/AssetImporter.h"
 #include "SimpleEditor/Asset/Pipeline/Factories/StaticMeshFactory.h"
 #include "SimpleEditor/Asset/Pipeline/Translators/AssimpTranslator.h"
@@ -8,11 +10,15 @@
 #include "SimpleEngine/Asset/AssetRegistry.h"
 #include "SimpleEngine/Asset/AssetSubsystem.h"
 #include "SimpleEngine/Asset/DerivedDataCache.h"
+#include "SimpleEngine/Core/Container/HashSet.h"
 #include "SimpleEngine/Core/FileSystem/FileSystem.h"
+#include "SimpleEngine/Core/FileSystem/VFS.h"
 #include "SimpleEngine/Core/Logging/Logging.h"
 #include "SimpleEngine/Core/Subsystem/SubsystemRegistration.h"
 #include "SimpleEngine/Utility/SHA256.h"
 #include "SimpleEngine/Utility/SubsystemUtils.h"
+
+#include "tracy/Tracy.hpp"
 
 
 namespace se::editor
@@ -46,19 +52,159 @@ bool EditorAssetSubsystem::Initialize()
         return CookAsset(file_path);
     });
 
-    // TODO: 캐시 불러오는 로직
+    // Registry 스냅샷 복원 시도
+    const bool snapshot_loaded = LoadRegistrySnapshot();
+
+    // VFS "Assets" 스킴에 마운트된 디렉토리를 스캔
+    // TODO: [VPath] 스캔 대상 스킴을 설정 파일에서 읽도록 변경
+    VFS::Get().VisitMounts([&](StringView scheme, const Path& physical_path, int32)
+    {
+        if (scheme != "Assets")
+        {
+            return;
+        }
+
+        if (snapshot_loaded)
+        {
+            // Hot Start: 스냅샷과 파일 시스템 비교
+            ScanAndReconcile(physical_path);
+        }
+        else
+        {
+            // Cold Start: 전체 스캔
+            ScanDirectory(physical_path);
+        }
+    });
+
     return true;
 }
 
 void EditorAssetSubsystem::Release()
 {
+    // 에디터 종료 시 Registry 스냅샷 저장
+    SaveRegistrySnapshot();
+
     if (asset_subsystem)
     {
         asset_subsystem->SetDDCMissHandler(nullptr);
     }
     importer.reset();
+}
 
-    // TODO: 캐시 저장 로직
+void EditorAssetSubsystem::ScanDirectory(const Path& root_path)
+{
+    ZoneScopedN("EditorAssetSubsystem::ScanDirectory");
+
+    if (!root_path.Exists() || !root_path.IsDirectory())
+    {
+        ConsoleLog(ELogLevel::Warning, "ScanDirectory: Invalid directory: {}", root_path.ToString());
+        return;
+    }
+
+    uint32 scanned_count = 0;
+    for (const DirectoryEntry& entry : FileSystem::ReadDir(root_path))
+    {
+        const Path entry_path = entry.GetPath();
+
+        // 디렉토리는 재귀적으로 스캔
+        if (entry.IsDirectory())
+        {
+            ScanDirectory(entry_path);
+            continue;
+        }
+
+        // 일반 파일이 아닌 경우 스킵
+        if (!entry.IsFile())
+        {
+            continue;
+        }
+
+        // .meta 파일 자체는 스킵
+        const Optional ext = entry_path.Extension();
+        if (ext == ".meta")
+        {
+            continue;
+        }
+
+        // Import 불가능한 파일은 스킵
+        if (!importer->CanImport(entry_path))
+        {
+            continue;
+        }
+
+        // .meta 파일 보장
+        if (!EnsureMetaFile(entry_path))
+        {
+            continue;
+        }
+
+        // Registry에 등록
+        RegisterFromMeta(entry_path);
+        ++scanned_count;
+    }
+
+    ConsoleLog(ELogLevel::Info, "ScanDirectory: Registered {} assets from: {}", scanned_count, root_path.ToString());
+}
+
+bool EditorAssetSubsystem::EnsureMetaFile(const Path& source_path)
+{
+    ZoneScopedN("EditorAssetSubsystem::EnsureMetaFile");
+
+    if (MetaFileManager::HasMeta(source_path))
+    {
+        return true;
+    }
+
+    // 새 MetaFileContent 생성
+    MetaFileContent content;
+    content.metadata = {
+        .guid = Guid::NewGuid(),
+        .source_hash = SHA256::HashFile(source_path),
+        .source_mtime = FileSystem::LastWriteTime(source_path).ValueOrDefault(),
+        .source_size = static_cast<uint64>(FileSystem::FileSize(source_path).ValueOrDefault()),
+        .cache_version = 1,
+    };
+
+    // ImportProfile은 기본값 (빈 프로파일)으로 생성
+    // TODO: ImportPresetManager에서 Translator별 기본 프리셋 로드
+
+    if (!MetaFileManager::Save(source_path, content))
+    {
+        ConsoleLog(ELogLevel::Error, "Failed to create .meta for: {}", source_path.ToString());
+        return false;
+    }
+
+    ConsoleLog(ELogLevel::Info, "Created .meta for: {}", source_path.ToString());
+    return true;
+}
+
+void EditorAssetSubsystem::RegisterFromMeta(const Path& source_path)
+{
+    ZoneScopedN("EditorAssetSubsystem::RegisterFromMeta");
+
+    const Optional content_opt = MetaFileManager::Load(source_path);
+    if (!content_opt.HasValue())
+    {
+        return;
+    }
+
+    const asset::AssetMetadata& meta = content_opt->metadata;
+    auto& registry = asset_subsystem->GetRegistry();
+
+    // Sub-asset 목록이 비어있으면 아직 Import가 안 된 상태이므로 스킵
+    if (meta.sub_assets.IsEmpty())
+    {
+        return;
+    }
+
+    // 각 Sub-asset을 Registry에 등록
+    for (const auto& sub : meta.sub_assets)
+    {
+        const asset::AssetId asset_id{ sub.guid };
+        const asset::AssetPath asset_path{ source_path, sub.name };
+
+        registry.RegisterAsset(asset_id, sub.type, asset_path, meta);
+    }
 }
 
 // ReSharper disable once CppMemberFunctionMayBeConst
@@ -66,8 +212,17 @@ bool EditorAssetSubsystem::CookAsset(const Path& file_path)
 {
     ZoneScopedN("EditorAssetSubsystem::CookAsset");
 
+    // .meta에서 ImportProfile 획득 (없으면 기본값)
+    Optional meta_content_opt = MetaFileManager::Load(file_path);
+    ImportProfile import_profile = meta_content_opt
+        .Map([](const MetaFileContent& content)
+        {
+            return content.import_settings;
+        })
+        .ValueOrDefault();
+
     // Import 수행
-    const auto result_exp = importer->Import(file_path);
+    const auto result_exp = importer->Import(file_path, import_profile);
     if (!result_exp.HasValue())
     {
         ConsoleLog(ELogLevel::Error, "Cook failed: {}", result_exp.Error().What());
@@ -79,10 +234,25 @@ bool EditorAssetSubsystem::CookAsset(const Path& file_path)
     const String source_hash = SHA256::HashFile(file_path); // TODO: 나중에 xxHash로 변경
     constexpr uint32 current_cache_version = 1;
     const uint64 file_mtime = FileSystem::LastWriteTime(file_path).ValueOrDefault();
-    const uint64 file_size = FileSystem::FileSize(file_path).ValueOrDefault();
+    const uint64 file_size = static_cast<uint64>(FileSystem::FileSize(file_path).ValueOrDefault());
 
     auto& registry = asset_subsystem->GetRegistry();
     auto& ddc = asset_subsystem->GetDDC();
+
+    // MetaFileContent 갱신 준비
+    MetaFileContent updated_content = std::move(meta_content_opt).ValueOrDefault();
+    updated_content.metadata = {
+        .source_hash = source_hash,
+        .source_mtime = file_mtime,
+        .source_size = file_size,
+        .cache_version = current_cache_version,
+    };
+
+    // Primary GUID 보장
+    if (!updated_content.metadata.guid.IsValid())
+    {
+        updated_content.metadata.guid = Guid::NewGuid();
+    }
 
     // Registry 및 DDC 갱신
     for (const auto& [name, idx] : result.GetNameToIndexMap())
@@ -99,21 +269,15 @@ bool EditorAssetSubsystem::CookAsset(const Path& file_path)
         // 기존 ID 재사용 또는 새 GUID 발급
         asset::AssetId asset_id = registry.GetAssetId(asset_path).ValueOr(asset::AssetId{ Guid::NewGuid() });
 
-        // Meta 생성
-        asset::AssetMetadata meta;
-        meta.guid = asset_id.GetGuid();
-        meta.source_hash = source_hash;
-        meta.source_mtime = file_mtime;
-        meta.source_size = file_size;
-        meta.cache_version = current_cache_version;
-        meta.sub_assets.Push({
+        // Meta에 Sub-asset 정보 추가
+        updated_content.metadata.sub_assets.Push({
             .name = name,
             .guid = asset_id.GetGuid(),
             .type = asset_type
         });
 
         // Registry 등록
-        registry.RegisterAsset(asset_id, asset_type, asset_path, std::move(meta));
+        registry.RegisterAsset(asset_id, asset_type, asset_path, updated_content.metadata);
 
         // DDC 굽기 (직렬화)
         if (!source_hash.IsEmpty())
@@ -131,6 +295,12 @@ bool EditorAssetSubsystem::CookAsset(const Path& file_path)
 
         // AssetCache 등록은 Callback 후 자동으로 이루어짐
         // [AssetSubsystem::LoadInternal 참고]
+    }
+
+    // .meta 파일 갱신 (Sub-asset 정보 기록)
+    if (!MetaFileManager::Save(file_path, updated_content))
+    {
+        ConsoleLog(ELogLevel::Warning, "CookAsset: Failed to update .meta for: {}", file_path.ToString());
     }
 
     ConsoleLog(ELogLevel::Info, "Successfully cooked {} assets from: {}", result.GetCount(), file_path);

--- a/Editor/Source/Asset/EditorAssetSubsystem.cpp
+++ b/Editor/Source/Asset/EditorAssetSubsystem.cpp
@@ -4,7 +4,9 @@
 
 #include "SimpleEditor/Asset/MetaFileContent.h"
 #include "SimpleEditor/Asset/MetaFileManager.h"
+#include "SimpleEditor/Asset/ImportSettings/MeshImportSettings.h"
 #include "SimpleEditor/Asset/Pipeline/AssetImporter.h"
+#include "SimpleEditor/Asset/Pipeline/PipelineProcessorStack.h"
 #include "SimpleEditor/Asset/Pipeline/Factories/StaticMeshFactory.h"
 #include "SimpleEditor/Asset/Pipeline/Translators/AssimpTranslator.h"
 
@@ -16,6 +18,7 @@
 #include "SimpleEngine/Core/FileSystem/FileSystem.h"
 #include "SimpleEngine/Core/FileSystem/VFS.h"
 #include "SimpleEngine/Core/Logging/Logging.h"
+#include "SimpleEngine/Core/Reflection/TypeRegistry.h"
 #include "SimpleEngine/Core/Subsystem/SubsystemRegistration.h"
 #include "SimpleEngine/Utility/SHA256.h"
 #include "SimpleEngine/Utility/SubsystemUtils.h"
@@ -47,6 +50,12 @@ bool EditorAssetSubsystem::Initialize()
         // Register Factories
         importer->RegisterFactory<StaticMeshFactory>();
     }
+
+    // Translator별 기본 ImportProfile 프리셋 등록
+    preset_manager.RegisterPreset(TypeId::Get<AssimpTranslator>(), [](ImportProfile& profile)
+    {
+        profile.Set(MeshImportSettings{});
+    });
 
     asset_subsystem = &GetSubsystemChecked<asset::AssetSubsystem>();
     asset_subsystem->SetDDCMissHandler([this](asset::AssetSubsystem&, const Path& file_path) -> bool
@@ -160,7 +169,7 @@ void EditorAssetSubsystem::ScanWorkspace(const Path& root_path, bool is_hot_star
 
             if (is_new || is_dirty)
             {
-                // TODO: [Phase 6] BackgroundWorker::PushCookTask(entry_path) 호출하여 백그라운드 굽기
+                // TODO: BackgroundWorker::PushCookTask(entry_path) 호출하여 백그라운드 굽기
                 if (is_new)
                 {
                     ++new_count;
@@ -228,8 +237,11 @@ Optional<MetaFileContent> EditorAssetSubsystem::EnsureMetaFile(const Path& sourc
         .cache_version = 1,
     };
 
-    // ImportProfile은 기본값 (빈 프로파일)으로 생성
-    // TODO: ImportPresetManager에서 Translator별 기본 프리셋 로드
+    // Translator에 맞는 기본 ImportProfile 설정
+    if (const Optional translator_type = importer->FindTranslatorTypeId(source_path))
+    {
+        content.import_settings = preset_manager.GetDefaultProfile(*translator_type);
+    }
 
     if (!MetaFileManager::Save(source_path, content))
     {
@@ -239,32 +251,6 @@ Optional<MetaFileContent> EditorAssetSubsystem::EnsureMetaFile(const Path& sourc
 
     ConsoleLog(ELogLevel::Info, "Created .meta for: {}", source_path);
     return content;
-}
-
-void EditorAssetSubsystem::RegisterFromMeta(const Path& source_path, const asset::AssetMetadata& meta)
-{
-    ZoneScopedN("EditorAssetSubsystem::RegisterFromMeta");
-
-    asset::AssetRegistry& registry = asset_subsystem->GetRegistry();
-
-    // Sub-asset 목록이 비어있으면 아직 Import가 안 된 상태이므로 스킵
-    if (meta.sub_assets.IsEmpty())
-    {
-        return;
-    }
-
-    // 각 Sub-asset을 Registry에 등록
-    for (const asset::SubAssetMeta& sub : meta.sub_assets)
-    {
-        const asset::AssetId asset_id{ sub.guid };
-        // TODO: [VPath] 물리 경로 대신 VPath를 AssetPath에 사용하도록 마이그레이션
-        asset::AssetPath asset_path{ source_path, sub.name };
-
-        asset::AssetMetadata sub_meta = meta;
-        sub_meta.guid = sub.guid;
-
-        registry.RegisterAsset(asset_id, sub.type, std::move(asset_path), std::move(sub_meta));
-    }
 }
 
 bool EditorAssetSubsystem::CookAsset(const Path& file_path)
@@ -280,8 +266,40 @@ bool EditorAssetSubsystem::CookAsset(const Path& file_path)
         })
         .ValueOrDefault();
 
+    // .meta에서 ProcessorStack 복원
+    Optional<PipelineProcessorStack> stack_opt;
+    if (meta_content_opt.HasValue() && !meta_content_opt->processor_stack.IsEmpty())
+    {
+        PipelineProcessorStack stack;
+        const TypeRegistry& type_registry = TypeRegistry::Get();
+
+        for (const ProcessorEntry& entry : meta_content_opt->processor_stack)
+        {
+            if (!entry.enabled)
+            {
+                continue;
+            }
+
+            const Optional info_opt = type_registry.Find(entry.processor_type);
+            if (!info_opt.HasValue() || !info_opt->constructor)
+            {
+                ConsoleLog(
+                    ELogLevel::Warning,
+                    "CookAsset: Processor type not found or not constructible: {}",
+                    entry.processor_type.GetName()
+                );
+                continue;
+            }
+
+            IPipelineProcessor* raw = static_cast<IPipelineProcessor*>(info_opt->constructor());
+            stack.AddProcessor(std::unique_ptr<IPipelineProcessor>(raw));
+        }
+
+        stack_opt.Emplace(std::move(stack));
+    }
+
     // Import 수행
-    const auto result_exp = importer->Import(file_path, import_profile);
+    const auto result_exp = importer->Import(file_path, import_profile, stack_opt);
     if (!result_exp.HasValue())
     {
         ConsoleLog(ELogLevel::Error, "Cook failed: {}", result_exp.Error().What());
@@ -356,8 +374,8 @@ bool EditorAssetSubsystem::CookAsset(const Path& file_path)
 
         // AssetCache 등록은 Callback 후 자동으로 이루어짐
         // [AssetSubsystem::LoadInternal 참고]
-        // TODO: [Phase 5] AssetDependency 추적 — import 결과의 의존 파일 목록을 DependencyGraph에 등록
-        // TODO: [Phase 7] Hot-reload 시 AssetCache::FindOrCreate + ExchangeAsset으로 메모리 교체
+        // TODO: AssetDependency 추적 — import 결과의 의존 파일 목록을 DependencyGraph에 등록
+        // TODO: Hot-reload 시 AssetCache::FindOrCreate + ExchangeAsset으로 메모리 교체
     }
 
     // .meta 파일 갱신 (Sub-asset 정보 기록)
@@ -368,6 +386,32 @@ bool EditorAssetSubsystem::CookAsset(const Path& file_path)
 
     ConsoleLog(ELogLevel::Info, "Successfully cooked {} assets from: {}", result.GetCount(), file_path);
     return true;
+}
+
+void EditorAssetSubsystem::RegisterFromMeta(const Path& source_path, const asset::AssetMetadata& meta)
+{
+    ZoneScopedN("EditorAssetSubsystem::RegisterFromMeta");
+
+    asset::AssetRegistry& registry = asset_subsystem->GetRegistry();
+
+    // Sub-asset 목록이 비어있으면 아직 Import가 안 된 상태이므로 스킵
+    if (meta.sub_assets.IsEmpty())
+    {
+        return;
+    }
+
+    // 각 Sub-asset을 Registry에 등록
+    for (const asset::SubAssetMeta& sub : meta.sub_assets)
+    {
+        const asset::AssetId asset_id{ sub.guid };
+        // TODO: [VPath] 물리 경로 대신 VPath를 AssetPath에 사용하도록 마이그레이션
+        asset::AssetPath asset_path{ source_path, sub.name };
+
+        asset::AssetMetadata sub_meta = meta;
+        sub_meta.guid = sub.guid;
+
+        registry.RegisterAsset(asset_id, sub.type, std::move(asset_path), std::move(sub_meta));
+    }
 }
 
 bool EditorAssetSubsystem::IsAssetDirty(const Path& source_path, const asset::AssetMetadata& meta) const

--- a/Editor/Source/Asset/EditorAssetSubsystem.cpp
+++ b/Editor/Source/Asset/EditorAssetSubsystem.cpp
@@ -54,8 +54,8 @@ bool EditorAssetSubsystem::Initialize()
         return CookAsset(file_path);
     });
 
-    // Registry 스냅샷 복원 시도
-    const bool snapshot_loaded = LoadRegistrySnapshot();
+    // Registry 스냅샷 복원 시도 (성공 시 Hot Start, 실패 시 Cold Start)
+    const bool is_hot_start = LoadRegistrySnapshot();
 
     // VFS "Assets" 스킴에 마운트된 디렉토리를 스캔
     // TODO: [VPath] 스캔 대상 스킴을 설정 파일에서 읽도록 변경
@@ -66,16 +66,7 @@ bool EditorAssetSubsystem::Initialize()
             return;
         }
 
-        if (snapshot_loaded)
-        {
-            // Hot Start: 스냅샷과 파일 시스템 비교
-            ScanAndReconcile(physical_path);
-        }
-        else
-        {
-            // Cold Start: 전체 스캔
-            ScanDirectory(physical_path);
-        }
+        ScanWorkspace(physical_path, is_hot_start);
     });
 
     return true;
@@ -93,20 +84,29 @@ void EditorAssetSubsystem::Release()
     importer.reset();
 }
 
-void EditorAssetSubsystem::ScanDirectory(const Path& root_path)
+void EditorAssetSubsystem::ScanWorkspace(const Path& root_path, bool is_hot_start)
 {
-    ZoneScopedN("EditorAssetSubsystem::ScanDirectory");
+    ZoneScopedN("EditorAssetSubsystem::ScanWorkspace");
 
     if (!root_path.Exists() || !root_path.IsDirectory())
     {
-        ConsoleLog(ELogLevel::Warning, "ScanDirectory: Invalid directory: {}", root_path);
+        ConsoleLog(ELogLevel::Warning, "ScanWorkspace: Invalid directory: {}", root_path);
         return;
     }
 
-    uint32 scanned_count = 0;
+    asset::AssetRegistry& registry = asset_subsystem->GetRegistry();
+
+    // 삭제된 파일 감지를 위한 Set
+    HashSet<Path> found_files;
 
     Array<Path> stack;
     stack.Push(root_path);
+
+    uint32 new_count = 0;
+    uint32 dirty_count = 0;
+    uint32 clean_count = 0;
+
+    // 디렉토리 순회 및 파일 상태 검사
     while (const Optional dir = stack.Pop())
     {
         for (const DirectoryEntry& entry : FileSystem::ReadDir(*dir))
@@ -139,23 +139,74 @@ void EditorAssetSubsystem::ScanDirectory(const Path& root_path)
                 continue;
             }
 
-            // .meta 파일 보장
-            if (Optional content_opt = EnsureMetaFile(entry_path))
+            // 발견된 파일 기록 (Hot Start 시 고아 파일 감지용)
+            if (is_hot_start)
             {
-                // Registry에 등록
-                RegisterFromMeta(entry_path, content_opt->metadata);
-
-                if (content_opt->metadata.sub_assets.IsEmpty())
-                {
-                    // TODO: [Phase 6] CookAsset을 Background thread로 dispatch (초기 대량 굽기)
-                }
-
-                ++scanned_count;
+                found_files.Insert(entry_path);
             }
+
+            // .meta 파일 보장
+            Optional content_opt = EnsureMetaFile(entry_path);
+            if (!content_opt.HasValue())
+            {
+                continue;
+            }
+
+            const asset::AssetMetadata& meta = content_opt->metadata;
+
+            // 상태 판별
+            const bool is_new = meta.sub_assets.IsEmpty();
+            const bool is_dirty = !is_new && IsAssetDirty(entry_path, meta);
+
+            if (is_new || is_dirty)
+            {
+                // TODO: [Phase 6] BackgroundWorker::PushCookTask(entry_path) 호출하여 백그라운드 굽기
+                if (is_new)
+                {
+                    ++new_count;
+                }
+                if (is_dirty)
+                {
+                    ++dirty_count;
+                }
+            }
+            else
+            {
+                ++clean_count;
+            }
+
+            // Registry에 등록 (Sub-asset이 비어있으면 함수 내부에서 알아서 스킵됨)
+            RegisterFromMeta(entry_path, meta);
         }
     }
 
-    ConsoleLog(ELogLevel::Info, "ScanDirectory: Registered {} assets from: {}", scanned_count, root_path);
+    // 삭제된 파일 감지 (Hot Start 전용 로직)
+    uint32 orphaned_count = 0;
+    if (is_hot_start)
+    {
+        Array<Path> orphaned;
+        registry.VisitAllPaths([&found_files, &orphaned](const Path& registered_path)
+        {
+            if (!found_files.Contains(registered_path))
+            {
+                orphaned.Push(registered_path);
+            }
+        });
+
+        for (const Path& path : orphaned)
+        {
+            ConsoleLog(ELogLevel::Warning, "Asset file deleted (offline): {}", path);
+            registry.UnregisterByPath(path);
+            MetaFileManager::DeleteMeta(path);
+            ++orphaned_count;
+        }
+    }
+
+    ConsoleLog(
+        ELogLevel::Info,
+        "ScanWorkspace Complete [HotStart: {}]: new={}, dirty={}, clean={}, orphaned={} in: {}",
+        is_hot_start, new_count, dirty_count, clean_count, orphaned_count, root_path
+    );
 }
 
 Optional<MetaFileContent> EditorAssetSubsystem::EnsureMetaFile(const Path& source_path)
@@ -317,104 +368,6 @@ bool EditorAssetSubsystem::CookAsset(const Path& file_path)
 
     ConsoleLog(ELogLevel::Info, "Successfully cooked {} assets from: {}", result.GetCount(), file_path);
     return true;
-}
-
-void EditorAssetSubsystem::ScanAndReconcile(const Path& root_path)
-{
-    ZoneScopedN("EditorAssetSubsystem::ScanAndReconcile");
-
-    auto& registry = asset_subsystem->GetRegistry();
-
-    // 파일 시스템에서 발견된 Import 가능 파일을 추적
-    HashSet<Path> found_files;
-
-    // 반복적 DFS로 디렉토리 순회 (깊은 계층 구조에서 스택 오버플로 방지)
-    Array<Path> stack;
-    stack.Push(root_path);
-
-    uint32 new_count = 0;
-    uint32 dirty_count = 0;
-
-    while (const Optional dir = stack.Pop())
-    {
-        for (const DirectoryEntry& entry : FileSystem::ReadDir(*dir))
-        {
-            if (entry.IsDirectory())
-            {
-                stack.Push(entry.GetPath());
-                continue;
-            }
-
-            if (!entry.IsFile())
-            {
-                continue;
-            }
-
-            const Path file_path = entry.GetPath();
-
-            // .meta 파일 자체는 스킵
-            if (file_path.Extension() == ".meta")
-            {
-                continue;
-            }
-
-            // Import 불가능한 파일은 스킵
-            if (!importer->CanImport(file_path))
-            {
-                continue;
-            }
-
-            found_files.Insert(file_path);
-
-            if (!MetaFileManager::HasMeta(file_path))
-            {
-                // 새 파일: .meta 생성 -> Registry 등록
-                // TODO: [Phase 6] CookAsset을 Background thread로 dispatch
-                if (Optional content_opt = EnsureMetaFile(file_path))
-                {
-                    RegisterFromMeta(file_path, content_opt->metadata);
-                    ++new_count;
-                }
-                continue;
-            }
-
-            // 기존 파일: 변경 여부 확인
-            if (Optional content_opt = MetaFileManager::Load(file_path))
-            {
-                if (IsAssetDirty(file_path, content_opt->metadata))
-                {
-                    ConsoleLog(ELogLevel::Info, "Dirty asset detected: {}", file_path);
-                    ++dirty_count;
-                }
-
-                // Registry에 등록 (Sub-asset이 비어있으면 RegisterFromMeta가 스킵)
-                RegisterFromMeta(file_path, content_opt->metadata);
-            }
-        }
-    }
-
-    // 삭제된 파일 감지: Registry에 있지만 파일 시스템에 없는 에셋 제거
-    Array<Path> orphaned;
-    registry.VisitAllPaths([&found_files, &orphaned](const Path& registered_path)
-    {
-        if (!found_files.Contains(registered_path))
-        {
-            orphaned.Push(registered_path);
-        }
-    });
-
-    for (const Path& path : orphaned)
-    {
-        ConsoleLog(ELogLevel::Warning, "Asset file deleted (offline): {}", path);
-        registry.UnregisterByPath(path);
-        MetaFileManager::DeleteMeta(path);
-    }
-
-    ConsoleLog(
-        ELogLevel::Info,
-        "ScanAndReconcile: new={}, dirty={}, orphaned={} in: {}",
-        new_count, dirty_count, orphaned.Len(), root_path
-    );
 }
 
 bool EditorAssetSubsystem::IsAssetDirty(const Path& source_path, const asset::AssetMetadata& meta) const

--- a/Editor/Source/Asset/EditorAssetSubsystem.cpp
+++ b/Editor/Source/Asset/EditorAssetSubsystem.cpp
@@ -140,27 +140,31 @@ void EditorAssetSubsystem::ScanDirectory(const Path& root_path)
             }
 
             // .meta 파일 보장
-            if (!EnsureMetaFile(entry_path))
+            if (Optional content_opt = EnsureMetaFile(entry_path))
             {
-                continue;
-            }
+                // Registry에 등록
+                RegisterFromMeta(entry_path, content_opt->metadata);
 
-            // Registry에 등록
-            RegisterFromMeta(entry_path);
-            ++scanned_count;
+                if (content_opt->metadata.sub_assets.IsEmpty())
+                {
+                    // TODO: [Phase 6] CookAsset을 Background thread로 dispatch (초기 대량 굽기)
+                }
+
+                ++scanned_count;
+            }
         }
     }
 
     ConsoleLog(ELogLevel::Info, "ScanDirectory: Registered {} assets from: {}", scanned_count, root_path);
 }
 
-bool EditorAssetSubsystem::EnsureMetaFile(const Path& source_path)
+Optional<MetaFileContent> EditorAssetSubsystem::EnsureMetaFile(const Path& source_path)
 {
     ZoneScopedN("EditorAssetSubsystem::EnsureMetaFile");
 
-    if (MetaFileManager::HasMeta(source_path))
+    if (Optional existing_content = MetaFileManager::Load(source_path))
     {
-        return true;
+        return existing_content;
     }
 
     // 새 MetaFileContent 생성
@@ -179,25 +183,17 @@ bool EditorAssetSubsystem::EnsureMetaFile(const Path& source_path)
     if (!MetaFileManager::Save(source_path, content))
     {
         ConsoleLog(ELogLevel::Error, "Failed to create .meta for: {}", source_path);
-        return false;
+        return NullOpt;
     }
 
     ConsoleLog(ELogLevel::Info, "Created .meta for: {}", source_path);
-    return true;
+    return content;
 }
 
-void EditorAssetSubsystem::RegisterFromMeta(const Path& source_path)
+void EditorAssetSubsystem::RegisterFromMeta(const Path& source_path, const asset::AssetMetadata& meta)
 {
     ZoneScopedN("EditorAssetSubsystem::RegisterFromMeta");
 
-    const Optional content_opt = MetaFileManager::Load(source_path);
-    if (!content_opt.HasValue())
-    {
-        ConsoleLog(ELogLevel::Error, "RegisterFromMeta: No .meta file for: {}", source_path);
-        return;
-    }
-
-    const asset::AssetMetadata& meta = content_opt->metadata;
     asset::AssetRegistry& registry = asset_subsystem->GetRegistry();
 
     // Sub-asset 목록이 비어있으면 아직 Import가 안 된 상태이므로 스킵
@@ -374,28 +370,26 @@ void EditorAssetSubsystem::ScanAndReconcile(const Path& root_path)
             {
                 // 새 파일: .meta 생성 -> Registry 등록
                 // TODO: [Phase 6] CookAsset을 Background thread로 dispatch
-                EnsureMetaFile(file_path);
-                RegisterFromMeta(file_path);
-                ++new_count;
+                if (Optional content_opt = EnsureMetaFile(file_path))
+                {
+                    RegisterFromMeta(file_path, content_opt->metadata);
+                    ++new_count;
+                }
                 continue;
             }
 
             // 기존 파일: 변경 여부 확인
-            const Optional content_opt = MetaFileManager::Load(file_path);
-            if (!content_opt.HasValue())
+            if (Optional content_opt = MetaFileManager::Load(file_path))
             {
-                continue;
-            }
+                if (IsAssetDirty(file_path, content_opt->metadata))
+                {
+                    ConsoleLog(ELogLevel::Info, "Dirty asset detected: {}", file_path);
+                    ++dirty_count;
+                }
 
-            if (IsAssetDirty(file_path, content_opt->metadata))
-            {
-                // TODO: [Phase 6] Dirty 에셋을 Background thread cook queue에 추가
-                ConsoleLog(ELogLevel::Info, "Dirty asset detected: {}", file_path);
-                ++dirty_count;
+                // Registry에 등록 (Sub-asset이 비어있으면 RegisterFromMeta가 스킵)
+                RegisterFromMeta(file_path, content_opt->metadata);
             }
-
-            // Registry에 등록 (아직 없다면 — Sub-asset이 비어있으면 RegisterFromMeta가 스킵)
-            RegisterFromMeta(file_path);
         }
     }
 

--- a/Editor/Source/Asset/EditorAssetSubsystem.cpp
+++ b/Editor/Source/Asset/EditorAssetSubsystem.cpp
@@ -421,6 +421,6 @@ bool EditorAssetSubsystem::LoadRegistrySnapshot()
 Path EditorAssetSubsystem::GetRegistrySnapshotPath()
 {
     // TODO: [VPath] VFS를 통해 프로젝트 빌드 디렉토리를 resolve하도록 변경
-    return Path{ "Build" } / "registry.bin";
+    return "registry.bin";
 }
 } // namespace se::editor

--- a/Editor/Source/Asset/EditorAssetSubsystem.cpp
+++ b/Editor/Source/Asset/EditorAssetSubsystem.cpp
@@ -105,91 +105,159 @@ void EditorAssetSubsystem::ScanWorkspace(const Path& root_path, bool is_hot_star
 
     asset::AssetRegistry& registry = asset_subsystem->GetRegistry();
 
-    // 삭제된 파일 감지를 위한 Set
+    // === 디렉토리 순회, 파일 분류 ===
+    struct OrphanMeta
+    {
+        Path source_path; // 빈 경로면 소비됨(이동 매칭 완료) 표시
+        MetaFileContent content;
+    };
+
+    Array<Path> source_files;
+    Array<OrphanMeta> orphan_metas;
     HashSet<Path> found_files;
 
-    Array<Path> stack;
-    stack.Push(root_path);
-
-    uint32 new_count = 0;
-    uint32 dirty_count = 0;
-    uint32 clean_count = 0;
-
-    // 디렉토리 순회 및 파일 상태 검사
-    while (const Optional dir = stack.Pop())
     {
-        for (const DirectoryEntry& entry : FileSystem::ReadDir(*dir))
+        Array<Path> stack;
+        stack.Push(root_path);
+
+        while (const Optional dir = stack.Pop())
         {
-            const Path entry_path = entry.GetPath();
-
-            // 디렉토리는 재귀적으로 스캔
-            if (entry.IsDirectory())
+            for (const DirectoryEntry& entry : FileSystem::ReadDir(*dir))
             {
-                stack.Push(entry_path);
-                continue;
-            }
+                const Path entry_path = entry.GetPath();
 
-            // 일반 파일이 아닌 경우 스킵
-            if (!entry.IsFile())
-            {
-                continue;
-            }
-
-            // .meta 파일 자체는 스킵
-            const Optional ext = entry_path.Extension();
-            if (ext == ".meta")
-            {
-                continue;
-            }
-
-            // Import 불가능한 파일은 스킵
-            if (!importer->CanImport(entry_path))
-            {
-                continue;
-            }
-
-            // 발견된 파일 기록 (Hot Start 시 고아 파일 감지용)
-            if (is_hot_start)
-            {
-                found_files.Insert(entry_path);
-            }
-
-            // .meta 파일 보장
-            Optional content_opt = EnsureMetaFile(entry_path);
-            if (!content_opt.HasValue())
-            {
-                continue;
-            }
-
-            const asset::AssetMetadata& meta = content_opt->metadata;
-
-            // 상태 판별
-            const bool is_new = meta.sub_assets.IsEmpty();
-            const bool is_dirty = !is_new && IsAssetDirty(entry_path, meta);
-
-            if (is_new || is_dirty)
-            {
-                // TODO: BackgroundWorker::PushCookTask(entry_path) 호출하여 백그라운드 굽기
-                if (is_new)
+                // 디렉토리는 재귀적으로 스캔
+                if (entry.IsDirectory())
                 {
-                    ++new_count;
+                    stack.Push(entry_path);
+                    continue;
                 }
-                if (is_dirty)
+
+                // 일반 파일이 아닌 경우 스킵
+                if (!entry.IsFile())
                 {
-                    ++dirty_count;
+                    continue;
+                }
+
+                // 실제 Source 파일도 같이 존재하는지 확인
+                const Optional ext = entry_path.Extension();
+                if (ext == ".meta")
+                {
+                    // .meta 파일의 소스 파일 존재 여부 확인 -> 없으면 고아 .meta
+                    Path source = MetaFileManager::GetSourcePath(entry_path);
+                    if (!source.Exists())
+                    {
+                        if (Optional content = MetaFileManager::Load(source))
+                        {
+                            orphan_metas.Push({ std::move(source), std::move(content).Value() });
+                        }
+                    }
+                    continue;
+                }
+
+                // Import 불가능한 파일은 스킵
+                if (!importer->CanImport(entry_path))
+                {
+                    continue;
+                }
+
+                source_files.Push(entry_path);
+                if (is_hot_start)
+                {
+                    found_files.Insert(entry_path);
                 }
             }
-            else
-            {
-                ++clean_count;
-            }
-
-            // Registry에 등록 (Sub-asset이 비어있으면 함수 내부에서 알아서 스킵됨)
-            RegisterFromMeta(entry_path, meta);
         }
     }
 
-    // 삭제된 파일 감지 (Hot Start 전용 로직)
+    // === 고아 .meta 해시 인덱스 구축 (이동 감지용) ===
+    HashMap<String, uint32> orphan_by_hash;
+    for (const auto [n, orphan_meta] : orphan_metas | std::views::enumerate)
+    {
+        const String& hash = orphan_meta.content.metadata.source_hash;
+        if (!hash.IsEmpty())
+        {
+            orphan_by_hash.Insert(hash, static_cast<uint32>(n));
+        }
+    }
+
+    // === 소스 파일별 처리 ===
+    uint32 new_count = 0;
+    uint32 dirty_count = 0;
+    uint32 clean_count = 0;
+    uint32 moved_count = 0;
+
+    for (const Path& file_path : source_files)
+    {
+        Optional<MetaFileContent> content_opt;
+
+        if (MetaFileManager::HasMeta(file_path))
+        {
+            // 기존 .meta 로드
+            content_opt = MetaFileManager::Load(file_path);
+        }
+        else if (!orphan_by_hash.IsEmpty())
+        {
+            // .meta 없음 -> 해시 매칭으로 오프라인 이동 감지
+            const String hash = SHA256::HashFile(file_path);
+            if (const Optional idx = orphan_by_hash.Find(hash))
+            {
+                OrphanMeta& orphan = orphan_metas[*idx];
+
+                ConsoleLog(ELogLevel::Info, "Asset moved (offline): {} -> {}", orphan.source_path, file_path);
+
+                // 고아 .meta의 GUID를 계승하여 새 위치에 저장
+                MetaFileContent adopted = std::move(orphan.content);
+                adopted.metadata.source_mtime = FileSystem::LastWriteTime(file_path).ValueOrDefault();
+                adopted.metadata.source_size = static_cast<uint64>(FileSystem::FileSize(file_path).ValueOrDefault());
+
+                MetaFileManager::Save(file_path, adopted);
+                MetaFileManager::DeleteMeta(orphan.source_path);
+
+                orphan.source_path = {}; // 소비됨 표시
+                orphan_by_hash.Remove(hash);
+                ++moved_count;
+
+                content_opt = std::move(adopted);
+            }
+        }
+
+        // 이동 매칭 실패 시 새 .meta 생성
+        if (!content_opt.HasValue())
+        {
+            content_opt = EnsureMetaFile(file_path);
+        }
+
+        if (!content_opt.HasValue())
+        {
+            continue;
+        }
+
+        const asset::AssetMetadata& meta = content_opt->metadata;
+        const bool is_new = meta.sub_assets.IsEmpty();
+        const bool is_dirty = !is_new && IsAssetDirty(file_path, meta);
+
+        if (is_new || is_dirty)
+        {
+            // TODO: BackgroundWorker::PushCookTask(file_path) 호출하여 백그라운드 굽기
+            if (is_new)
+            {
+                ++new_count;
+            }
+            if (is_dirty)
+            {
+                ++dirty_count;
+            }
+        }
+        else
+        {
+            ++clean_count;
+        }
+
+        RegisterFromMeta(file_path, meta);
+    }
+
+    // === 삭제된 파일 감지 (Hot Start 전용) ===
     uint32 orphaned_count = 0;
     if (is_hot_start)
     {
@@ -211,10 +279,22 @@ void EditorAssetSubsystem::ScanWorkspace(const Path& root_path, bool is_hot_star
         }
     }
 
+    // === 매칭되지 않은 고아 .meta 정리 ===
+    uint32 orphan_meta_count = 0;
+    for (const OrphanMeta& orphan : orphan_metas)
+    {
+        if (!orphan.source_path.IsEmpty())
+        {
+            ConsoleLog(ELogLevel::Info, "Deleted orphan .meta: {}", MetaFileManager::GetMetaPath(orphan.source_path));
+            MetaFileManager::DeleteMeta(orphan.source_path);
+            ++orphan_meta_count;
+        }
+    }
+
     ConsoleLog(
         ELogLevel::Info,
-        "ScanWorkspace Complete [HotStart: {}]: new={}, dirty={}, clean={}, orphaned={} in: {}",
-        is_hot_start, new_count, dirty_count, clean_count, orphaned_count, root_path
+        "ScanWorkspace Complete [HotStart: {}]: new={}, dirty={}, clean={}, moved={}, orphaned={}, orphan_meta={} in: {}",
+        is_hot_start, new_count, dirty_count, clean_count, moved_count, orphaned_count, orphan_meta_count, root_path
     );
 }
 

--- a/Editor/Source/Asset/EditorAssetSubsystem.cpp
+++ b/Editor/Source/Asset/EditorAssetSubsystem.cpp
@@ -54,7 +54,7 @@ bool EditorAssetSubsystem::Initialize()
     // Translator별 기본 ImportProfile 프리셋 등록
     preset_manager.RegisterPreset(TypeId::Get<AssimpTranslator>(), [](ImportProfile& profile)
     {
-        profile.Set(MeshImportSettings{});
+        profile.Emplace<MeshImportSettings>();
     });
 
     asset_subsystem = &GetSubsystemChecked<asset::AssetSubsystem>();

--- a/Editor/Source/Asset/EditorAssetSubsystem.cpp
+++ b/Editor/Source/Asset/EditorAssetSubsystem.cpp
@@ -149,7 +149,10 @@ void EditorAssetSubsystem::ScanWorkspace(const Path& root_path, bool is_hot_star
                     {
                         if (Optional content = MetaFileManager::Load(source))
                         {
-                            orphan_metas.Push({ std::move(source), std::move(content).Value() });
+                            orphan_metas.Push({
+                                .source_path = std::move(source),
+                                .content = std::move(content).Value(),
+                            });
                         }
                     }
                     continue;

--- a/Editor/Source/Asset/EditorAssetSubsystem.cpp
+++ b/Editor/Source/Asset/EditorAssetSubsystem.cpp
@@ -52,7 +52,7 @@ bool EditorAssetSubsystem::Initialize()
     }
 
     // Translator별 기본 ImportProfile 프리셋 등록
-    preset_manager.RegisterPreset(TypeId::Get<AssimpTranslator>(), [](ImportProfile& profile)
+    preset_manager.RegisterPreset<AssimpTranslator>([](ImportProfile& profile)
     {
         profile.Emplace<MeshImportSettings>();
     });

--- a/Editor/Source/Asset/EditorAssetSubsystem.h
+++ b/Editor/Source/Asset/EditorAssetSubsystem.h
@@ -34,11 +34,12 @@ public:
 
 public:
     /**
-     * 디렉토리를 재귀적으로 순회하며, Import 가능한 파일에 대해
-     * .meta 파일 보장 및 AssetRegistry 등록을 수행합니다.
+     * 작업 공간(Workspace)의 디렉토리를 순회하며 에셋의 상태를 스캔하고 레지스트리를 갱신합니다.
+     * Import 가능한 파일에 대해 .meta 파일을 보장하고, 변경(New/Dirty) 상태를 감지하여 등록합니다.
      * @param root_path 스캔할 루트 디렉토리 경로
+     * @param is_hot_start true일 경우 레지스트리 스냅샷과 비교하여 삭제된(Orphaned) 에셋을 찾아 등록 해제합니다.
      */
-    void ScanDirectory(const Path& root_path);
+    void ScanWorkspace(const Path& root_path, bool is_hot_start);
 
     /**
      * 소스 파일에 대한 .meta 파일이 존재하는지 확인하고,
@@ -47,13 +48,6 @@ public:
      * @return .meta 파일이 존재하거나 생성에 성공하면 true
      */
     [[nodiscard]] Optional<MetaFileContent> EnsureMetaFile(const Path& source_path);
-
-    /**
-     * Registry 스냅샷과 파일 시스템을 비교하여 변경 사항을 감지합니다.
-     * 새 파일 -> .meta 생성 + 등록, 수정됨 -> Dirty 감지, 삭제됨 -> 등록 해제
-     * @param root_path 스캔할 루트 디렉토리 경로
-     */
-    void ScanAndReconcile(const Path& root_path);
 
 private:
     /**

--- a/Editor/Source/Asset/EditorAssetSubsystem.h
+++ b/Editor/Source/Asset/EditorAssetSubsystem.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "SimpleEditor/Asset/ImportPresetManager.h"
+
 #include "SimpleEngine/Asset/AssetMetadata.h"
 #include "SimpleEngine/Asset/AssetSubsystem.h"
 #include "SimpleEngine/Core/Subsystem/SubsystemBase.h"
@@ -49,14 +51,6 @@ public:
      */
     [[nodiscard]] Optional<MetaFileContent> EnsureMetaFile(const Path& source_path);
 
-private:
-    /**
-     * .meta 파일에서 메타데이터를 읽어 AssetRegistry에 등록합니다.
-     * @param source_path 소스 파일 경로
-     * @param meta
-     */
-    void RegisterFromMeta(const Path& source_path, const asset::AssetMetadata& meta);
-
     /**
      * Asset을 Import하여 Registry 등록과 DDC 바이너리를 생성합니다.
      * .meta 파일이 존재하면 ImportProfile을 획득하여 Import에 전달합니다.
@@ -64,6 +58,14 @@ private:
      * @return 성공 여부
      */
     bool CookAsset(const Path& file_path);
+
+private:
+    /**
+     * .meta 파일에서 메타데이터를 읽어 AssetRegistry에 등록합니다.
+     * @param source_path 소스 파일 경로
+     * @param meta
+     */
+    void RegisterFromMeta(const Path& source_path, const asset::AssetMetadata& meta);
 
     /**
      * 소스 파일의 mtime/size와 .meta의 기록값을 비교하여 변경 여부를 판별합니다.
@@ -86,5 +88,6 @@ private:
 private:
     std::unique_ptr<AssetImporter> importer;
     asset::AssetSubsystem* asset_subsystem = nullptr;
+    ImportPresetManager preset_manager;
 };
 }  // namespace se::editor

--- a/Editor/Source/Asset/EditorAssetSubsystem.h
+++ b/Editor/Source/Asset/EditorAssetSubsystem.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "SimpleEngine/Asset/AssetMetadata.h"
 #include "SimpleEngine/Asset/AssetSubsystem.h"
 #include "SimpleEngine/Core/Subsystem/SubsystemBase.h"
 #include "SimpleEngine/Core/Types/Path.h"
@@ -46,6 +47,13 @@ public:
      */
     bool EnsureMetaFile(const Path& source_path);
 
+    /**
+     * Registry 스냅샷과 파일 시스템을 비교하여 변경 사항을 감지합니다.
+     * 새 파일 -> .meta 생성 + 등록, 수정됨 -> Dirty 감지, 삭제됨 -> 등록 해제
+     * @param root_path 스캔할 루트 디렉토리 경로
+     */
+    void ScanAndReconcile(const Path& root_path);
+
 private:
     /**
      * .meta 파일에서 메타데이터를 읽어 AssetRegistry에 등록합니다.
@@ -60,6 +68,24 @@ private:
      * @return 성공 여부
      */
     bool CookAsset(const Path& file_path);
+
+    /**
+     * 소스 파일의 mtime/size와 .meta의 기록값을 비교하여 변경 여부를 판별합니다.
+     * mtime 비교 -> size 비교 -> hash 비교 순서의 단계적 검증을 수행합니다.
+     * @param source_path 소스 파일 경로
+     * @param meta 저장된 메타데이터
+     * @return 소스 파일이 수정되었으면 true
+     */
+    [[nodiscard]] bool IsAssetDirty(const Path& source_path, const asset::AssetMetadata& meta) const;
+
+    /** Registry를 바이너리 파일로 저장합니다. (에디터 종료 시 호출) */
+    void SaveRegistrySnapshot();
+
+    /** 바이너리 스냅샷에서 Registry를 복원합니다. */
+    [[nodiscard]] bool LoadRegistrySnapshot();
+
+    /** Registry 스냅샷 파일 경로를 반환합니다. */
+    [[nodiscard]] static Path GetRegistrySnapshotPath();
 
 private:
     std::unique_ptr<AssetImporter> importer;

--- a/Editor/Source/Asset/EditorAssetSubsystem.h
+++ b/Editor/Source/Asset/EditorAssetSubsystem.h
@@ -12,6 +12,7 @@ namespace se::editor
 {
 // forward declarations
 class AssetImporter;
+struct MetaFileContent;
 
 /**
  * Editor 전용 에셋 서브시스템
@@ -45,7 +46,7 @@ public:
      * @param source_path 소스 파일 경로
      * @return .meta 파일이 존재하거나 생성에 성공하면 true
      */
-    bool EnsureMetaFile(const Path& source_path);
+    [[nodiscard]] Optional<MetaFileContent> EnsureMetaFile(const Path& source_path);
 
     /**
      * Registry 스냅샷과 파일 시스템을 비교하여 변경 사항을 감지합니다.
@@ -58,8 +59,9 @@ private:
     /**
      * .meta 파일에서 메타데이터를 읽어 AssetRegistry에 등록합니다.
      * @param source_path 소스 파일 경로
+     * @param meta
      */
-    void RegisterFromMeta(const Path& source_path);
+    void RegisterFromMeta(const Path& source_path, const asset::AssetMetadata& meta);
 
     /**
      * Asset을 Import하여 Registry 등록과 DDC 바이너리를 생성합니다.

--- a/Editor/Source/Asset/EditorAssetSubsystem.h
+++ b/Editor/Source/Asset/EditorAssetSubsystem.h
@@ -4,14 +4,19 @@
 #include "SimpleEngine/Core/Subsystem/SubsystemBase.h"
 #include "SimpleEngine/Core/Types/Path.h"
 
+#include <memory>
+
 
 namespace se::editor
 {
-// forward declaration
+// forward declarations
 class AssetImporter;
 
 /**
- * @todo docs
+ * Editor 전용 에셋 서브시스템
+ *
+ * Core의 AssetSubsystem에 DDCMissHandler를 등록하여
+ * Import 파이프라인을 연결하고, .meta 파일 관리 및 디렉토리 스캔 기능을 제공합니다.
  */
 class SE_ANNOTATION(=meta::Internal) EditorAssetSubsystem : public SubsystemBase
 {
@@ -25,8 +30,35 @@ public:
     [[nodiscard]] virtual bool Initialize() override;
     virtual void Release() override;
 
+public:
+    /**
+     * 디렉토리를 재귀적으로 순회하며, Import 가능한 파일에 대해
+     * .meta 파일 보장 및 AssetRegistry 등록을 수행합니다.
+     * @param root_path 스캔할 루트 디렉토리 경로
+     */
+    void ScanDirectory(const Path& root_path);
+
+    /**
+     * 소스 파일에 대한 .meta 파일이 존재하는지 확인하고,
+     * 없으면 새로 생성합니다.
+     * @param source_path 소스 파일 경로
+     * @return .meta 파일이 존재하거나 생성에 성공하면 true
+     */
+    bool EnsureMetaFile(const Path& source_path);
+
 private:
-    /** Asset을 불러와 Registry 등록과 DDC로 저장합니다.  */
+    /**
+     * .meta 파일에서 메타데이터를 읽어 AssetRegistry에 등록합니다.
+     * @param source_path 소스 파일 경로
+     */
+    void RegisterFromMeta(const Path& source_path);
+
+    /**
+     * Asset을 Import하여 Registry 등록과 DDC 바이너리를 생성합니다.
+     * .meta 파일이 존재하면 ImportProfile을 획득하여 Import에 전달합니다.
+     * @param file_path 소스 파일 경로
+     * @return 성공 여부
+     */
     bool CookAsset(const Path& file_path);
 
 private:

--- a/Editor/Source/Asset/ImportPresetManager.cpp
+++ b/Editor/Source/Asset/ImportPresetManager.cpp
@@ -1,0 +1,25 @@
+#include "SimpleEditor/Asset/ImportPresetManager.h"
+
+
+namespace se::editor
+{
+void ImportPresetManager::RegisterPreset(const TypeId& translator_type, Function<void(ImportProfile&)> initializer)
+{
+    preset_map.Insert(translator_type, std::move(initializer));
+}
+
+ImportProfile ImportPresetManager::GetDefaultProfile(const TypeId& translator_type) const
+{
+    ImportProfile profile;
+    if (const Optional init_opt = preset_map.Find(translator_type))
+    {
+        (*init_opt)(profile);
+    }
+    return profile;
+}
+
+bool ImportPresetManager::HasPreset(const TypeId& translator_type) const
+{
+    return preset_map.Contains(translator_type);
+}
+} // namespace se::editor

--- a/Editor/Source/Asset/MetaFileContent.cpp
+++ b/Editor/Source/Asset/MetaFileContent.cpp
@@ -7,5 +7,6 @@ namespace se::editor
 SE_BEGIN_REFLECT(MetaFileContent, meta::SerializeOnly)
     SE_REFLECT_PROPERTY(metadata, meta::Property)
     SE_REFLECT_PROPERTY(import_settings, meta::Property)
+    SE_REFLECT_PROPERTY(processor_stack, meta::Property)
 SE_END_REFLECT(MetaFileContent)
 }  // namespace se::editor

--- a/Editor/Source/Asset/MetaFileContent.cpp
+++ b/Editor/Source/Asset/MetaFileContent.cpp
@@ -1,0 +1,11 @@
+#include "SimpleEditor/Asset/MetaFileContent.h"
+#include "SimpleEngine/Core/Reflection/Reflect.h"
+
+
+namespace se::editor
+{
+SE_BEGIN_REFLECT(MetaFileContent, meta::SerializeOnly)
+    SE_REFLECT_PROPERTY(metadata, meta::Property)
+    SE_REFLECT_PROPERTY(import_settings, meta::Property)
+SE_END_REFLECT(MetaFileContent)
+}  // namespace se::editor

--- a/Editor/Source/Asset/MetaFileManager.cpp
+++ b/Editor/Source/Asset/MetaFileManager.cpp
@@ -132,4 +132,15 @@ Path MetaFileManager::GetMetaPath(const Path& source_path)
     meta_path += META_EXTENSION;
     return meta_path;
 }
+
+Path MetaFileManager::GetSourcePath(const Path& meta_path)
+{
+    // "dir/foo.fbx.meta" → FileStem()="foo.fbx", Parent()="dir" → "dir/foo.fbx"
+    const String stem = meta_path.FileStem().ValueOrDefault();
+    if (const Optional parent = meta_path.Parent())
+    {
+        return *parent / Path(stem);
+    }
+    return Path(stem);
+}
 } // namespace se::editor

--- a/Editor/Source/Asset/MetaFileManager.cpp
+++ b/Editor/Source/Asset/MetaFileManager.cpp
@@ -36,7 +36,6 @@ Optional<MetaFileContent> MetaFileManager::Load(const Path& source_path)
     const Path meta_path = GetMetaPath(source_path);
     if (!meta_path.Exists())
     {
-        ConsoleLog(ELogLevel::Warning, "Meta file not found: {}", meta_path.ToString());
         return NullOpt;
     }
 
@@ -44,7 +43,7 @@ Optional<MetaFileContent> MetaFileManager::Load(const Path& source_path)
     const auto file_content = FileSystem::ReadToString(meta_path);
     if (!file_content.HasValue())
     {
-        ConsoleLog(ELogLevel::Error, "Failed to read meta file: {}", meta_path.ToString());
+        ConsoleLog(ELogLevel::Error, "Failed to read meta file: {}", meta_path);
         return NullOpt;
     }
 
@@ -52,8 +51,7 @@ Optional<MetaFileContent> MetaFileManager::Load(const Path& source_path)
     const toml::parse_result parse_result = toml::parse(file_content.Value().CStr());
     if (!parse_result)
     {
-        ConsoleLog(ELogLevel::Error, "Failed to parse meta file: {} - {}",
-            meta_path.ToString(), parse_result.error().description());
+        ConsoleLog(ELogLevel::Error, "Failed to parse meta file: {} - {}", meta_path, parse_result.error().description());
         return NullOpt;
     }
 

--- a/Editor/Source/Asset/MetaFileManager.cpp
+++ b/Editor/Source/Asset/MetaFileManager.cpp
@@ -25,7 +25,7 @@ constexpr StringView TEMP_EXTENSION = ".tmp";
 Path BuildTempPath(const Path& meta_path)
 {
     const size_t thread_hash = std::hash<std::thread::id>{}(std::this_thread::get_id());
-    return String::Format("_{}_{}{}", thread_hash, meta_path, TEMP_EXTENSION);
+    return String::Format("{}_{}{}", meta_path, thread_hash, TEMP_EXTENSION);
 }
 } // namespace
 

--- a/Editor/Source/Asset/MetaFileManager.cpp
+++ b/Editor/Source/Asset/MetaFileManager.cpp
@@ -84,13 +84,11 @@ bool MetaFileManager::Save(const Path& source_path, const MetaFileContent& conte
     toml::table root;
     TomlWriter writer(root);
 
-    MetaFileContent mutable_content = content;
-    writer << mutable_content;
+    writer << content;
 
     // TOML 문자열 생성
     std::ostringstream oss;
     oss << root;
-    const String toml_string = StringUtils::ToString(oss.str());
 
     // Atomic Write: .tmp에 먼저 쓰고 rename
     const Path temp_path = BuildTempPath(meta_path);
@@ -98,7 +96,7 @@ bool MetaFileManager::Save(const Path& source_path, const MetaFileContent& conte
         FileSystem::Remove(temp_path);
     };
 
-    if (!FileSystem::WriteString(temp_path, toml_string))
+    if (!FileSystem::WriteString(temp_path, oss.view()))
     {
         ConsoleLog(ELogLevel::Error, "MetaFileManager::Save - Failed to write temp file: {}", temp_path.ToString());
         return false;

--- a/Editor/Source/Asset/MetaFileManager.cpp
+++ b/Editor/Source/Asset/MetaFileManager.cpp
@@ -81,7 +81,6 @@ bool MetaFileManager::Save(const Path& source_path, const MetaFileContent& conte
     // TOML 트리에 직렬화
     toml::table root;
     TomlWriter writer(root);
-
     writer << content;
 
     // TOML 문자열 생성

--- a/Editor/Source/Asset/MetaFileManager.cpp
+++ b/Editor/Source/Asset/MetaFileManager.cpp
@@ -3,7 +3,6 @@
 #include "SimpleEngine/Core/FileSystem/FileSystem.h"
 #include "SimpleEngine/Core/Logging/Logging.h"
 #include "SimpleEngine/Core/Serialization/TomlArchive.h"
-#include "SimpleEngine/Utility/StringUtils.h"
 
 #include "tracy/Tracy.hpp"
 

--- a/Editor/Source/Asset/MetaFileManager.cpp
+++ b/Editor/Source/Asset/MetaFileManager.cpp
@@ -1,0 +1,140 @@
+#include "SimpleEditor/Asset/MetaFileManager.h"
+
+#include "SimpleEngine/Core/FileSystem/FileSystem.h"
+#include "SimpleEngine/Core/Logging/Logging.h"
+#include "SimpleEngine/Core/Serialization/TomlArchive.h"
+#include "SimpleEngine/Utility/StringUtils.h"
+
+#include "tracy/Tracy.hpp"
+
+#include <sstream>
+#include <thread>
+
+
+namespace se::editor
+{
+namespace
+{
+constexpr StringView META_EXTENSION = ".meta";
+constexpr StringView TEMP_EXTENSION = ".tmp";
+
+/**
+ * 임시 파일 경로를 생성합니다. (Atomic Write용)
+ * 스레드 ID 해시를 포함하여 멀티스레드 환경에서도 충돌을 방지합니다.
+ */
+Path BuildTempPath(const Path& meta_path)
+{
+    const size_t thread_hash = std::hash<std::thread::id>{}(std::this_thread::get_id());
+    return String::Format("_{}_{}{}", thread_hash, meta_path, TEMP_EXTENSION);
+}
+} // namespace
+
+Optional<MetaFileContent> MetaFileManager::Load(const Path& source_path)
+{
+    ZoneScopedN("MetaFileManager::Load");
+
+    const Path meta_path = GetMetaPath(source_path);
+    if (!meta_path.Exists())
+    {
+        ConsoleLog(ELogLevel::Warning, "Meta file not found: {}", meta_path.ToString());
+        return NullOpt;
+    }
+
+    // TOML 파일 읽기
+    const auto file_content = FileSystem::ReadToString(meta_path);
+    if (!file_content.HasValue())
+    {
+        ConsoleLog(ELogLevel::Error, "Failed to read meta file: {}", meta_path.ToString());
+        return NullOpt;
+    }
+
+    // TOML 파싱
+    const toml::parse_result parse_result = toml::parse(file_content.Value().CStr());
+    if (!parse_result)
+    {
+        ConsoleLog(ELogLevel::Error, "Failed to parse meta file: {} - {}",
+            meta_path.ToString(), parse_result.error().description());
+        return NullOpt;
+    }
+
+    // 역직렬화
+    MetaFileContent content;
+    TomlReader reader(parse_result.table());
+    reader << content;
+
+    return content;
+}
+
+bool MetaFileManager::Save(const Path& source_path, const MetaFileContent& content)
+{
+    ZoneScopedN("MetaFileManager::Save");
+
+    const Path meta_path = GetMetaPath(source_path);
+
+    // 부모 디렉토리 보장
+    if (const Optional parent = meta_path.Parent())
+    {
+        if (!parent->Exists())
+        {
+            FileSystem::CreateDirectories(*parent);
+        }
+    }
+
+    // TOML 트리에 직렬화
+    toml::table root;
+    TomlWriter writer(root);
+
+    MetaFileContent mutable_content = content;
+    writer << mutable_content;
+
+    // TOML 문자열 생성
+    std::ostringstream oss;
+    oss << root;
+    const String toml_string = StringUtils::ToString(oss.str());
+
+    // Atomic Write: .tmp에 먼저 쓰고 rename
+    const Path temp_path = BuildTempPath(meta_path);
+    SE_SCOPE_DEFER_NAMED(rollback) {
+        FileSystem::Remove(temp_path);
+    };
+
+    if (!FileSystem::WriteString(temp_path, toml_string))
+    {
+        ConsoleLog(ELogLevel::Error, "MetaFileManager::Save - Failed to write temp file: {}", temp_path.ToString());
+        return false;
+    }
+
+    if (!FileSystem::Rename(temp_path, meta_path))
+    {
+        ConsoleLog(ELogLevel::Error, "MetaFileManager::Save - Failed to rename temp -> meta: {} -> {}", temp_path.ToString(), meta_path.ToString());
+        return false;
+    }
+
+    rollback.Discard();
+    return true;
+}
+
+bool MetaFileManager::HasMeta(const Path& source_path)
+{
+    return GetMetaPath(source_path).Exists();
+}
+
+void MetaFileManager::DeleteMeta(const Path& source_path)
+{
+    const Path meta_path = GetMetaPath(source_path);
+    if (meta_path.Exists())
+    {
+        if (!FileSystem::Remove(meta_path))
+        {
+            ConsoleLog(ELogLevel::Warning, "Failed to delete meta file: {}", meta_path.ToString());
+        }
+    }
+}
+
+Path MetaFileManager::GetMetaPath(const Path& source_path)
+{
+    Path meta_path = source_path;
+    meta_path += META_EXTENSION;
+    return meta_path;
+}
+} // namespace se::editor

--- a/Editor/Source/Asset/MetaFileManager.cpp
+++ b/Editor/Source/Asset/MetaFileManager.cpp
@@ -134,12 +134,12 @@ Path MetaFileManager::GetMetaPath(const Path& source_path)
 
 Path MetaFileManager::GetSourcePath(const Path& meta_path)
 {
-    // "dir/foo.fbx.meta" → FileStem()="foo.fbx", Parent()="dir" → "dir/foo.fbx"
+    // "dir/foo.fbx.meta" -> FileStem()="foo.fbx", Parent()="dir" -> "dir/foo.fbx"
     const String stem = meta_path.FileStem().ValueOrDefault();
     if (const Optional parent = meta_path.Parent())
     {
-        return *parent / Path(stem);
+        return *parent / stem;
     }
-    return Path(stem);
+    return stem;
 }
 } // namespace se::editor

--- a/Editor/Source/Asset/MetaFileManager.cpp
+++ b/Editor/Source/Asset/MetaFileManager.cpp
@@ -47,7 +47,7 @@ Optional<MetaFileContent> MetaFileManager::Load(const Path& source_path)
     }
 
     // TOML 파싱
-    const toml::parse_result parse_result = toml::parse(file_content.Value().CStr());
+    const toml::parse_result parse_result = toml::parse(file_content.Value().Bytes());
     if (!parse_result)
     {
         ConsoleLog(ELogLevel::Error, "Failed to parse meta file: {} - {}", meta_path, parse_result.error().description());

--- a/Editor/Source/Asset/Pipeline/AssetImporter.cpp
+++ b/Editor/Source/Asset/Pipeline/AssetImporter.cpp
@@ -15,6 +15,22 @@ bool AssetImporter::CanImport(const Path& file_path) const
     return FindTranslator(file_path).HasValue();
 }
 
+Optional<TypeId> AssetImporter::FindTranslatorTypeId(const Path& file_path) const
+{
+    if (const Optional ext_opt = file_path.Extension())
+    {
+        const String ext = ext_opt->ToLower();
+        for (const auto [n, translator] : translators | std::views::enumerate)
+        {
+            if (translator->CanTranslate(ext))
+            {
+                return translator_type_ids[n];
+            }
+        }
+    }
+    return NullOpt;
+}
+
 HashSet<StringView> AssetImporter::GetAllSupportedExtensions() const
 {
     HashSet<StringView> result;

--- a/Editor/Source/Asset/Pipeline/AssetImporter.cpp
+++ b/Editor/Source/Asset/Pipeline/AssetImporter.cpp
@@ -20,11 +20,11 @@ Optional<TypeId> AssetImporter::FindTranslatorTypeId(const Path& file_path) cons
     if (const Optional ext_opt = file_path.Extension())
     {
         const String ext = ext_opt->ToLower();
-        for (const auto [n, translator] : translators | std::views::enumerate)
+        for (const auto [n, entry] : translators | std::views::enumerate)
         {
-            if (translator->CanTranslate(ext))
+            if (entry.translator->CanTranslate(ext))
             {
-                return translator_type_ids[n];
+                return entry.type_id;
             }
         }
     }
@@ -34,7 +34,7 @@ Optional<TypeId> AssetImporter::FindTranslatorTypeId(const Path& file_path) cons
 HashSet<StringView> AssetImporter::GetAllSupportedExtensions() const
 {
     HashSet<StringView> result;
-    for (const auto& translator : translators)
+    for (const auto& [_, translator] : translators)
     {
         for (const StringView ext : translator->GetSupportedExtensions())
         {
@@ -176,7 +176,7 @@ Optional<IPipelineTranslator&> AssetImporter::FindTranslator(const Path& file_pa
     }
 
     const String ext = ext_opt->ToLower();
-    for (const auto& translator : translators)
+    for (const auto& [_, translator] : translators)
     {
         if (translator->CanTranslate(ext))
         {

--- a/Editor/Source/Asset/Pipeline/AssetImporter.cpp
+++ b/Editor/Source/Asset/Pipeline/AssetImporter.cpp
@@ -20,11 +20,15 @@ Optional<TypeId> AssetImporter::FindTranslatorTypeId(const Path& file_path) cons
     if (const Optional ext_opt = file_path.Extension())
     {
         const String ext = ext_opt->ToLower();
-        for (const auto [n, entry] : translators | std::views::enumerate)
+        if (const auto indices_opt = extension_to_translator_indices.Find(ext))
         {
-            if (entry.translator->CanTranslate(ext))
+            for (const usize idx : *indices_opt)
             {
-                return entry.type_id;
+                const TranslatorEntry& entry = translators[idx];
+                if (entry.translator->CanTranslate(ext))
+                {
+                    return entry.type_id;
+                }
             }
         }
     }

--- a/Editor/Source/Asset/Pipeline/ProcessorEntry.cpp
+++ b/Editor/Source/Asset/Pipeline/ProcessorEntry.cpp
@@ -1,0 +1,12 @@
+﻿#include "SimpleEditor/Asset/Pipeline/ProcessorEntry.h"
+
+#include "SimpleEngine/Core/Reflection/Reflect.h"
+
+
+namespace se::editor
+{
+SE_BEGIN_REFLECT(ProcessorEntry, meta::SerializeOnly)
+    SE_REFLECT_PROPERTY(processor_type, meta::Property)
+    SE_REFLECT_PROPERTY(enabled, meta::Property)
+SE_END_REFLECT(ProcessorEntry)
+} // namespace se::editor

--- a/Editor/Source/UI/Panels/AssetsBrowserPanel.cpp
+++ b/Editor/Source/UI/Panels/AssetsBrowserPanel.cpp
@@ -36,7 +36,7 @@ struct AssetItem
         return name <=> other.name;
     }
 };
-}  // namespace
+} // namespace
 
 namespace se::editor
 {
@@ -53,6 +53,8 @@ void AssetsBrowserPanel::Draw()
     // TreeView | GridView를 분할
     if (ImGui::BeginTable("AssetsBrowser_PanelSplit", 2, ImGuiTableFlags_Resizable | ImGuiTableFlags_BordersInnerV))
     {
+        SE_SCOPE_DEFER{ ImGui::EndTable(); };
+
         // 좌측 컬럼 너비 초기값 설정
         ImGui::TableSetupColumn("Tree", ImGuiTableColumnFlags_WidthFixed, 150.0f);
         ImGui::TableSetupColumn("Assets", ImGuiTableColumnFlags_WidthStretch);
@@ -83,8 +85,6 @@ void AssetsBrowserPanel::Draw()
             DrawAssetGrid();
         }
         ImGui::EndChild();
-
-        ImGui::EndTable();
     }
 
     if (pending_open_import_settings)
@@ -256,14 +256,10 @@ void AssetsBrowserPanel::DrawAssetGrid()
 
 bool AssetsBrowserPanel::HasSubDirectories(const Path& path)
 {
-    for (const auto& entry : FileSystem::ReadDir(path))
+    return std::ranges::any_of(FileSystem::ReadDir(path), [](const DirectoryEntry& entry)
     {
-        if (entry.IsDirectory())
-        {
-            return true;
-        }
-    }
-    return false;
+        return entry.IsDirectory();
+    });
 }
 
 const Path& AssetsBrowserPanel::GetSelectedDirPath() const noexcept
@@ -503,7 +499,7 @@ bool AssetsBrowserPanel::DrawImportSettings()
     const TypeRegistry& registry = TypeRegistry::Get();
     DrawerRegistry& drawer = DrawerRegistry::Get();
 
-    for (auto& [type_id, settings_ptr] : settings_map)
+    for (const auto& [type_id, settings_ptr] : settings_map)
     {
         if (!settings_ptr)
         {
@@ -546,10 +542,9 @@ bool AssetsBrowserPanel::DrawProcessorStack()
 
     const TypeRegistry& registry = TypeRegistry::Get();
 
-    for (usize i = 0; i < entries.Len(); ++i)
+    for (const auto [n, entry] : entries | std::views::enumerate)
     {
-        ProcessorEntry& entry = entries[i];
-        ImGui::PushID(static_cast<int>(i));
+        ImGui::PushID(static_cast<int>(n));
 
         String label = "Unknown Processor";
         if (const Optional info_opt = registry.Find(entry.processor_type))
@@ -567,4 +562,4 @@ bool AssetsBrowserPanel::DrawProcessorStack()
 
     return modified;
 }
-}  // namespace se::editor
+} // namespace se::editor

--- a/Editor/Source/UI/Panels/AssetsBrowserPanel.cpp
+++ b/Editor/Source/UI/Panels/AssetsBrowserPanel.cpp
@@ -1,15 +1,17 @@
 #include "UI/Panels/AssetsBrowserPanel.h"
 
 #include "Asset/EditorAssetSubsystem.h"
+#include "UI/ImGui/ImGuiString.h"
+
 #include "SimpleEditor/Asset/MetaFileManager.h"
 #include "SimpleEditor/UI/PropertyDrawer/PropertyDrawer.h"
 
 #include "SimpleEngine/Core/Container/StringView.h"
+#include "SimpleEngine/Core/FileSystem/FileSystem.h"
+#include "SimpleEngine/Core/FileSystem/VFS.h"
 #include "SimpleEngine/Core/Logging/Logging.h"
 #include "SimpleEngine/Core/Reflection/TypeRegistry.h"
 #include "SimpleEngine/Core/Types/Path.h"
-#include "SimpleEngine/Core/FileSystem/FileSystem.h"
-#include "SimpleEngine/Core/FileSystem/VFS.h"
 #include "SimpleEngine/Utility/SubsystemUtils.h"
 
 #include "imgui.h"
@@ -424,9 +426,9 @@ void AssetsBrowserPanel::DrawImportSettingsModal()
 
     // GUID (읽기 전용)
     {
-        const String guid_str = modal_content->metadata.guid.ToString();
+        String guid_str = modal_content->metadata.guid.ToString();
         ImGui::BeginDisabled();
-        ImGui::InputText("GUID", const_cast<char*>(guid_str.CStr()), guid_str.ByteLen(), ImGuiInputTextFlags_ReadOnly);
+        ImGui::InputText("GUID", &guid_str, ImGuiInputTextFlags_ReadOnly);
         ImGui::EndDisabled();
     }
 

--- a/Editor/Source/UI/Panels/AssetsBrowserPanel.cpp
+++ b/Editor/Source/UI/Panels/AssetsBrowserPanel.cpp
@@ -1,14 +1,21 @@
 #include "UI/Panels/AssetsBrowserPanel.h"
 
-#include <compare>
+#include "Asset/EditorAssetSubsystem.h"
+#include "SimpleEditor/Asset/MetaFileManager.h"
+#include "SimpleEditor/UI/PropertyDrawer/PropertyDrawer.h"
 
 #include "SimpleEngine/Core/Container/StringView.h"
 #include "SimpleEngine/Core/Logging/Logging.h"
+#include "SimpleEngine/Core/Reflection/TypeRegistry.h"
 #include "SimpleEngine/Core/Types/Path.h"
 #include "SimpleEngine/Core/FileSystem/FileSystem.h"
 #include "SimpleEngine/Core/FileSystem/VFS.h"
+#include "SimpleEngine/Utility/SubsystemUtils.h"
 
 #include "imgui.h"
+
+#include <compare>
+
 
 namespace
 {
@@ -39,6 +46,7 @@ const char* AssetsBrowserPanel::GetName() const
 void AssetsBrowserPanel::Draw()
 {
     ImGui::Begin(GetName(), &is_visible, ImGuiWindowFlags_MenuBar);
+    SE_SCOPE_DEFER{ ImGui::End(); };
 
     // TreeView | GridView를 분할
     if (ImGui::BeginTable("AssetsBrowser_PanelSplit", 2, ImGuiTableFlags_Resizable | ImGuiTableFlags_BordersInnerV))
@@ -77,7 +85,14 @@ void AssetsBrowserPanel::Draw()
         ImGui::EndTable();
     }
 
-    ImGui::End();
+    if (pending_open_import_settings)
+    {
+        ImGui::OpenPopup("Import Settings");
+        pending_open_import_settings = false;
+    }
+
+    // Import Settings 모달은 AssetsBrowser 윈도우 밖에서 렌더
+    DrawImportSettingsModal();
 }
 
 void AssetsBrowserPanel::DrawAssetTree()
@@ -338,6 +353,13 @@ void AssetsBrowserPanel::DrawFileContextMenu(const Path& path)
     ImGui::TextDisabled("%s", path.FileName().ValueOr("(Unknown)").CStr());
     ImGui::Separator();
 
+    if (ImGui::MenuItem("Import Settings..."))
+    {
+        OpenImportSettingsModal(path);
+    }
+
+    ImGui::Separator();
+
     if (ImGui::MenuItem("Open"))
     {
         // TODO: 에셋 타입에 맞는 에디터 열기
@@ -363,5 +385,184 @@ void AssetsBrowserPanel::DrawFileContextMenu(const Path& path)
         ConsoleLog(ELogLevel::Info, "Show in Explorer: {}", path);
         Platform::RevealInExplorer(path);
     }
+}
+
+void AssetsBrowserPanel::OpenImportSettingsModal(const Path& asset_path)
+{
+    modal_asset_path = asset_path;
+    modal_content = MetaFileManager::Load(asset_path);
+    modal_dirty = false;
+    pending_open_import_settings = true;
+}
+
+void AssetsBrowserPanel::DrawImportSettingsModal()
+{
+    const ImVec2 center = ImGui::GetMainViewport()->GetCenter();
+    ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+    ImGui::SetNextWindowSize(ImVec2(420, 0), ImGuiCond_Appearing);
+
+    if (!ImGui::BeginPopupModal("Import Settings", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+    {
+        return;
+    }
+
+    if (!modal_content.HasValue())
+    {
+        ImGui::TextDisabled("No .meta file found for this asset.");
+        if (ImGui::Button("Close"))
+        {
+            ImGui::CloseCurrentPopup();
+        }
+        ImGui::EndPopup();
+        return;
+    }
+
+    // 헤더: 파일 이름
+    const String filename = modal_asset_path.FileName().ValueOr("(Unknown)");
+    ImGui::Text("%s", filename.CStr());
+    ImGui::Separator();
+
+    // GUID (읽기 전용)
+    {
+        const String guid_str = modal_content->metadata.guid.ToString();
+        ImGui::BeginDisabled();
+        ImGui::InputText("GUID", const_cast<char*>(guid_str.CStr()), guid_str.ByteLen(), ImGuiInputTextFlags_ReadOnly);
+        ImGui::EndDisabled();
+    }
+
+    ImGui::Spacing();
+
+    // Import Settings 섹션
+    if (ImGui::CollapsingHeader("Import Settings", ImGuiTreeNodeFlags_DefaultOpen))
+    {
+        modal_dirty |= DrawImportSettings();
+    }
+
+    // Processor Stack 섹션
+    if (ImGui::CollapsingHeader("Processor Stack"))
+    {
+        modal_dirty |= DrawProcessorStack();
+    }
+
+    ImGui::Spacing();
+    ImGui::Separator();
+
+    // Apply / Revert / Cancel 버튼
+    ImGui::BeginDisabled(!modal_dirty);
+    if (ImGui::Button("Apply"))
+    {
+        if (MetaFileManager::Save(modal_asset_path, *modal_content))
+        {
+            if (EditorAssetSubsystem* asset_sub = GetSubsystem<EditorAssetSubsystem>())
+            {
+                asset_sub->CookAsset(modal_asset_path);
+            }
+        }
+        else
+        {
+            ConsoleLog(ELogLevel::Error, "Failed to save .meta for: {}", modal_asset_path);
+        }
+        modal_dirty = false;
+        ImGui::CloseCurrentPopup();
+    }
+    ImGui::EndDisabled();
+
+    ImGui::SameLine();
+
+    ImGui::BeginDisabled(!modal_dirty);
+    if (ImGui::Button("Revert"))
+    {
+        modal_content = MetaFileManager::Load(modal_asset_path);
+        modal_dirty = false;
+    }
+    ImGui::EndDisabled();
+
+    ImGui::SameLine();
+
+    if (ImGui::Button("Cancel"))
+    {
+        ImGui::CloseCurrentPopup();
+    }
+
+    ImGui::EndPopup();
+}
+
+bool AssetsBrowserPanel::DrawImportSettings()
+{
+    bool modified = false;
+
+    const ImportProfile::SettingsMap& settings_map = modal_content->import_settings.GetSettingsMap();
+    if (settings_map.IsEmpty())
+    {
+        ImGui::TextDisabled("No import settings.");
+        return false;
+    }
+
+    const TypeRegistry& registry = TypeRegistry::Get();
+    DrawerRegistry& drawer = DrawerRegistry::Get();
+
+    for (auto& [type_id, settings_ptr] : settings_map)
+    {
+        if (!settings_ptr)
+        {
+            continue;
+        }
+
+        const Optional info_opt = registry.Find(type_id);
+        if (!info_opt.HasValue())
+        {
+            const StringView view = type_id.GetName();
+            ImGui::TextDisabled("Unknown settings type: %.*s", static_cast<int>(view.ByteLen()), view.Data());
+            continue;
+        }
+
+        // 설정 타입 이름을 서브 헤더로 표시
+        const StringView& type_name = info_opt->name;
+        if (ImGui::TreeNodeEx(String(type_name).CStr(), ImGuiTreeNodeFlags_DefaultOpen))
+        {
+            if (drawer.DrawProperties(*info_opt, settings_ptr.get()))
+            {
+                modified = true;
+            }
+            ImGui::TreePop();
+        }
+    }
+
+    return modified;
+}
+
+bool AssetsBrowserPanel::DrawProcessorStack()
+{
+    bool modified = false;
+
+    Array<ProcessorEntry>& entries = modal_content->processor_stack;
+    if (entries.IsEmpty())
+    {
+        ImGui::TextDisabled("No processors configured.");
+        return false;
+    }
+
+    const TypeRegistry& registry = TypeRegistry::Get();
+
+    for (usize i = 0; i < entries.Len(); ++i)
+    {
+        ProcessorEntry& entry = entries[i];
+        ImGui::PushID(static_cast<int>(i));
+
+        String label = "Unknown Processor";
+        if (const Optional info_opt = registry.Find(entry.processor_type))
+        {
+            label = String(info_opt->name);
+        }
+
+        if (ImGui::Checkbox(label.CStr(), &entry.enabled))
+        {
+            modified = true;
+        }
+
+        ImGui::PopID();
+    }
+
+    return modified;
 }
 }  // namespace se::editor

--- a/Editor/Source/UI/Panels/AssetsBrowserPanel.h
+++ b/Editor/Source/UI/Panels/AssetsBrowserPanel.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "SimpleEditor/UI/IEditorPanel.h"
+#include "SimpleEditor/Asset/MetaFileContent.h"
+
 #include "SimpleEngine/Core/Types/Path.h"
 
 
@@ -25,10 +27,21 @@ protected:
 private:
     void RenderDirectoryTreeRecursive(const Path& path);
     void DrawDirectoryContextMenu(const Path& path);
-
     void DrawFileContextMenu(const Path& path);
+
+    // Import Settings 모달
+    void OpenImportSettingsModal(const Path& asset_path);
+    void DrawImportSettingsModal();
+    bool DrawImportSettings();
+    bool DrawProcessorStack();
 
 private:
     Path selected_dir_path;
+
+    // Import Settings 모달 상태
+    Path modal_asset_path;
+    Optional<MetaFileContent> modal_content;
+    bool modal_dirty = false;
+    bool pending_open_import_settings = false;
 };
 }  // namespace se::editor

--- a/Editor/Source/UI/Panels/AssetsBrowserPanel.h
+++ b/Editor/Source/UI/Panels/AssetsBrowserPanel.h
@@ -36,12 +36,13 @@ private:
     bool DrawProcessorStack();
 
 private:
+    // 선택된 Directory 경로
     Path selected_dir_path;
 
     // Import Settings 모달 상태
-    Path modal_asset_path;
-    Optional<MetaFileContent> modal_content;
-    bool modal_dirty = false;
-    bool pending_open_import_settings = false;
+    Path modal_asset_path;                     // Import Settings를 띄울 에셋의 경로
+    Optional<MetaFileContent> modal_content;   // 에셋의 Import Settings 정보
+    bool modal_dirty = false;                  // Import Settings가 수정되었는지 여부
+    bool pending_open_import_settings = false; // Modal을 띄우기 위한 Flag
 };
 }  // namespace se::editor

--- a/EngineCore/Include/SimpleEngine/Asset/AssetRegistry.h
+++ b/EngineCore/Include/SimpleEngine/Asset/AssetRegistry.h
@@ -4,6 +4,7 @@
 #include "SimpleEngine/Asset/AssetMetadata.h"
 #include "SimpleEngine/Asset/AssetPath.h"
 #include "SimpleEngine/Core/Container/HashMap.h"
+#include "SimpleEngine/Core/Functional/Function.h"
 #include "SimpleEngine/Core/Reflection/Annotations.h"
 #include "SimpleEngine/Core/Reflection/TypeId.h"
 
@@ -97,6 +98,18 @@ public:
 
     /** 현재 등록된 Asset의 총 개수를 반환합니다. */
     [[nodiscard]] uint32 GetAssetCount() const;
+
+    /**
+     * Registry에 등록된 모든 소스 파일 경로를 순회합니다.
+     * @param visitor 각 소스 파일 경로에 대해 호출되는 콜백
+     */
+    void VisitAllPaths(const Function<void(const Path&)>& visitor) const;
+
+    /**
+     * 소스 파일 경로에 연결된 모든 Sub-asset을 일괄 제거합니다.
+     * @param source_path 제거할 소스 파일 경로
+     */
+    void UnregisterByPath(const Path& source_path);
 
 public:
     /**

--- a/EngineCore/Include/SimpleEngine/Core/Reflection/Cast.h
+++ b/EngineCore/Include/SimpleEngine/Core/Reflection/Cast.h
@@ -112,6 +112,36 @@ template <typename Interface>
 }
 
 /**
+ * 리플렉션을 통해 생성된 원시 포인터(void*)를 특정 타입(클래스 또는 인터페이스)으로 안전하게 캐스팅합니다.
+ * @tparam To 대상 타입 (클래스 또는 인터페이스)
+ * @param raw_instance 원본 객체의 포인터
+ * @param actual_type_id 원본 객체의 실제 런타임 TypeId
+ * @return 성공 시 To* 포인터, 실패 시 nullptr
+ */
+template <typename To>
+[[nodiscard]] To* CastFromRaw(void* raw_instance, TypeId actual_type_id)
+{
+    if (!raw_instance)
+    {
+        return nullptr;
+    }
+
+    // 일반 상속 (Base Class) 캐스팅 시도
+    if (detail::IsTypeDerivedFrom(actual_type_id, TypeId::Get<To>()))
+    {
+        return static_cast<To*>(raw_instance);
+    }
+
+    // 인터페이스 캐스팅 시도
+    if (void* result = detail::CastToInterface(raw_instance, actual_type_id, TypeId::Get<To>()))
+    {
+        return static_cast<To*>(result);
+    }
+
+    return nullptr;
+}
+
+/**
  * 안전한 다운캐스팅을 수행합니다.
  * 상속 체인을 검사한 뒤, 유효하지 않으면 nullptr을 반환합니다.
  *

--- a/EngineCore/Include/SimpleEngine/Core/Reflection/TypeRegistry.h
+++ b/EngineCore/Include/SimpleEngine/Core/Reflection/TypeRegistry.h
@@ -1,10 +1,13 @@
 #pragma once
 
+#include "SimpleEngine/Core/Container/Array.h"
 #include "SimpleEngine/Core/Container/HashMap.h"
 #include "SimpleEngine/Core/Container/Optional.h"
 #include "SimpleEngine/Core/Reflection/Traits.h"
 #include "SimpleEngine/Core/Reflection/TypeBuilder.h"
 #include "SimpleEngine/Core/Types/StringName.h"
+
+#include <ranges>
 
 
 namespace se
@@ -62,6 +65,14 @@ public:
     [[nodiscard]] const TypeInfo& FindChecked(const TypeId& type_id) const;
 
     [[nodiscard]] const HashMap<TypeId, TypeInfo>& GetAllTypes() const { return type_map; }
+
+    /**
+     * 특정 인터페이스를 구현(Implements)하는 모든 등록된 타입의 TypeInfo 목록을 반환합니다.
+     * @tparam T 인터페이스 타입
+     * @return 해당 인터페이스를 구현하는 TypeInfo 포인터 목록
+     */
+    template <typename T>
+    [[nodiscard]] Array<const TypeInfo*> GetImplementations() const;
 
 private:
     HashMap<StringName, TypeId> name_map;
@@ -147,5 +158,21 @@ detail::TypeBuilder<T> TypeRegistry::RegisterEnum()
     name_map.Insert(info.name, id);
 
     return detail::TypeBuilder<T>(&info, ETypeKind::Enum);
+}
+
+template <typename T>
+Array<const TypeInfo*> TypeRegistry::GetImplementations() const
+{
+    // TODO: 나중에 HashMap<interface_id, Array<TypeInfo*>>로 최적화할 수 있을 듯
+    const TypeId interface_id = TypeId::Get<T>();
+    Array<const TypeInfo*> result;
+    for (const TypeInfo& info : type_map | std::views::values)
+    {
+        if (info.interfaces.Contains(interface_id))
+        {
+            result.Push(&info);
+        }
+    }
+    return result;
 }
 } // namespace se

--- a/EngineCore/Include/SimpleEngine/Core/Reflection/TypeRegistry.h
+++ b/EngineCore/Include/SimpleEngine/Core/Reflection/TypeRegistry.h
@@ -31,6 +31,9 @@ public:
     static TypeRegistry& Get();
 
 public:
+    /** 등록된 모든 리플렉션 데이터를 순회하여 인터페이스 캐시 등을 구축합니다. */
+    void Resolve();
+
     /**
      * Registry에 타입을 등록합니다.
      * @tparam T 등록할 타입
@@ -74,9 +77,14 @@ public:
     template <typename T>
     [[nodiscard]] Array<const TypeInfo*> GetImplementations() const;
 
+    [[nodiscard]] Array<const TypeInfo*> GetImplementations(const TypeId& interface_id) const;
+
 private:
     HashMap<StringName, TypeId> name_map;
     HashMap<TypeId, TypeInfo> type_map;
+
+    bool is_resolved = false;
+    HashMap<TypeId, Array<const TypeInfo*>> interface_implementations_map;
 };
 
 template <typename T>
@@ -115,6 +123,7 @@ detail::TypeBuilder<T> TypeRegistry::Register()
     SE_ASSERT(!name_map.Contains(info.name), "Type name '{}' collision detected!", info.name);
     name_map.Insert(info.name, id);
 
+    is_resolved = false; // Resolve 캐시 무효화
     return detail::TypeBuilder<T>(&info, ETypeKind::Struct);
 }
 
@@ -135,6 +144,7 @@ detail::TypeBuilder<T> TypeRegistry::RegisterPrimitive()
     SE_ASSERT(!name_map.Contains(info.name), "Type name '{}' collision detected!", info.name);
     name_map.Insert(info.name, id);
 
+    is_resolved = false; // Resolve 캐시 무효화
     return detail::TypeBuilder<T>(&info, ETypeKind::Primitive);
 }
 
@@ -157,22 +167,14 @@ detail::TypeBuilder<T> TypeRegistry::RegisterEnum()
     SE_ASSERT(!name_map.Contains(info.name), "Type name '{}' collision detected!", info.name);
     name_map.Insert(info.name, id);
 
+    is_resolved = false; // Resolve 캐시 무효화
     return detail::TypeBuilder<T>(&info, ETypeKind::Enum);
 }
 
 template <typename T>
 Array<const TypeInfo*> TypeRegistry::GetImplementations() const
 {
-    // TODO: 나중에 HashMap<interface_id, Array<TypeInfo*>>로 최적화할 수 있을 듯
     const TypeId interface_id = TypeId::Get<T>();
-    Array<const TypeInfo*> result;
-    for (const TypeInfo& info : type_map | std::views::values)
-    {
-        if (info.interfaces.Contains(interface_id))
-        {
-            result.Push(&info);
-        }
-    }
-    return result;
+    return GetImplementations(interface_id);
 }
 } // namespace se

--- a/EngineCore/Source/Asset/AssetRegistry.cpp
+++ b/EngineCore/Source/Asset/AssetRegistry.cpp
@@ -23,6 +23,26 @@ void AssetRegistry::RegisterAsset(
 {
     std::unique_lock lock(registry_mutex);
 
+    // 동일 ID로 재등록 시 이전 경로 인덱스를 정리 (Asset 이동/재스캔 시 stale 인덱스 방지)
+    if (const Optional old_record = records.Find(asset_id))
+    {
+        const Path old_file = old_record->logical_path.GetFilePath();
+        path_to_id.Remove(old_record->logical_path);
+
+        if (const Optional old_entries = file_to_assets.Find(old_file))
+        {
+            old_entries->RemoveIf([&asset_id](const AssetId& id)
+            {
+                return id == asset_id;
+            });
+
+            if (old_entries->IsEmpty())
+            {
+                file_to_assets.Remove(old_file);
+            }
+        }
+    }
+
     Path file_path = asset_path.GetFilePath();
     records.Insert(asset_id, {
         .id = asset_id,

--- a/EngineCore/Source/Asset/AssetRegistry.cpp
+++ b/EngineCore/Source/Asset/AssetRegistry.cpp
@@ -127,6 +127,40 @@ uint32 AssetRegistry::GetAssetCount() const
     return static_cast<uint32>(records.Len());
 }
 
+void AssetRegistry::VisitAllPaths(const Function<void(const Path&)>& visitor) const
+{
+    std::shared_lock lock(registry_mutex);
+    for (const Path& path : file_to_assets | std::views::keys)
+    {
+        visitor(path);
+    }
+}
+
+void AssetRegistry::UnregisterByPath(const Path& source_path)
+{
+    std::unique_lock lock(registry_mutex);
+
+    const Optional entries_opt = file_to_assets.Find(source_path);
+    if (!entries_opt.HasValue())
+    {
+        return;
+    }
+
+    // ID 목록을 복사 (순회 중 삭제 방지)
+    const Array<AssetId> ids_to_remove = *entries_opt;
+
+    for (const AssetId& id : ids_to_remove)
+    {
+        if (const Optional record_opt = records.Find(id))
+        {
+            path_to_id.Remove(record_opt->logical_path);
+        }
+        records.Remove(id);
+    }
+
+    file_to_assets.Remove(source_path);
+}
+
 /** AssetRegistry 바이너리 파일 매직 넘버 ("SEAR" = SimpleEngine Asset Registry) */
 static constexpr uint32 REGISTRY_MAGIC =
     static_cast<uint32>('S')

--- a/EngineCore/Source/Core/Engine/Engine.cpp
+++ b/EngineCore/Source/Core/Engine/Engine.cpp
@@ -31,6 +31,9 @@ Engine::Engine()
     SE_ASSERT(!Instance, "Engine instance already exists.");
     Instance = this;
 
+    // Interface Cache 구축
+    TypeRegistry::Get().Resolve();
+
     VFS& vfs = VFS::Get();
 
     // 센티넬 파일(*.seproject) 탐색으로 프로젝트 루트 결정

--- a/EngineCore/Source/Core/Reflection/TypeRegistry.cpp
+++ b/EngineCore/Source/Core/Reflection/TypeRegistry.cpp
@@ -14,6 +14,27 @@ TypeRegistry& TypeRegistry::Get()
     return instance;
 }
 
+void TypeRegistry::Resolve()
+{
+    if (is_resolved)
+    {
+        return;
+    }
+
+    interface_implementations_map.Clear();
+
+    for (const TypeInfo& info : type_map | std::views::values)
+    {
+        // info가 구현하는 모든 인터페이스를 순회
+        for (const TypeId& interface_id : info.interfaces | std::views::keys)
+        {
+            interface_implementations_map[interface_id].Push(&info);
+        }
+    }
+
+    is_resolved = true;
+}
+
 Optional<const TypeInfo&> TypeRegistry::Find(const TypeId& type_id) const
 {
     return type_map.Find(type_id);
@@ -32,6 +53,12 @@ const TypeInfo& TypeRegistry::FindChecked(const TypeId& type_id) const
     SE_ASSERT(type_map.Contains(type_id), "Type '{}' is not registered yet! Make sure SE_END_REFLECT is called.", type_id.GetName());
     return type_map.FindChecked(type_id);
 }
+
+Array<const TypeInfo*> TypeRegistry::GetImplementations(const TypeId& interface_id) const
+{
+    SE_ASSERT(is_resolved, "TypeRegistry::Resolve() must be called before querying implementations!");
+    return interface_implementations_map.Find(interface_id).Copy().ValueOrDefault();
+}
 } // namespace se
 
 namespace
@@ -46,7 +73,7 @@ void MakeSerialize(Archive& ar, void* ptr)
 
 [[maybe_unused]] const bool Primitive_Registrar = [] -> bool
 {
-    [[maybe_unused]] TypeRegistry& registry = TypeRegistry::Get();
+    TypeRegistry& registry = TypeRegistry::Get();
 
     // 기본 산술 타입
     registry.RegisterPrimitive<bool>()   .Serialize(&MakeSerialize<bool>);


### PR DESCRIPTION
> 아래 PR 메시지는 Gemini Pro 3.1을 이용하여 작성되었습니다.

### 🚀 핵심 변경 사항 (Key Changes)

**1. 오프라인 에셋 스캐너 통합 및 최적화**

* `ScanDirectory`와 `ScanAndReconcile`을 `ScanWorkspace` 단일 함수로 통합하여 코드 중복(DRY) 완벽 제거.
* 재귀 호출 대신 **반복적 DFS(Stack)**를 사용하여 깊은 폴더 구조에서의 스택 오버플로 위험 원천 차단.
* `.meta` 파일 로드 시 발생하는 중복 I/O 제거 (`EnsureMetaFile`이 데이터를 반환하여 즉시 Registry에 등록하도록 파이프라인 개선).
* 새 에셋 스캔 시 발생하는 불필요한 "Meta file not found" 경고 로그 제거하여 에디터 부팅 시 콘솔 스팸 방지.

**2. File I/O 안정성 및 Zero-copy 직렬화 (Core)**

* `MetaFileManager` 및 `MetaFileContent` 구조체 구현.
* 파일 저장 시 **Atomic Write (임시 파일 작성 후 Rename)** 패턴을 도입하여 크래시 발생 시 파일 오염(Corruption) 완벽 방지.
* TOML 직렬화 시 `std::ostringstream::view()`를 활용하여 불필요한 `std::string` 메모리 할당(Copy)을 제거한 Zero-copy 최적화 달성.

**3. Import Settings 및 Processor Stack 기반 구축**

* 파일 확장자에 대응하는 Translator TypeId 조회 및 기본 `ImportProfile` 프리셋 제공 기능 추가.
* 파이프라인 프로세서(Processor)를 직렬화하고 `.meta` 파일에 담기 위한 `ProcessorStack` 관리 기능 확장.
* 특정 인터페이스(`IPipelineProcessor` 등)를 구현하는 구체 타입들을 런타임에 조회할 수 있는 리플렉션 헬퍼(`GetImplementations<T>`) 추가.
* 에디터의 AssetsBrowser에 Import Settings를 편집할 수 있는 UI Modal 연동.