### PR TITLE
[Refactor] std::filesystem 제거 및 SDL3 기반 Path/VFS 시스템으로 전면 교체

### DIFF
--- a/EngineCore/Include/SimpleEngine/Core/FileSystem/FileSystem.h
+++ b/EngineCore/Include/SimpleEngine/Core/FileSystem/FileSystem.h
@@ -9,7 +9,6 @@
 #include "SimpleEngine/Core/HAL/PlatformTypes.h"
 #include "SimpleEngine/Core/Types/Path.h"
 
-#include <filesystem>
 #include <generator>
 
 
@@ -71,12 +70,13 @@ using FileResult = Expected<T, FileReadError>;
  */
 class SE_CORE_API DirectoryEntry
 {
+    friend class DirectoryIterator;
+
 public:
     DirectoryEntry() = default;
-    explicit DirectoryEntry(std::filesystem::directory_entry entry);
 
     /** 엔트리의 경로를 반환합니다. */
-    [[nodiscard]] Path GetPath() const;
+    [[nodiscard]] const Path& GetPath() const;
 
     /** 디렉토리인지 확인합니다. */
     [[nodiscard]] bool IsDirectory() const;
@@ -84,17 +84,21 @@ public:
     /** 일반 파일인지 확인합니다. */
     [[nodiscard]] bool IsFile() const;
 
-    /** 심볼릭 링크인지 확인합니다. */
+    /** 심볼릭 링크인지 확인합니다. (SDL3 한계로 항상 false 반환) */
     [[nodiscard]] bool IsSymlink() const;
 
     /** 파일 크기를 반환합니다. (파일이 아닌 경우 0) */
     [[nodiscard]] usize FileSize() const;
 
-    /** 마지막 수정 시간을 반환합니다. */
+    /** 마지막 수정 시간을 반환합니다. (SDL3 시간: Unix epoch 초 단위) */
     [[nodiscard]] uint64 LastWriteTime() const;
 
 private:
-    std::filesystem::directory_entry internal_entry;
+    Path entry_path;
+    bool is_directory = false;
+    bool is_file = false;
+    usize file_size = 0;
+    uint64 last_write_time = 0;
 };
 
 
@@ -114,10 +118,10 @@ public:
     explicit DirectoryIterator(const Path& path);
 
     DirectoryIterator& operator++();
-    DirectoryIterator operator++(int);
+    void operator++(int);
 
-    [[nodiscard]] reference operator*() const { return current_entry; }
-    [[nodiscard]] pointer operator->() const { return &current_entry; }
+    [[nodiscard]] reference operator*() const { return entries[current_index]; }
+    [[nodiscard]] pointer operator->() const { return &entries[current_index]; }
 
     [[nodiscard]] bool operator==(const DirectoryIterator& other) const;
     [[nodiscard]] bool operator!=(const DirectoryIterator& other) const { return !(*this == other); }
@@ -126,9 +130,10 @@ public:
     [[nodiscard]] DirectoryIterator end() const { return {}; }
 
 private:
-    std::filesystem::directory_iterator internal_iter;
-    DirectoryEntry current_entry;
-    bool is_end = true;
+    [[nodiscard]] bool IsEnd() const { return current_index >= entries.Len(); }
+
+    Array<DirectoryEntry> entries;
+    usize current_index = 0;
 };
 
 
@@ -152,7 +157,7 @@ struct SE_CORE_API FileSystem
 
     /**
      * 경로를 정규화된 절대 경로(canonical path)로 변환합니다.
-     * 심볼릭 링크를 해석하고 `.`, `..`을 제거합니다.
+     * @note SDL3에는 심볼릭 링크 해소 API가 없으므로 Absolute + 존재 확인만 수행합니다.
      * @param path 변환할 경로 (반드시 존재해야 함)
      * @return 정규화된 절대 경로. 실패 시 nullopt를 반환합니다.
      */
@@ -164,14 +169,7 @@ struct SE_CORE_API FileSystem
     // =========================================================================
 
     /**
-     * 디렉토리를 생성합니다.
-     * @param path 생성할 디렉토리 경로
-     * @return 성공 시 true, 실패 시 false (이미 존재하는 경우도 true)
-     */
-    static bool CreateDirectory(const Path& path);
-
-    /**
-     * 디렉토리를 재귀적으로 생성합니다.
+     * 디렉토리를 생성합니다. 중간 디렉토리가 없으면 함께 생성합니다.
      * @param path 생성할 디렉토리 경로
      * @return 성공 시 true, 실패 시 false (이미 존재하는 경우도 true)
      */
@@ -225,7 +223,7 @@ struct SE_CORE_API FileSystem
     [[nodiscard]] static Optional<usize> FileSize(const Path& path);
 
     /**
-     * 파일 또는 디렉토리의 마지막 수정 시간을 반환합니다.
+     * 파일 또는 디렉토리의 마지막 수정 시간을 반환합니다. (SDL3: Unix epoch 초 단위)
      * @param path 대상 경로
      * @return 마지막 수정 시간 (uint64). 실패 시 nullopt
      */

--- a/EngineCore/Include/SimpleEngine/Core/Logging/Backends/FileBackend.h
+++ b/EngineCore/Include/SimpleEngine/Core/Logging/Backends/FileBackend.h
@@ -1,9 +1,10 @@
 ﻿#pragma once
-#include <fstream>
 
 #include "SimpleEngine/Core/HAL/PlatformTypes.h"
 #include "SimpleEngine/Core/Logging/Backends/ILogBackend.h"
 #include "SimpleEngine/Core/Types/Path.h"
+
+#include "SDL3/SDL.h"
 
 
 namespace se
@@ -13,6 +14,10 @@ class SE_CORE_API FileBackend : public ILogBackend
 public:
     FileBackend();
     FileBackend(Path path);
+    virtual ~FileBackend() override;
+
+    FileBackend(const FileBackend&) = delete;
+    FileBackend& operator=(const FileBackend&) = delete;
 
     virtual void WriteLog(const LogEntry& entry) override;
     virtual void Flush() override;
@@ -21,6 +26,9 @@ private:
     /** .log 파일을 새로 엽니다. (없다면 새로 생성) */
     void OpenFile();
 
+    /** 현재 로그 파일을 닫습니다. */
+    void CloseFile();
+
     /** 현재 로그 파일을 백업하고 새로운 파일을 생성합니다. */
     void RotateFile();
 
@@ -28,7 +36,7 @@ private:
     [[nodiscard]] bool CheckRotation() const;
 
 private:
-    std::ofstream file;
+    SDL_IOStream* io_stream = nullptr;
     Path file_path;
     usize current_file_size = 0;
     constexpr static usize max_file_size = 10ULL * 1024 * 1024; // 10MB

--- a/EngineCore/Include/SimpleEngine/Core/Types/Path.h
+++ b/EngineCore/Include/SimpleEngine/Core/Types/Path.h
@@ -1,18 +1,25 @@
 #pragma once
 
-#include <filesystem>
-#include <compare>
-#include <functional>
-
 #include "SimpleEngine/Core/Container/Optional.h"
 #include "SimpleEngine/Core/Container/String.h"
 #include "SimpleEngine/Core/Container/StringView.h"
+
+#include <compare>
+#include <functional>
 
 
 namespace se
 {
 /**
  * 파일 시스템 경로를 다루는 클래스
+ *
+ * 내부적으로 se::String으로 관리하며, 항상 정규화된 상태를 유지합니다.
+ * - 구분자는 '/'로 통일
+ * - 불필요한 "./" 제거, "A/B/../C"는 "A/C"로 압축
+ * - 연속된 슬래시 "//" 제거, 후행 슬래시 제거
+ *
+ * @note 경로 비교(==, <=>)는 모든 플랫폼에서 case-sensitive로 동작합니다.
+ *       크로스 플랫폼 예측 가능성을 위한 의도적 설계입니다.
  */
 class SE_CORE_API Path
 {
@@ -21,7 +28,6 @@ public:
     Path(const char* in_path);
     Path(const String& in_path);
     Path(StringView in_path);
-    Path(std::filesystem::path in_path);
 
     Path(const Path&) = default;
     Path& operator=(const Path&) = default;
@@ -44,13 +50,6 @@ public:
      */
     Path& Concat(const String& str);
     Path& operator+=(const String& str);
-
-    /**
-     * 경로를 정규화합니다.
-     * ".." (상위 폴더), "." (현재 폴더) 등의 참조를 정리하여 최단 경로로 만듭니다.
-     * 예: "A/./B/../C" -> "A/C"
-     */
-    Path& Normalize();
 
     /**
      * 파일명을 변경합니다.
@@ -77,13 +76,11 @@ public:
     /** 확장자가 변경된 새로운 Path를 반환합니다. */
     [[nodiscard]] Path WithExtension(const String& extension) const;
 
-    /** 정규화된 새로운 Path를 반환합니다. */
-    [[nodiscard]] Path GetNormalized() const;
-
     /**
      * base 경로를 기준으로 한 상대 경로를 계산하여 반환합니다.
      * 예: (*this)"/A/B/C", base="/A" -> "B/C"
-     * @note 경로가 base 내부에 있지 않거나 계산 불가능할 경우 nullopt를 반환할 수 있습니다.
+     * @note 절대/상대 불일치, 루트 접두사 불일치, 공통 접두사가 없는 경우 nullopt를 반환합니다.
+     *       (예: "/A/B"와 "/C/D"처럼 공통 경로가 없는 경우)
      */
     [[nodiscard]] Optional<Path> RelativeTo(const Path& base) const;
 
@@ -136,18 +133,16 @@ public:
 
     // --- Conversions ---
 
-    /** 경로를 UTF-8 문자열로 변환하여 반환합니다. */
-    [[nodiscard]] String ToString() const;
+    /** 경로를 UTF-8 문자열로 반환합니다. (내부 문자열의 const 참조) */
+    [[nodiscard]] const String& ToString() const;
 
-    // [[nodiscard]] const char* CStr() const; // 필요 시 주석 해제
+    /** 경로를 C 문자열(null-terminated)로 반환합니다. */
+    [[nodiscard]] const char* CStr() const;
 
     void Swap(Path& other) noexcept;
 
 public:
     // --- Operators ---
-
-    /** 내부 std::filesystem::path 객체를 반환합니다. (나중에 API 변경 가능성 있음) */
-    [[nodiscard]] explicit operator const std::filesystem::path&() const { return internal_path; }
 
     [[nodiscard]] bool operator==(const Path& other) const;
     [[nodiscard]] std::strong_ordering operator<=>(const Path& other) const;
@@ -155,8 +150,14 @@ public:
     friend void swap(Path& lhs, Path& rhs) noexcept { lhs.Swap(rhs); }
 
 private:
+    /** 입력 문자열을 정규화하여 반환합니다. O(n) 단일 패스. */
+    static String NormalizePath(StringView input);
+
+    /** 경로 문자열에서 루트 접두사 길이를 반환합니다. (예: "/" -> 1, "C:/" -> 3) */
+    static usize DetectRootLength(StringView view);
+
     friend struct std::hash<Path>;
-    std::filesystem::path internal_path;
+    String path;
 };
 } // namespace se
 
@@ -165,7 +166,7 @@ struct std::hash<se::Path>
 {
     size_t operator()(const se::Path& in_path) const noexcept
     {
-        return std::filesystem::hash_value(in_path.internal_path);
+        return std::hash<se::String>{}(in_path.path);
     }
 };
 
@@ -174,7 +175,6 @@ struct std::formatter<se::Path> : std::formatter<se::String>
 {
     auto format(const se::Path& path, std::format_context& ctx) const
     {
-        const se::String str = path.ToString();
-        return std::formatter<se::String>::format(str, ctx);
+        return std::formatter<se::String>::format(path.ToString(), ctx);
     }
 };

--- a/EngineCore/Source/Core/FileSystem/FileSystem.cpp
+++ b/EngineCore/Source/Core/FileSystem/FileSystem.cpp
@@ -1,29 +1,35 @@
 #include "SimpleEngine/Core/FileSystem/FileSystem.h"
+#include "SimpleEngine/Utility/Common.h"
 
 #include "SDL3/SDL.h"
-
 
 #if SE_PLATFORM_WINDOWS
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #include <Windows.h>
 #undef CreateDirectory
-#endif
-
-#include <filesystem>
-#include <fstream>
-
-#include "SimpleEngine/Utility/Common.h"
-
 
 namespace
 {
-std::filesystem::path ToStdPath(const se::Path& path)
+std::wstring ToWideString(const se::String& str)
 {
-    const se::String str = path.ToString();
-    return std::filesystem::path{ reinterpret_cast<const char8_t*>(str.CStr()) };
+    if (str.IsEmpty())
+    {
+        return {};
+    }
+    const int size_needed = MultiByteToWideChar(
+        CP_UTF8, 0, str.Data(), static_cast<int>(str.ByteLen()),
+        nullptr, 0
+    );
+    std::wstring wide(size_needed, 0);
+    MultiByteToWideChar(
+        CP_UTF8, 0, str.Data(), static_cast<int>(str.ByteLen()),
+        wide.data(), size_needed
+    );
+    return wide;
 }
-}  // namespace
+} // namespace
+#endif
 
 
 namespace se
@@ -32,46 +38,34 @@ namespace se
 // DirectoryEntry
 // =============================================================================
 
-DirectoryEntry::DirectoryEntry(std::filesystem::directory_entry entry)
-    : internal_entry(std::move(entry))
+const Path& DirectoryEntry::GetPath() const
 {
-}
-
-Path DirectoryEntry::GetPath() const
-{
-    return Path{ internal_entry.path() };
+    return entry_path;
 }
 
 bool DirectoryEntry::IsDirectory() const
 {
-    std::error_code ec;
-    return internal_entry.is_directory(ec);
+    return is_directory;
 }
 
 bool DirectoryEntry::IsFile() const
 {
-    std::error_code ec;
-    return internal_entry.is_regular_file(ec);
+    return is_file;
 }
 
 bool DirectoryEntry::IsSymlink() const
 {
-    std::error_code ec;
-    return internal_entry.is_symlink(ec);
+    return false;
 }
 
 usize DirectoryEntry::FileSize() const
 {
-    std::error_code ec;
-    const auto size = internal_entry.file_size(ec);
-    return ec ? 0 : static_cast<usize>(size);
+    return file_size;
 }
 
 uint64 DirectoryEntry::LastWriteTime() const
 {
-    std::error_code ec;
-    const auto time = internal_entry.last_write_time(ec);
-    return ec ? 0 : time.time_since_epoch().count();
+    return last_write_time;
 }
 
 
@@ -79,51 +73,66 @@ uint64 DirectoryEntry::LastWriteTime() const
 // DirectoryIterator
 // =============================================================================
 
+// TODO: [Performance] 현재 생성자에서 모든 엔트리를 즉시 Array에 적재 (eager loading)하여,
+//       대량 파일이 있는 디렉토리에서 메모리 사용량이 증가할 수 있음
+//       필요 시 SDL_EnumerateDirectory 콜백 내에서 yield하는 lazy iterator로 전환 검토
 DirectoryIterator::DirectoryIterator(const Path& path)
 {
-    std::error_code ec;
-    internal_iter = std::filesystem::directory_iterator(ToStdPath(path), ec);
-    if (!ec && internal_iter != std::filesystem::directory_iterator{})
+    struct Context
     {
-        is_end = false;
-        current_entry = DirectoryEntry{ *internal_iter };
-    }
+        Array<DirectoryEntry>& entries;
+        const Path& parent;
+    };
+    Context context{ .entries = entries, .parent = path };
+
+    SDL_EnumerateDirectory(path.CStr(), [](void* userdata, const char* /*dirname*/, const char* fname) -> SDL_EnumerationResult
+    {
+        Context& ctx = *static_cast<Context*>(userdata);
+
+        DirectoryEntry entry;
+        entry.entry_path = ctx.parent / fname;
+
+        SDL_PathInfo info;
+        if (SDL_GetPathInfo(entry.entry_path.CStr(), &info))
+        {
+            entry.is_directory = info.type == SDL_PATHTYPE_DIRECTORY;
+            entry.is_file = info.type == SDL_PATHTYPE_FILE;
+            entry.file_size = static_cast<usize>(info.size);
+            entry.last_write_time = static_cast<uint64>(info.modify_time);
+        }
+
+        ctx.entries.Push(std::move(entry));
+        return SDL_ENUM_CONTINUE;
+    }, &context);
+
+    current_index = 0;
 }
 
 DirectoryIterator& DirectoryIterator::operator++()
 {
-    ++internal_iter;
-    if (internal_iter == std::filesystem::directory_iterator{})
+    if (!IsEnd())
     {
-        is_end = true;
-        current_entry = {};
-    }
-    else
-    {
-        current_entry = DirectoryEntry{ *internal_iter };
+        ++current_index;
     }
     return *this;
 }
 
-DirectoryIterator DirectoryIterator::operator++(int)
+void DirectoryIterator::operator++(int)
 {
-    DirectoryIterator tmp = *this;
     ++(*this);
-    return tmp;
 }
 
 bool DirectoryIterator::operator==(const DirectoryIterator& other) const
 {
-    // 둘 다 end이거나, 내부 이터레이터가 같으면 equal
-    if (is_end && other.is_end)
+    if (IsEnd() && other.IsEnd())
     {
         return true;
     }
-    if (is_end != other.is_end)
+    if (IsEnd() != other.IsEnd())
     {
         return false;
     }
-    return internal_iter == other.internal_iter;
+    return &entries == &other.entries && current_index == other.current_index;
 }
 
 
@@ -133,70 +142,131 @@ bool DirectoryIterator::operator==(const DirectoryIterator& other) const
 
 Path FileSystem::Absolute(const Path& path)
 {
-    std::error_code ec;
-    std::filesystem::path result = std::filesystem::absolute(ToStdPath(path), ec);
-    if (ec)
+    if (path.IsEmpty())
     {
         return {};
     }
-    return Path{ std::move(result) };
+    if (path.IsAbsolute())
+    {
+        return path;
+    }
+
+    char* cwd = SDL_GetCurrentDirectory();
+    if (!cwd)
+    {
+        return {};
+    }
+
+    Path result = cwd;
+    SDL_free(cwd);
+    result /= path;
+    return result;
 }
 
 Optional<Path> FileSystem::Canonical(const Path& path)
 {
-    std::error_code ec;
-    std::filesystem::path result = std::filesystem::canonical(ToStdPath(path), ec);
-    if (ec)
+    Path abs = Absolute(path);
+    if (abs.IsEmpty() || !abs.Exists())
     {
         return NullOpt;
     }
-    return Path{ std::move(result) };
-}
-
-bool FileSystem::CreateDirectory(const Path& path)
-{
-    std::error_code ec;
-    return std::filesystem::create_directory(ToStdPath(path), ec) || !ec;
+    return abs;
 }
 
 bool FileSystem::CreateDirectories(const Path& path)
 {
-    std::error_code ec;
-    return std::filesystem::create_directories(ToStdPath(path), ec) || !ec;
+    if (path.IsEmpty())
+    {
+        return false;
+    }
+    return SDL_CreateDirectory(path.CStr());
 }
 
 bool FileSystem::Remove(const Path& path)
 {
-    std::error_code ec;
-    return std::filesystem::remove(ToStdPath(path), ec);
+    if (path.IsEmpty())
+    {
+        return false;
+    }
+    if (!path.Exists())
+    {
+        return false;
+    }
+    return SDL_RemovePath(path.CStr());
 }
 
 usize FileSystem::RemoveAll(const Path& path)
 {
-    std::error_code ec;
-    return std::filesystem::remove_all(ToStdPath(path), ec);
+    if (path.IsEmpty())
+    {
+        return 0;
+    }
+
+    SDL_PathInfo info;
+    if (!SDL_GetPathInfo(path.CStr(), &info))
+    {
+        return 0;
+    }
+
+    usize count = 0;
+
+    if (info.type == SDL_PATHTYPE_DIRECTORY)
+    {
+        for (const DirectoryEntry& entry : ReadDir(path))
+        {
+            count += RemoveAll(entry.GetPath());
+        }
+    }
+
+    if (SDL_RemovePath(path.CStr()))
+    {
+        count++;
+    }
+
+    return count;
 }
 
 bool FileSystem::Copy(const Path& from, const Path& to)
 {
-    std::error_code ec;
-    std::filesystem::copy(ToStdPath(from), ToStdPath(to), ec);
-    return !ec;
+    if (from.IsEmpty() || to.IsEmpty())
+    {
+        return false;
+    }
+
+    SDL_PathInfo info;
+    if (!SDL_GetPathInfo(from.CStr(), &info))
+    {
+        return false;
+    }
+
+    if (info.type == SDL_PATHTYPE_FILE)
+    {
+        return SDL_CopyFile(from.CStr(), to.CStr());
+    }
+    if (info.type == SDL_PATHTYPE_DIRECTORY)
+    {
+        return SDL_CreateDirectory(to.CStr());
+    }
+    return false;
 }
 
 bool FileSystem::Rename(const Path& from, const Path& to)
 {
-    const std::filesystem::path std_from = ToStdPath(from);
-    const std::filesystem::path std_to = ToStdPath(to);
+    if (from.IsEmpty() || to.IsEmpty())
+    {
+        return false;
+    }
 
 #if SE_PLATFORM_WINDOWS
-    // Windows에서는 std::filesystem::rename시,
-    // 이미 같은 이름의 파일이 있을 경우 실패하기 때문에 ReplaceFileW를 대신 사용
-    const std::wstring& wide_from = std_from.native();
-    const std::wstring& wide_to = std_to.native();
+    // Windows에서는 ReplaceFileW로 원자적 덮어쓰기를 보장
+    const std::wstring wide_from = ToWideString(from.ToString());
+    const std::wstring wide_to = ToWideString(to.ToString());
 
     // ReplaceFileW 시도
-    if (::ReplaceFileW(wide_to.c_str(), wide_from.c_str(), nullptr, REPLACEFILE_IGNORE_MERGE_ERRORS, nullptr, nullptr))
+    if (::ReplaceFileW(
+        wide_to.c_str(), wide_from.c_str(),
+        nullptr, REPLACEFILE_IGNORE_MERGE_ERRORS, nullptr, nullptr
+    ))
     {
         return true;
     }
@@ -207,47 +277,57 @@ bool FileSystem::Rename(const Path& from, const Path& to)
     // 대상 파일이 없어서 실패한 것이라면, 단순 MoveFileEx로 처리 가능
     if (last_error == ERROR_FILE_NOT_FOUND || last_error == ERROR_PATH_NOT_FOUND)
     {
-        return ::MoveFileExW(wide_from.c_str(), wide_to.c_str(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_COPY_ALLOWED);
+        return ::MoveFileExW(
+            wide_from.c_str(), wide_to.c_str(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_COPY_ALLOWED
+        );
     }
 
     // 그 외의 에러(권한, 공유 위반 등)는 실패로 처리
     return false;
 
 #else
-    std::error_code ec;
-    std::filesystem::rename(std_from, std_to, ec);
-    return !ec;
+    return SDL_RenamePath(from.CStr(), to.CStr());
 #endif
 }
 
 Optional<usize> FileSystem::FileSize(const Path& path)
 {
-    std::error_code ec;
-    const auto size = std::filesystem::file_size(ToStdPath(path), ec);
-    if (ec)
+    if (path.IsEmpty())
     {
         return NullOpt;
     }
-    return static_cast<usize>(size);
+    SDL_PathInfo info;
+    if (!SDL_GetPathInfo(path.CStr(), &info))
+    {
+        return NullOpt;
+    }
+    return static_cast<usize>(info.size);
 }
 
 Optional<uint64> FileSystem::LastWriteTime(const Path& path)
 {
-    std::error_code ec;
-    const auto time = std::filesystem::last_write_time(ToStdPath(path), ec);
-    if (ec)
+    if (path.IsEmpty())
     {
         return NullOpt;
     }
-    return time.time_since_epoch().count();
+    SDL_PathInfo info;
+    if (!SDL_GetPathInfo(path.CStr(), &info))
+    {
+        return NullOpt;
+    }
+    return static_cast<uint64>(info.modify_time);
 }
 
+// TODO: [Performance] SDL_LoadFile가 내부적으로 malloc한 버퍼를 String 생성자에서 다시 복사함
+//       String이 외부 버퍼 소유권을 직접 인수받는 생성자를 지원하면 복사 1회 절약 가능
 FileResult<String> FileSystem::ReadToString(const Path& path)
 {
-    const String path_str = path.ToString();
+    const String& path_str = path.ToString();
 
-    std::ifstream file(ToStdPath(path), std::ios::in | std::ios::binary);
-    if (!file.is_open())
+    size_t size = 0;
+    void* data = SDL_LoadFile(path.CStr(), &size);
+    if (!data)
     {
         if (!path.Exists())
         {
@@ -256,34 +336,18 @@ FileResult<String> FileSystem::ReadToString(const Path& path)
         return Unexpected{ FileReadError::OpenFailed("Failed to open file: " + path_str) };
     }
 
-    file.seekg(0, std::ios::end);
-    const auto size = file.tellg();
-    file.seekg(0, std::ios::beg);
-
-    if (size < 0)
-    {
-        return Unexpected{ FileReadError::EndOfFile("File size error: " + path_str) };
-    }
-
-    // 문자열로 읽기
-    String content;
-    content.ResizeForOverwrite(static_cast<usize>(size));
-    file.read(content.Data(), size);
-
-    if (file.fail() && !file.eof())
-    {
-        return Unexpected{ FileReadError::Read("Failed to read file: " + path_str) };
-    }
-
+    String content(static_cast<const char*>(data), static_cast<usize>(size));
+    SDL_free(data);
     return content;
 }
 
 FileResult<Array<uint8>> FileSystem::ReadBytes(const Path& path)
 {
-    const String path_str = path.ToString();
+    const String& path_str = path.ToString();
 
-    std::ifstream file(ToStdPath(path), std::ios::in | std::ios::binary);
-    if (!file.is_open())
+    size_t size = 0;
+    void* data = SDL_LoadFile(path.CStr(), &size);
+    if (!data)
     {
         if (!path.Exists())
         {
@@ -292,31 +356,16 @@ FileResult<Array<uint8>> FileSystem::ReadBytes(const Path& path)
         return Unexpected{ FileReadError::OpenFailed("Failed to open file: " + path_str) };
     }
 
-    file.seekg(0, std::ios::end);
-    const auto size = file.tellg();
-    file.seekg(0, std::ios::beg);
-
-    if (size < 0)
-    {
-        return Unexpected{ FileReadError::EndOfFile("File size error: " + path_str) };
-    }
-
-    // 바이트 배열로 읽기
-    Array<uint8> data;
-    data.Resize(static_cast<usize>(size));
-    file.read(reinterpret_cast<char*>(data.Data()), size);
-
-    if (file.fail() && !file.eof())
-    {
-        return Unexpected{ FileReadError::Read("Failed to read file: " + path_str) };
-    }
-
-    return data;
+    Array<uint8> result;
+    result.ResizeUninitialized(static_cast<usize>(size));
+    std::memcpy(result.Data(), data, size);
+    SDL_free(data);
+    return result;
 }
 
 std::generator<FileResult<ArrayView<const uint8>>> FileSystem::ReadChunked(Path path, usize chunk_size)
 {
-    const String path_str = path.ToString();
+    const String& path_str = path.ToString();
 
     // 바이너리 읽기모드
     SDL_IOStream* stream = SDL_IOFromFile(path_str.CStr(), "rb");
@@ -373,26 +422,20 @@ std::generator<FileResult<ArrayView<const uint8>>> FileSystem::ReadChunked(Path 
 
 bool FileSystem::WriteString(const Path& path, StringView content)
 {
-    std::ofstream file(ToStdPath(path), std::ios::out | std::ios::binary | std::ios::trunc);
-    if (!file.is_open())
+    if (path.IsEmpty())
     {
         return false;
     }
-
-    file.write(content.Data(), static_cast<std::streamsize>(content.ByteLen()));
-    return !file.fail();
+    return SDL_SaveFile(path.CStr(), content.Data(), content.ByteLen());
 }
 
 bool FileSystem::Write(const Path& path, ArrayView<const uint8> data)
 {
-    std::ofstream file(ToStdPath(path), std::ios::out | std::ios::binary | std::ios::trunc);
-    if (!file.is_open())
+    if (path.IsEmpty())
     {
         return false;
     }
-
-    file.write(reinterpret_cast<const char*>(data.Data()), static_cast<std::streamsize>(data.Len()));
-    return !file.fail();
+    return SDL_SaveFile(path.CStr(), data.Data(), data.Len());
 }
 
 DirectoryIterator FileSystem::ReadDir(const Path& path)

--- a/EngineCore/Source/Core/FileSystem/VFS.cpp
+++ b/EngineCore/Source/Core/FileSystem/VFS.cpp
@@ -54,7 +54,7 @@ void VFS::Mount(StringView scheme, const Path& physical_path, int32 priority)
     }
 
     points.Push({
-        .physical_path = physical_path,
+        .physical_path = FileSystem::Absolute(physical_path),
         .priority = priority
     });
 

--- a/EngineCore/Source/Core/FileSystem/VFS.cpp
+++ b/EngineCore/Source/Core/FileSystem/VFS.cpp
@@ -39,16 +39,13 @@ void VFS::Mount(StringView scheme, const Path& physical_path, int32 priority)
 {
     std::unique_lock lock(mutex);
 
-    // 경로를 정규화하여 저장
-    Path abs_path = physical_path.GetNormalized();
-
     const StringName scheme_name{ scheme };
     Array<MountPoint>& points = mount_points[scheme_name];
 
     // 이미 존재하는지 확인
     const MountPoint* it = std::ranges::find_if(points, [&](const MountPoint& point)
     {
-        return point.priority == priority && point.physical_path == abs_path;
+        return point.priority == priority && point.physical_path == physical_path;
     });
 
     if (it != points.end())
@@ -57,7 +54,7 @@ void VFS::Mount(StringView scheme, const Path& physical_path, int32 priority)
     }
 
     points.Push({
-        .physical_path = std::move(abs_path),
+        .physical_path = physical_path,
         .priority = priority
     });
 
@@ -144,13 +141,14 @@ Optional<Path> VFS::ResolveImpl(const VPath& virtual_path, bool check_existence)
     return NullOpt;
 }
 
+// TODO: [Performance] 모든 마운트 포인트를 선형 탐색함. 마운트 수가 많아지면
+//       경로 접두사 기반 trie 또는 정렬된 배열 + 이진 탐색으로 전환 검토.
 Optional<VPath> VFS::UnresolveImpl(const Path& physical_path) const
 {
     std::shared_lock lock(mutex);
 
     Path abs_input = FileSystem::Absolute(physical_path);
-    abs_input.Normalize();
-    const String input_str = abs_input.ToString();
+    const String& input_str = abs_input.ToString();
     const StringView input_view{ input_str };
 
     const StringName* best_scheme = nullptr;
@@ -161,7 +159,7 @@ Optional<VPath> VFS::UnresolveImpl(const Path& physical_path) const
     {
         for (const MountPoint& point : points)
         {
-            const String root_str = point.physical_path.ToString();
+            const String& root_str = point.physical_path.ToString();
             const StringView root_view{ root_str };
 
             // 물리적 경로가 마운트 포인트의 하위 경로인지 확인

--- a/EngineCore/Source/Core/FileSystem/VFS.cpp
+++ b/EngineCore/Source/Core/FileSystem/VFS.cpp
@@ -123,6 +123,17 @@ Optional<Path> VFS::ResolveImpl(const VPath& virtual_path, bool check_existence)
     {
         Path candidate = mount_point.physical_path / relative_part;
 
+        // ".."을 포함하는 가상 경로가 마운트 포인트 외부로 탈출하는 것을 방지
+        if (!candidate.IsSubPathOf(mount_point.physical_path))
+        {
+            ConsoleLog(
+                ELogLevel::Warning,
+                "VFS: Path traversal blocked. '{}' escapes mount point '{}'.",
+                virtual_path.ToString(), mount_point.physical_path
+            );
+            continue;
+        }
+
         if (check_existence)
         {
             if (candidate.Exists())

--- a/EngineCore/Source/Core/Logging/Backends/FileBackend.cpp
+++ b/EngineCore/Source/Core/Logging/Backends/FileBackend.cpp
@@ -18,14 +18,19 @@ FileBackend::FileBackend(Path path)
     OpenFile();
 }
 
+FileBackend::~FileBackend()
+{
+    CloseFile();
+}
+
 void FileBackend::WriteLog(const LogEntry& entry)
 {
-    if (!file.is_open())
+    if (!io_stream)
     {
         return;
     }
 
-    const std::string formatted = std::format(
+    const String formatted = String::Format(
         "{} {:<7} {:<16} [{}:{}] {}\n",
         entry.GetTimestampString(),
         entry.GetLevelString(),
@@ -35,8 +40,8 @@ void FileBackend::WriteLog(const LogEntry& entry)
         entry.formatted_message
     );
 
-    file << formatted;
-    current_file_size += formatted.size();
+    SDL_WriteIO(io_stream, formatted.Data(), formatted.ByteLen());
+    current_file_size += formatted.ByteLen();
 
     if (CheckRotation())
     {
@@ -46,9 +51,9 @@ void FileBackend::WriteLog(const LogEntry& entry)
 
 void FileBackend::Flush()
 {
-    if (file.is_open())
+    if (io_stream)
     {
-        file.flush();
+        SDL_FlushIO(io_stream);
     }
 }
 
@@ -62,17 +67,26 @@ void FileBackend::OpenFile()
         }
     }
 
-    const String file_path_str = file_path.ToString();
-    file.open(file_path_str.CStr(), std::ios::out | std::ios::app);
-    if (file.is_open())
+    io_stream = SDL_IOFromFile(file_path.CStr(), "ab");
+    if (io_stream)
     {
         current_file_size = FileSystem::FileSize(file_path).ValueOr(0);
     }
 }
 
+void FileBackend::CloseFile()
+{
+    if (io_stream)
+    {
+        SDL_FlushIO(io_stream);
+        SDL_CloseIO(io_stream);
+        io_stream = nullptr;
+    }
+}
+
 void FileBackend::RotateFile()
 {
-    file.close();
+    CloseFile();
 
     namespace chrono = std::chrono;
     auto zt = chrono::zoned_time{ chrono::current_zone(), chrono::system_clock::now() };

--- a/EngineCore/Source/Core/Types/Path.cpp
+++ b/EngineCore/Source/Core/Types/Path.cpp
@@ -1,47 +1,62 @@
 #include "SimpleEngine/Core/Types/Path.h"
-#include "SimpleEngine/Utility/StringUtils.h"
 
-#include <string>
-#include <utility>
+#include "SDL3/SDL_filesystem.h"
 
 
 namespace se
 {
-Path::Path(const char* in_path)
+namespace
 {
-    if (in_path)
-    {
-        internal_path = std::filesystem::path{ reinterpret_cast<const char8_t*>(in_path) };
-    }
+bool IsAsciiAlpha(char c)
+{
+    return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+}
+} // namespace
+
+Path::Path(const char* in_path)
+    : path(in_path ? NormalizePath(StringView{ in_path }) : String{})
+{
 }
 
 Path::Path(const String& in_path)
+    : path(in_path.IsEmpty() ? String{} : NormalizePath(StringView{ in_path }))
 {
-    if (!in_path.IsEmpty())
-    {
-        internal_path = std::filesystem::path{ reinterpret_cast<const char8_t*>(in_path.CStr()) };
-    }
 }
 
 Path::Path(StringView in_path)
-{
-    if (!in_path.IsEmpty())
-    {
-        internal_path = std::filesystem::path{
-            reinterpret_cast<const char8_t*>(in_path.Data()),
-            reinterpret_cast<const char8_t*>(in_path.Data() + in_path.ByteLen())
-        };
-    }
-}
-
-Path::Path(std::filesystem::path in_path)
-    : internal_path(std::move(in_path))
+    : path(in_path.IsEmpty() ? String{} : NormalizePath(in_path))
 {
 }
 
 Path& Path::Append(const Path& other)
 {
-    internal_path /= other.internal_path;
+    if (other.IsEmpty())
+    {
+        return *this;
+    }
+
+    // 절대 경로가 RHS이면 대체 (std::filesystem::path 동작과 동일)
+    if (other.IsAbsolute())
+    {
+        path = other.path;
+        return *this;
+    }
+
+    if (path.IsEmpty())
+    {
+        path = other.path;
+        return *this;
+    }
+
+    // TODO: [Performance] other에 ".."이 없으면 재정규화 없이 직접 연결하는 fast path 도입 검토
+    //       대부분의 Append 호출에서 other는 단순 세그먼트(예: "Source")이므로
+    //       NormalizePath O(n) 재호출을 피하면 hot-path에서 유의미한 개선 가능
+    String combined;
+    combined.Reserve(path.ByteLen() + 1 + other.path.ByteLen());
+    combined.Append(path);
+    combined += '/';
+    combined.Append(other.path);
+    path = NormalizePath(combined);
     return *this;
 }
 
@@ -52,7 +67,18 @@ Path& Path::operator/=(const Path& other)
 
 Path& Path::Concat(const String& str)
 {
-    internal_path += std::filesystem::path{ reinterpret_cast<const char8_t*>(str.CStr()) };
+    if (str.IsEmpty())
+    {
+        return *this;
+    }
+
+    // TODO: [Performance] str에 경로 구분자('/', '\\')나 ".."이 없으면 재정규화 생략 가능
+    //       확장자 변경 등 단순 연결 시 NormalizePath 비용 회피
+    String combined;
+    combined.Reserve(path.ByteLen() + str.ByteLen());
+    combined.Append(path);
+    combined.Append(str);
+    path = NormalizePath(combined);
     return *this;
 }
 
@@ -61,25 +87,51 @@ Path& Path::operator+=(const String& str)
     return Concat(str);
 }
 
-Path& Path::Normalize()
-{
-    internal_path = internal_path.lexically_normal();
-    return *this;
-}
-
 Path& Path::SetFileName(const String& name)
 {
-    internal_path.replace_filename({
-        reinterpret_cast<const char8_t*>(name.CStr())
-    });
+    const StringView view{ path };
+    const usize root_len = DetectRootLength(view);
+
+    const Optional<usize> last_slash = view.FindLast('/');
+    if (last_slash.HasValue() && *last_slash >= root_len)
+    {
+        path.Truncate(*last_slash + 1);
+    }
+    else
+    {
+        path.Clear();
+    }
+
+    path.Append(name);
+    path = NormalizePath(path);
     return *this;
 }
 
 Path& Path::SetExtension(const String& extension)
 {
-    internal_path.replace_extension({
-        reinterpret_cast<const char8_t*>(extension.CStr())
-    });
+    // 파일명 내에서 확장자 위치를 찾아 교체
+    const StringView view{ path };
+    const Optional<usize> last_slash = view.FindLast('/');
+    const usize name_start = last_slash.HasValue() ? (*last_slash + 1) : 0;
+    const StringView name_part = view.Substr(name_start);
+
+    // 이름 부분에서 마지막 '.' 찾기 (첫 글자 '.'는 숨김파일이므로 제외)
+    const Optional<usize> dot = name_part.FindLast('.');
+    if (dot.HasValue() && *dot > 0)
+    {
+        path.Truncate(name_start + *dot);
+    }
+
+    // 새 확장자 추가
+    if (!extension.IsEmpty())
+    {
+        if (!StringView{ extension }.StartsWith('.'))
+        {
+            path += ".";
+        }
+        path.Append(extension);
+    }
+
     return *this;
 }
 
@@ -104,138 +156,460 @@ Path Path::WithExtension(const String& extension) const
     return new_path;
 }
 
-Path Path::GetNormalized() const
-{
-    Path new_path = *this;
-    new_path.Normalize();
-    return new_path;
-}
-
 Optional<Path> Path::RelativeTo(const Path& base) const
 {
-    std::filesystem::path relative = internal_path.lexically_relative(base.internal_path);
-
-    if (relative.empty())
+    // 절대/상대 불일치 시 계산 불가
+    if (IsAbsolute() != base.IsAbsolute())
     {
         return NullOpt;
     }
-    return Path{ std::move(relative) };
+
+    const StringView this_view{ path };
+    const StringView base_view{ base.path };
+    const usize this_root = DetectRootLength(this_view);
+    const usize base_root = DetectRootLength(base_view);
+
+    // 루트 접두사가 다르면 계산 불가
+    if (this_view.Substr(0, this_root) != base_view.Substr(0, base_root))
+    {
+        return NullOpt;
+    }
+
+    // 세그먼트 분할 헬퍼
+    auto split = [](StringView view, usize root_len) -> Array<StringView>
+    {
+        Array<StringView> segments;
+        usize pos = root_len;
+        while (pos < view.ByteLen())
+        {
+            const Optional<usize> slash = view.Find('/', pos);
+            const usize end = slash.HasValue() ? *slash : view.ByteLen();
+            if (end > pos)
+            {
+                segments.Push(view.Substr(pos, end - pos));
+            }
+            pos = end + 1;
+        }
+        return segments;
+    };
+
+    const Array<StringView> this_segs = split(this_view, this_root);
+    const Array<StringView> base_segs = split(base_view, base_root);
+
+    // 공통 접두사 길이
+    usize common = 0;
+    while (
+        common < this_segs.Len() && common < base_segs.Len()
+        && this_segs[common] == base_segs[common]
+    )
+    {
+        ++common;
+    }
+
+    // 공통 부분이 없고 양쪽 모두 비어있지 않으면 관계 없음
+    if (common == 0 && !this_segs.IsEmpty() && !base_segs.IsEmpty())
+    {
+        return NullOpt;
+    }
+
+    // 결과 조립: base 잔여분만큼 ".." + this 잔여분
+    String result;
+    for (usize i = common; i < base_segs.Len(); ++i)
+    {
+        if (!result.IsEmpty())
+        {
+            result += '/';
+        }
+        result += "..";
+    }
+    for (usize i = common; i < this_segs.Len(); ++i)
+    {
+        if (!result.IsEmpty())
+        {
+            result += '/';
+        }
+        result.Append(this_segs[i]);
+    }
+
+    if (result.IsEmpty())
+    {
+        result = ".";
+    }
+
+    Path rel;
+    rel.path = std::move(result);
+    return rel;
 }
 
 Optional<Path> Path::Parent() const
 {
-    // 기본적으로 상위 경로가 없다고 판단되는 경우 (예: "filename", ".")
-    if (!internal_path.has_parent_path())
+    if (path.IsEmpty())
     {
         return NullOpt;
     }
 
-    // 만약 .parent_path()를 해도 경로가 같다면, 이미 Root 경로인것으로 판정
-    auto parent = internal_path.parent_path();
-    if (parent == internal_path)
+    const StringView view{ path };
+    const usize root_len = DetectRootLength(view);
+
+    const Optional<usize> last_slash = view.FindLast('/');
+    if (!last_slash.HasValue())
     {
+        // 슬래시 없음 (예: "foo") -> 부모 없음
         return NullOpt;
     }
-    return Path{ std::move(parent) };
+
+    if (*last_slash < root_len)
+    {
+        // 슬래시가 루트 접두사 내에 있음 (예: "C:/foo"의 "/" 또는 "/"의 "/")
+        // 현재 경로가 루트 자체인 경우
+        if (view.ByteLen() <= root_len)
+        {
+            return NullOpt;
+        }
+        // 루트 바로 아래의 항목 -> 루트를 반환
+        Path parent;
+        parent.path = view.Substr(0, root_len).ToString();
+        return parent;
+    }
+
+    // 일반적인 경우: 마지막 슬래시 이전까지
+    Path parent;
+    parent.path = view.Substr(0, *last_slash).ToString();
+    return parent;
 }
 
 Optional<String> Path::FileName() const
 {
-    if (!internal_path.has_filename())
+    if (path.IsEmpty())
     {
         return NullOpt;
     }
-    const std::u8string u8_str = internal_path.filename().generic_u8string();
-    return StringUtils::ToString(u8_str);
+
+    const StringView view{ path };
+    const usize root_len = DetectRootLength(view);
+
+    // 경로가 루트 자체인 경우
+    if (view.ByteLen() <= root_len)
+    {
+        return NullOpt;
+    }
+
+    const Optional<usize> last_slash = view.FindLast('/');
+    StringView name = last_slash.HasValue() ? view.Substr(*last_slash + 1) : view;
+
+    if (name.IsEmpty())
+    {
+        return NullOpt;
+    }
+    return name.ToString();
 }
 
 Optional<String> Path::FileStem() const
 {
-    if (!internal_path.has_stem())
+    const Optional<String> name = FileName();
+    if (!name.HasValue())
     {
         return NullOpt;
     }
 
-    const std::u8string u8_str = internal_path.stem().generic_u8string();
-    return StringUtils::ToString(u8_str);
+    const StringView view{ *name };
+    const Optional<usize> dot = view.FindLast('.');
+
+    // dot이 없거나 첫 글자가 '.'인 경우 (숨김파일, 전체가 stem)
+    if (!dot.HasValue() || *dot == 0)
+    {
+        return name;
+    }
+
+    return view.Substr(0, *dot).ToString();
 }
 
 Optional<String> Path::Extension() const
 {
-    if (!internal_path.has_extension())
+    const Optional<String> name = FileName();
+    if (!name.HasValue())
     {
         return NullOpt;
     }
 
-    const std::u8string u8_str = internal_path.extension().generic_u8string();
-    return StringUtils::ToString(u8_str);
+    const StringView view{ *name };
+    const Optional<usize> dot = view.FindLast('.');
+
+    if (!dot.HasValue() || *dot == 0)
+    {
+        return NullOpt;
+    }
+
+    return view.Substr(*dot).ToString();
 }
 
 bool Path::IsEmpty() const
 {
-    return internal_path.empty();
+    return path.IsEmpty();
 }
 
 bool Path::IsAbsolute() const
 {
-    return internal_path.is_absolute();
-}
-
-bool Path::IsRelative() const
-{
-    return internal_path.is_relative();
-}
-
-bool Path::IsSubPathOf(const Path& base) const
-{
-    // 상대 경로를 구했을 때 ".."으로 시작하면 하위 경로가 아님
-    const std::filesystem::path relative = internal_path.lexically_relative(base.internal_path);
-
-    if (relative.empty())
+    const StringView view{ path };
+    if (view.IsEmpty())
     {
         return false;
     }
 
-    // 상대 경로의 첫 부분이 ".."인지 확인
-    return *relative.begin() != "..";
+    // Unix 절대 경로
+    if (view[0] == '/')
+    {
+        return true;
+    }
+
+    // Windows 절대 경로: C:/
+    if (view.ByteLen() >= 3 && IsAsciiAlpha(view[0]) && view[1] == ':' && view[2] == '/')
+    {
+        return true;
+    }
+
+    return false;
+}
+
+bool Path::IsRelative() const
+{
+    return !IsAbsolute();
+}
+
+bool Path::IsSubPathOf(const Path& base) const
+{
+    const Optional<Path> rel = RelativeTo(base);
+    if (!rel.HasValue())
+    {
+        return false;
+    }
+    return !rel->path.StartsWith("..");
 }
 
 bool Path::Exists() const
 {
-    std::error_code ec;
-    return std::filesystem::exists(internal_path, ec);
+    if (path.IsEmpty())
+    {
+        return false;
+    }
+    SDL_PathInfo info;
+    return SDL_GetPathInfo(path.CStr(), &info);
 }
 
 bool Path::IsDirectory() const
 {
-    std::error_code ec;
-    return std::filesystem::is_directory(internal_path, ec);
+    if (path.IsEmpty())
+    {
+        return false;
+    }
+    SDL_PathInfo info;
+    if (!SDL_GetPathInfo(path.CStr(), &info))
+    {
+        return false;
+    }
+    return info.type == SDL_PATHTYPE_DIRECTORY;
 }
 
 bool Path::IsFile() const
 {
-    std::error_code ec;
-    return std::filesystem::is_regular_file(internal_path, ec);
+    if (path.IsEmpty())
+    {
+        return false;
+    }
+    SDL_PathInfo info;
+    if (!SDL_GetPathInfo(path.CStr(), &info))
+    {
+        return false;
+    }
+    return info.type == SDL_PATHTYPE_FILE;
 }
 
-String Path::ToString() const
+const String& Path::ToString() const
 {
-    const std::u8string u8_str = internal_path.generic_u8string();
-    return StringUtils::ToString(u8_str);
+    return path;
+}
+
+const char* Path::CStr() const
+{
+    return path.CStr();
 }
 
 void Path::Swap(Path& other) noexcept
 {
-    internal_path.swap(other.internal_path);
+    std::swap(path, other.path);
 }
 
 bool Path::operator==(const Path& other) const
 {
-    return internal_path == other.internal_path;
+    return path == other.path;
 }
 
 std::strong_ordering Path::operator<=>(const Path& other) const
 {
-    return internal_path <=> other.internal_path;
+    return StringView{ path } <=> StringView{ other.path };
 }
-}  // namespace se
+
+String Path::NormalizePath(StringView input)
+{
+    if (input.IsEmpty())
+    {
+        return {};
+    }
+
+    const usize len = input.ByteLen();
+
+    // 작업 버퍼 할당 (최악의 경우 원본과 동일 길이)
+    String buffer;
+    buffer.ResizeForOverwrite(len);
+    char* buf = buffer.Data();
+
+    // Step 1: 복사하면서 '\' -> '/'
+    for (usize i = 0; i < len; ++i)
+    {
+        buf[i] = (input[i] == '\\') ? '/' : input[i];
+    }
+
+    // Step 2: 루트 접두사 탐지
+    const usize root_len = DetectRootLength(StringView{ buf, len });
+    const bool is_absolute = (root_len > 0 && buf[0] == '/')
+        || (root_len >= 3 && IsAsciiAlpha(buf[0]) && buf[1] == ':' && buf[2] == '/');
+
+    // Step 3: 세그먼트 처리 (in-place write-pointer)
+    usize write = root_len;
+    usize read = root_len;
+
+    // 세그먼트 시작 위치 스택 (일반적인 경로 깊이 ≤ 32)
+    Array<usize> seg_starts;
+
+    while (read < len)
+    {
+        // 연속 슬래시 skip
+        while (read < len && buf[read] == '/')
+        {
+            ++read;
+        }
+        if (read >= len)
+        {
+            break;
+        }
+
+        // 세그먼트 추출
+        const usize seg_begin = read;
+        while (read < len && buf[read] != '/')
+        {
+            ++read;
+        }
+        const usize seg_len = read - seg_begin;
+
+        // "." 세그먼트: skip
+        if (seg_len == 1 && buf[seg_begin] == '.')
+        {
+            continue;
+        }
+
+        // ".." 세그먼트
+        if (seg_len == 2 && buf[seg_begin] == '.' && buf[seg_begin + 1] == '.')
+        {
+            if (!seg_starts.IsEmpty())
+            {
+                const usize prev_start = seg_starts.Back().Value();
+                const usize prev_len = write - prev_start;
+                const bool prev_is_dotdot = (prev_len == 2 && buf[prev_start] == '.' && buf[prev_start + 1] == '.');
+
+                if (!prev_is_dotdot)
+                {
+                    // 이전 세그먼트를 pop (구분자 포함)
+                    write = prev_start;
+                    seg_starts.Pop();
+                    if (write > root_len && write > 0 && buf[write - 1] == '/')
+                    {
+                        --write;
+                    }
+                    continue;
+                }
+            }
+
+            if (!is_absolute)
+            {
+                // 상대 경로: ".."을 그대로 출력
+                if (write > root_len)
+                {
+                    buf[write++] = '/';
+                }
+                seg_starts.Push(write);
+                buf[write++] = '.';
+                buf[write++] = '.';
+            }
+            // 절대 경로에서 루트 위로의 ..는 무시
+            continue;
+        }
+
+        // 일반 세그먼트
+        if (write > root_len)
+        {
+            buf[write++] = '/';
+        }
+        seg_starts.Push(write);
+        if (write != seg_begin)
+        {
+            std::memmove(buf + write, buf + seg_begin, seg_len);
+        }
+        write += seg_len;
+    }
+
+    // 축퇴 처리: 상대 경로가 빈 문자열로 해소된 경우
+    if (write == 0)
+    {
+        return ".";
+    }
+
+    buffer.Truncate(write);
+    return buffer;
+}
+
+usize Path::DetectRootLength(StringView view)
+{
+    const usize len = view.ByteLen();
+    if (len == 0)
+    {
+        return 0;
+    }
+
+    // Windows 드라이브 문자: "C:" 또는 "C:/"
+    if (len >= 2 && IsAsciiAlpha(view[0]) && view[1] == ':')
+    {
+        if (len >= 3 && view[2] == '/')
+        {
+            return 3;
+        }
+        return 2;
+    }
+
+    // UNC 경로: "//server/share"
+    if (len >= 2 && view[0] == '/' && view[1] == '/')
+    {
+        usize pos = 2;
+        while (pos < len && view[pos] != '/')
+        {
+            ++pos;  // server
+        }
+        if (pos < len)
+        {
+            ++pos;  // separator
+        }
+        while (pos < len && view[pos] != '/')
+        {
+            ++pos;  // share
+        }
+        return pos;
+    }
+
+    // Unix 절대 경로: "/"
+    if (view[0] == '/')
+    {
+        return 1;
+    }
+
+    return 0;
+}
+} // namespace se

--- a/EngineCore/Source/Core/Types/Path.cpp
+++ b/EngineCore/Source/Core/Types/Path.cpp
@@ -132,6 +132,9 @@ Path& Path::SetExtension(const String& extension)
         path.Append(extension);
     }
 
+    // 확장자를 통한 Path Traversal 방지(예: ".ext/../") 및 정규화 불변식 유지
+    path = NormalizePath(path);
+
     return *this;
 }
 
@@ -544,8 +547,8 @@ String Path::NormalizePath(StringView input)
             continue;
         }
 
-        // 일반 세그먼트
-        if (write > root_len)
+        // 일반 세그먼트 - UNC 루트("//server/share")는 '/'로 끝나지 않으므로 구분자 보충
+        if (write > root_len || (write == root_len && root_len >= 2 && buf[0] == '/' && buf[1] == '/'))
         {
             buf[write++] = '/';
         }

--- a/EngineCore/Source/Core/Types/Path.cpp
+++ b/EngineCore/Source/Core/Types/Path.cpp
@@ -51,10 +51,20 @@ Path& Path::Append(const Path& other)
     // TODO: [Performance] other에 ".."이 없으면 재정규화 없이 직접 연결하는 fast path 도입 검토
     //       대부분의 Append 호출에서 other는 단순 세그먼트(예: "Source")이므로
     //       NormalizePath O(n) 재호출을 피하면 hot-path에서 유의미한 개선 가능
+
+    // "C:" 형태의 드라이브-상대 루트는 '/' 삽입 시 의미가 바뀌므로 생략
+    // C:foo (드라이브-상대) vs C:/foo (드라이브-절대)
+    const bool is_drive_relative_root = (path.ByteLen() == 2 && DetectRootLength(path) == 2);
+
     String combined;
-    combined.Reserve(path.ByteLen() + 1 + other.path.ByteLen());
+    combined.Reserve(path.ByteLen() + (is_drive_relative_root ? 0 : 1) + other.path.ByteLen());
     combined.Append(path);
-    combined += '/';
+
+    if (!is_drive_relative_root)
+    {
+        combined += '/';
+    }
+
     combined.Append(other.path);
     path = NormalizePath(combined);
     return *this;
@@ -386,7 +396,9 @@ bool Path::IsSubPathOf(const Path& base) const
     {
         return false;
     }
-    return !rel->path.StartsWith("..");
+
+    const StringView view{ rel->path };
+    return !(view == ".." || view.StartsWith("../"));
 }
 
 bool Path::Exists() const

--- a/EngineCore/Source/Core/Types/VPath.cpp
+++ b/EngineCore/Source/Core/Types/VPath.cpp
@@ -1,4 +1,4 @@
-﻿#include "SimpleEngine/Core/Types/VPath.h"
+#include "SimpleEngine/Core/Types/VPath.h"
 
 
 namespace se
@@ -25,17 +25,19 @@ VPath VPath::operator/(StringView relative_path) const
         return *this;
     }
 
-    VPath new_path;
-    new_path.full_path = full_path;
+    VPath new_path = *this;
+    String& str = new_path.full_path;
+    const StringView view{ str };
 
-    // 슬래시 중복 방지
-    String& new_path_str = new_path.full_path;
-    const StringView view{ new_path_str };
-    if (view.Back() != '/' && relative_path.Front() != '/')
+    const bool trail = (view.Back() == '/');
+    const bool lead = (relative_path.Front() == '/');
+
+    if (!trail && !lead)
     {
-        new_path_str += '/';
+        str += '/';
     }
-    new_path_str += relative_path;
+
+    str += (trail && lead) ? relative_path.Substr(1) : relative_path;
 
     return new_path;
 }
@@ -100,9 +102,9 @@ StringView VPath::GetExtension() const noexcept
     }
 
     const auto last_dot = filename.FindLastOf('.');
-    if (!last_dot.HasValue())
+    if (!last_dot.HasValue() || *last_dot == 0)
     {
-        return {}; // 확장자 없음
+        return {}; // 확장자 없음 또는 숨김파일(.gitignore 등)
     }
     return filename.Substr(*last_dot);
 }
@@ -116,9 +118,9 @@ StringView VPath::GetStem() const noexcept
     }
 
     const Optional last_dot = filename.FindLastOf('.');
-    if (!last_dot.HasValue())
+    if (!last_dot.HasValue() || *last_dot == 0)
     {
-        return filename; // 확장자 없음
+        return filename; // 확장자 없음 또는 숨김파일(.gitignore 등)
     }
     return filename.Substr(0, *last_dot);
 }

--- a/EngineTest/Source/UnitTestEnvironment.h
+++ b/EngineTest/Source/UnitTestEnvironment.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 #include "gtest/gtest.h"
 #include "SimpleEngine/Core/FileSystem/VFS.h"
+#include "SimpleEngine/Core/FileSystem/FileSystem.h"
 
 
 // ConfigTest에서 사용하는 Environment
@@ -10,7 +11,7 @@ public:
     virtual void SetUp() override
     {
         // 모든 테스트가 실행되기 전에 딱 한 번 호출됩니다.
-        se::VFS::Get().Mount("Config", std::filesystem::current_path() / "Config");
+        se::VFS::Get().Mount("Config", se::FileSystem::Absolute("Config"));
     }
 
     virtual void TearDown() override

--- a/EngineTest/Source/UnitTests/AssetPipelineTest.cpp
+++ b/EngineTest/Source/UnitTests/AssetPipelineTest.cpp
@@ -1,6 +1,5 @@
 #include "gtest/gtest.h"
 
-#include <filesystem>
 #include <ranges>
 
 #include "SimpleEditor/Asset/Pipeline/AssetImporter.h"

--- a/EngineTest/Source/UnitTests/DerivedDataCacheTest.cpp
+++ b/EngineTest/Source/UnitTests/DerivedDataCacheTest.cpp
@@ -1,11 +1,11 @@
 #include "gtest/gtest.h"
 
-#include <filesystem>
-
 #include "SimpleEngine/Asset/DerivedDataCache.h"
 #include "SimpleEngine/Core/Container/Array.h"
 #include "SimpleEngine/Core/FileSystem/FileSystem.h"
 #include "SimpleEngine/Core/Types/Guid.h"
+
+#include "SDL3/SDL_filesystem.h"
 
 using namespace se;
 using namespace se::asset;
@@ -18,21 +18,22 @@ class TempDir
 {
 public:
     explicit TempDir(StringView name)
-        : root_path(std::filesystem::temp_directory_path() / "SimpleEngineTest" / "DDCTest" / std::string(std::string_view{ name }))
     {
-        std::filesystem::create_directories(root_path);
+        char* pref = SDL_GetPrefPath("SimpleEngine", "Tests");
+        root_path = Path(pref) / Path("DDCTest") / Path(name);
+        SDL_free(pref);
+        FileSystem::CreateDirectories(root_path);
     }
 
     ~TempDir()
     {
-        std::error_code ec;
-        std::filesystem::remove_all(root_path, ec);
+        FileSystem::RemoveAll(root_path);
     }
 
-    [[nodiscard]] Path GetPath() const { return Path{ root_path }; }
+    [[nodiscard]] const Path& GetPath() const { return root_path; }
 
 private:
-    std::filesystem::path root_path;
+    Path root_path;
 };
 
 // 테스트용 페이로드 생성

--- a/EngineTest/Source/UnitTests/FileSystemTest.cpp
+++ b/EngineTest/Source/UnitTests/FileSystemTest.cpp
@@ -1,10 +1,10 @@
 #include "gtest/gtest.h"
 
-#include <filesystem>
-
 #include "SimpleEngine/Core/Container/Array.h"
 #include "SimpleEngine/Core/Types/Path.h"
 #include "SimpleEngine/Core/FileSystem/FileSystem.h"
+
+#include "SDL3/SDL_filesystem.h"
 
 using namespace se;
 
@@ -16,29 +16,27 @@ class TempDir
 {
 public:
     TempDir(StringView name)
-        : root_path(std::filesystem::temp_directory_path() / "SimpleEngineTest" / "FileSystemTest" / std::string(std::string_view{ name }))
     {
-        std::filesystem::create_directories(root_path);
+        char* pref = SDL_GetPrefPath("SimpleEngine", "Tests");
+        root_path = Path(pref) / Path("FileSystemTest") / Path(name);
+        SDL_free(pref);
+        FileSystem::CreateDirectories(root_path);
     }
 
     ~TempDir()
     {
-        std::error_code ec;
-        std::filesystem::remove_all(root_path, ec);
+        FileSystem::RemoveAll(root_path);
     }
 
-    Path GetPath() const { return Path{ root_path }; }
+    const Path& GetPath() const { return root_path; }
 
-    // UTF-8 문자열을 올바르게 처리하기 위해 char8_t로 변환
     Path operator/(StringView relative) const
     {
-        std::filesystem::path relative_path{ reinterpret_cast<const char8_t*>(relative.Data()),
-                                             reinterpret_cast<const char8_t*>(relative.Data() + relative.ByteLen()) };
-        return Path{ root_path / relative_path };
+        return root_path / Path(relative);
     }
 
 private:
-    std::filesystem::path root_path;
+    Path root_path;
 };
 }  // namespace
 
@@ -78,7 +76,7 @@ TEST_F(FileSystemPathTest, CanonicalNormalizesExistingPath)
 
     // 정규화 테스트 (. 과 .. 포함)
     Path with_dots = temp_dir / "subdir/../canonical_test.txt";
-    FileSystem::CreateDirectory(temp_dir / "subdir");
+    FileSystem::CreateDirectories(temp_dir / "subdir");
 
     Optional<Path> canonical = FileSystem::Canonical(with_dots);
     ASSERT_TRUE(canonical.HasValue());
@@ -96,25 +94,25 @@ protected:
     TempDir temp_dir{ "DirOps" };
 };
 
-TEST_F(FileSystemDirTest, CreateDirectorySucceeds)
+TEST_F(FileSystemDirTest, CreateDirectoriesSucceeds)
 {
     Path new_dir = temp_dir / "new_directory";
     EXPECT_FALSE(new_dir.Exists());
 
-    bool result = FileSystem::CreateDirectory(new_dir);
+    bool result = FileSystem::CreateDirectories(new_dir);
 
     EXPECT_TRUE(result);
     EXPECT_TRUE(new_dir.Exists());
     EXPECT_TRUE(new_dir.IsDirectory());
 }
 
-TEST_F(FileSystemDirTest, CreateDirectoryReturnsTrueIfAlreadyExists)
+TEST_F(FileSystemDirTest, CreateDirectoriesReturnsTrueIfAlreadyExists)
 {
     Path existing_dir = temp_dir / "existing_directory";
-    FileSystem::CreateDirectory(existing_dir);
+    FileSystem::CreateDirectories(existing_dir);
     ASSERT_TRUE(existing_dir.Exists());
 
-    bool result = FileSystem::CreateDirectory(existing_dir);
+    bool result = FileSystem::CreateDirectories(existing_dir);
     EXPECT_TRUE(result);
 }
 
@@ -344,8 +342,8 @@ protected:
     void SetUp() override
     {
         // 테스트용 파일/디렉토리 구조 생성
-        FileSystem::CreateDirectory(temp_dir / "subdir1");
-        FileSystem::CreateDirectory(temp_dir / "subdir2");
+        FileSystem::CreateDirectories(temp_dir / "subdir1");
+        FileSystem::CreateDirectories(temp_dir / "subdir2");
         FileSystem::WriteString(temp_dir / "file1.txt", "1");
         FileSystem::WriteString(temp_dir / "file2.txt", "2");
         FileSystem::WriteString(temp_dir / "subdir1/nested.txt", "nested");
@@ -410,7 +408,7 @@ TEST_F(FileSystemIteratorTest, DirectoryEntryFileSizeReturnsCorrectSize)
 TEST_F(FileSystemIteratorTest, ReadDirOnEmptyDirectoryProducesNoEntries)
 {
     Path empty_dir = temp_dir / "empty_dir";
-    FileSystem::CreateDirectory(empty_dir);
+    FileSystem::CreateDirectories(empty_dir);
 
     int count = 0;
     for ([[maybe_unused]] const auto& entry : FileSystem::ReadDir(empty_dir))
@@ -474,11 +472,11 @@ TEST_F(FileSystemUtf8Test, WriteAndReadFileWithKoreanPath)
     EXPECT_EQ(StringView(read_result->CStr(), read_result->ByteLen()), content);
 }
 
-TEST_F(FileSystemUtf8Test, CreateDirectoryWithUnicodeName)
+TEST_F(FileSystemUtf8Test, CreateDirectoriesWithUnicodeName)
 {
     Path unicode_dir = temp_dir / "日本語フォルダ";
 
-    bool result = FileSystem::CreateDirectory(unicode_dir);
+    bool result = FileSystem::CreateDirectories(unicode_dir);
 
     EXPECT_TRUE(result);
     EXPECT_TRUE(unicode_dir.Exists());
@@ -497,4 +495,352 @@ TEST_F(FileSystemUtf8Test, ReadDirWithUnicodeNames)
     }
 
     EXPECT_EQ(count, 3);
+}
+
+TEST_F(FileSystemUtf8Test, CopyFileWithUnicodeName)
+{
+    Path src = temp_dir / "원본파일.txt";
+    Path dst = temp_dir / "복사본ファイル.txt";
+    FileSystem::WriteString(src, "UTF-8 내용");
+
+    EXPECT_TRUE(FileSystem::Copy(src, dst));
+    EXPECT_TRUE(dst.Exists());
+
+    auto content = FileSystem::ReadToString(dst);
+    ASSERT_TRUE(content.HasValue());
+    EXPECT_EQ(StringView(content->CStr(), content->ByteLen()), "UTF-8 내용");
+}
+
+TEST_F(FileSystemUtf8Test, RenameFileWithUnicodeName)
+{
+    Path old_path = temp_dir / "이전이름.txt";
+    Path new_path = temp_dir / "새이름_新名前.txt";
+    FileSystem::WriteString(old_path, "rename test");
+
+    EXPECT_TRUE(FileSystem::Rename(old_path, new_path));
+    EXPECT_FALSE(old_path.Exists());
+    EXPECT_TRUE(new_path.Exists());
+}
+
+TEST_F(FileSystemUtf8Test, SpacesInPath)
+{
+    Path file = temp_dir / "path with spaces/sub dir/file name.txt";
+    FileSystem::CreateDirectories(temp_dir / "path with spaces/sub dir");
+    FileSystem::WriteString(file, "spaces content");
+
+    EXPECT_TRUE(file.Exists());
+    auto content = FileSystem::ReadToString(file);
+    ASSERT_TRUE(content.HasValue());
+    EXPECT_EQ(StringView(content->CStr(), content->ByteLen()), "spaces content");
+}
+
+TEST_F(FileSystemUtf8Test, SpecialCharactersInFilename)
+{
+    // 괄호, 하이픈, 플러스 등 특수문자
+    Path file = temp_dir / "file (1) - copy [backup]+test.txt";
+    FileSystem::WriteString(file, "special chars");
+
+    EXPECT_TRUE(file.Exists());
+    EXPECT_EQ(FileSystem::ReadToString(file).Value(),
+        String("special chars"));
+}
+
+
+// =============================================================================
+// ReadChunked 엣지 케이스 (Chunked Reading Edge Cases)
+// =============================================================================
+
+class FileSystemChunkedTest : public ::testing::Test
+{
+protected:
+    TempDir temp_dir{ "Chunked" };
+};
+
+TEST_F(FileSystemChunkedTest, ReadChunkedEmptyFile)
+{
+    Path file = temp_dir / "empty.bin";
+    FileSystem::WriteString(file, "");
+
+    int chunk_count = 0;
+    for (auto&& chunk_result : FileSystem::ReadChunked(file, 1024))
+    {
+        ASSERT_TRUE(chunk_result.HasValue());
+        ++chunk_count;
+    }
+
+    // 빈 파일은 0바이트 읽기 → 루프 진입하지 않음
+    EXPECT_EQ(chunk_count, 0);
+}
+
+TEST_F(FileSystemChunkedTest, ReadChunkedSmallerThanChunkSize)
+{
+    Path file = temp_dir / "small.bin";
+    FileSystem::WriteString(file, "Hello");
+
+    int chunk_count = 0;
+    usize total_bytes = 0;
+    for (auto&& chunk_result : FileSystem::ReadChunked(file, 1024))
+    {
+        ASSERT_TRUE(chunk_result.HasValue());
+        total_bytes += chunk_result->Len();
+        ++chunk_count;
+    }
+
+    EXPECT_EQ(chunk_count, 1);
+    EXPECT_EQ(total_bytes, 5u);
+}
+
+TEST_F(FileSystemChunkedTest, ReadChunkedExactMultiple)
+{
+    // chunk_size의 정확한 배수 크기 파일
+    const usize chunk_size = 4;
+    String content("ABCDABCD"); // 8바이트 = 4 * 2
+    Path file = temp_dir / "exact.bin";
+    FileSystem::WriteString(file, content);
+
+    int chunk_count = 0;
+    usize total_bytes = 0;
+    for (auto&& chunk_result : FileSystem::ReadChunked(file, chunk_size))
+    {
+        ASSERT_TRUE(chunk_result.HasValue());
+        total_bytes += chunk_result->Len();
+        ++chunk_count;
+    }
+
+    EXPECT_EQ(total_bytes, 8u);
+    // chunk_size 정확히 배수이므로 마지막에 0바이트 read 후 종료
+    // chunk_count는 2 또는 3 (구현에 따라 마지막 0-byte read 포함 여부)
+    EXPECT_GE(chunk_count, 2);
+}
+
+TEST_F(FileSystemChunkedTest, ReadChunkedNonExistentFile)
+{
+    Path non_existent = temp_dir / "no_such_file.bin";
+
+    for (auto&& chunk_result : FileSystem::ReadChunked(non_existent, 1024))
+    {
+        // 첫 yield가 에러여야 함
+        EXPECT_FALSE(chunk_result.HasValue());
+        break;
+    }
+}
+
+
+// =============================================================================
+// Rename 엣지 케이스 (Rename Edge Cases)
+// =============================================================================
+
+class FileSystemRenameTest : public ::testing::Test
+{
+protected:
+    TempDir temp_dir{ "Rename" };
+};
+
+TEST_F(FileSystemRenameTest, RenameOverwritesExistingFile)
+{
+    Path src = temp_dir / "source.txt";
+    Path dst = temp_dir / "destination.txt";
+    FileSystem::WriteString(src, "new content");
+    FileSystem::WriteString(dst, "old content");
+
+    bool result = FileSystem::Rename(src, dst);
+    EXPECT_TRUE(result);
+    EXPECT_FALSE(src.Exists());
+    EXPECT_EQ(FileSystem::ReadToString(dst).Value(), String("new content"));
+}
+
+TEST_F(FileSystemRenameTest, RenameToNonExistentTarget)
+{
+    Path src = temp_dir / "exists.txt";
+    Path dst = temp_dir / "new_name.txt";
+    FileSystem::WriteString(src, "content");
+
+    EXPECT_TRUE(FileSystem::Rename(src, dst));
+    EXPECT_TRUE(dst.Exists());
+}
+
+TEST_F(FileSystemRenameTest, RenameEmptyPaths)
+{
+    EXPECT_FALSE(FileSystem::Rename(Path{}, Path{"target"}));
+    EXPECT_FALSE(FileSystem::Rename(Path{"source"}, Path{}));
+    EXPECT_FALSE(FileSystem::Rename(Path{}, Path{}));
+}
+
+
+// =============================================================================
+// Copy 엣지 케이스 (Copy Edge Cases)
+// =============================================================================
+
+class FileSystemCopyTest : public ::testing::Test
+{
+protected:
+    TempDir temp_dir{ "Copy" };
+};
+
+TEST_F(FileSystemCopyTest, CopyDirectoryOnlyCreatesTarget)
+{
+    // ARCH-2: 디렉토리 Copy는 대상 디렉토리만 생성하고 내용물은 복사하지 않음
+    Path src_dir = temp_dir / "src_dir";
+    FileSystem::CreateDirectories(src_dir);
+    FileSystem::WriteString(src_dir / "inside.txt", "data");
+
+    Path dst_dir = temp_dir / "dst_dir";
+    EXPECT_TRUE(FileSystem::Copy(src_dir, dst_dir));
+    EXPECT_TRUE(dst_dir.IsDirectory());
+
+    // 내용물은 복사되지 않음 (현재 구현 동작 문서화)
+    EXPECT_FALSE((dst_dir / "inside.txt").Exists());
+}
+
+TEST_F(FileSystemCopyTest, CopyNonExistentFile)
+{
+    Path src = temp_dir / "non_existent.txt";
+    Path dst = temp_dir / "destination.txt";
+    EXPECT_FALSE(FileSystem::Copy(src, dst));
+}
+
+TEST_F(FileSystemCopyTest, CopyEmptyPaths)
+{
+    Path valid = temp_dir / "some_file.txt";
+    EXPECT_FALSE(FileSystem::Copy(Path{}, valid));
+    EXPECT_FALSE(FileSystem::Copy(valid, Path{}));
+}
+
+
+// =============================================================================
+// RemoveAll 엣지 케이스
+// =============================================================================
+
+class FileSystemRemoveAllTest : public ::testing::Test
+{
+protected:
+    TempDir temp_dir{ "RemoveAll" };
+};
+
+TEST_F(FileSystemRemoveAllTest, RemoveAllSingleFile)
+{
+    Path file = temp_dir / "single.txt";
+    FileSystem::WriteString(file, "data");
+
+    usize count = FileSystem::RemoveAll(file);
+    EXPECT_EQ(count, 1u);
+    EXPECT_FALSE(file.Exists());
+}
+
+TEST_F(FileSystemRemoveAllTest, RemoveAllDeeplyNested)
+{
+    // 5단계 중첩 디렉토리
+    Path deep = temp_dir / "a/b/c/d/e";
+    FileSystem::CreateDirectories(deep);
+    FileSystem::WriteString(deep / "leaf.txt", "data");
+
+    usize count = FileSystem::RemoveAll(temp_dir / "a");
+    EXPECT_GT(count, 1u);
+    EXPECT_FALSE((temp_dir / "a").Exists());
+}
+
+TEST_F(FileSystemRemoveAllTest, RemoveAllEmptyDirectory)
+{
+    Path empty_dir = temp_dir / "empty";
+    FileSystem::CreateDirectories(empty_dir);
+
+    usize count = FileSystem::RemoveAll(empty_dir);
+    EXPECT_EQ(count, 1u);
+    EXPECT_FALSE(empty_dir.Exists());
+}
+
+TEST_F(FileSystemRemoveAllTest, RemoveAllNonExistentReturnsZero)
+{
+    usize count = FileSystem::RemoveAll(temp_dir / "ghost");
+    EXPECT_EQ(count, 0u);
+}
+
+TEST_F(FileSystemRemoveAllTest, RemoveAllEmptyPathReturnsZero)
+{
+    usize count = FileSystem::RemoveAll(Path{});
+    EXPECT_EQ(count, 0u);
+}
+
+
+// =============================================================================
+// FileInfo 엣지 케이스
+// =============================================================================
+
+TEST_F(FileSystemFileTest, FileSizeOfEmptyFile)
+{
+    Path file = temp_dir / "zero.bin";
+    FileSystem::WriteString(file, "");
+
+    auto size = FileSystem::FileSize(file);
+    ASSERT_TRUE(size.HasValue());
+    EXPECT_EQ(*size, 0u);
+}
+
+TEST_F(FileSystemFileTest, LastWriteTimeReturnedForExistingFile)
+{
+    Path file = temp_dir / "timed.txt";
+    FileSystem::WriteString(file, "hello");
+
+    auto mtime = FileSystem::LastWriteTime(file);
+    ASSERT_TRUE(mtime.HasValue());
+    // Unix epoch 이후 시간이어야 함 (0보다 큰 값)
+    EXPECT_GT(*mtime, 0u);
+}
+
+TEST_F(FileSystemFileTest, LastWriteTimeNulloptForNonExistent)
+{
+    auto mtime = FileSystem::LastWriteTime(temp_dir / "ghost.txt");
+    EXPECT_FALSE(mtime.HasValue());
+}
+
+TEST_F(FileSystemFileTest, FileSizeEmptyPath)
+{
+    auto size = FileSystem::FileSize(Path{});
+    EXPECT_FALSE(size.HasValue());
+}
+
+
+// =============================================================================
+// WriteString 엣지 케이스
+// =============================================================================
+
+TEST_F(FileSystemReadWriteTest, WriteEmptyPathReturnsFalse)
+{
+    EXPECT_FALSE(FileSystem::WriteString(Path{}, "content"));
+}
+
+TEST_F(FileSystemReadWriteTest, WriteBinaryEmptyPathReturnsFalse)
+{
+    Array<uint8> data;
+    data.Push(0x42);
+    EXPECT_FALSE(FileSystem::Write(Path{}, data));
+}
+
+TEST_F(FileSystemReadWriteTest, ReadWriteLargeFile)
+{
+    // 1MB 파일 읽기/쓰기
+    Path file = temp_dir / "large.bin";
+    Array<uint8> data;
+    const usize size = 1024 * 1024;
+    data.ResizeUninitialized(size);
+    for (usize i = 0; i < size; ++i)
+    {
+        data[i] = static_cast<uint8>(i & 0xFF);
+    }
+
+    ASSERT_TRUE(FileSystem::Write(file, data));
+
+    auto read_result = FileSystem::ReadBytes(file);
+    ASSERT_TRUE(read_result.HasValue());
+    EXPECT_EQ(read_result->Len(), size);
+
+    // 첫 1KB와 마지막 1KB 검증
+    for (usize i = 0; i < 1024; ++i)
+    {
+        EXPECT_EQ((*read_result)[i], static_cast<uint8>(i & 0xFF));
+    }
+    for (usize i = size - 1024; i < size; ++i)
+    {
+        EXPECT_EQ((*read_result)[i], static_cast<uint8>(i & 0xFF));
+    }
 }

--- a/EngineTest/Source/UnitTests/PathTest.cpp
+++ b/EngineTest/Source/UnitTests/PathTest.cpp
@@ -3,6 +3,11 @@
 
 using namespace se;
 
+
+// =============================================================================
+// 기본 기능 테스트 (Basic Functionality)
+// =============================================================================
+
 TEST(PathTest, Constructors)
 {
     Path p1;
@@ -14,6 +19,13 @@ TEST(PathTest, Constructors)
     String s = "Engine/Source/Main.cpp";
     Path p3(s);
     EXPECT_EQ(p3.ToString(), s);
+}
+
+TEST(PathTest, ConstructorNullptr)
+{
+    const char* null_ptr = nullptr;
+    Path p(null_ptr);
+    EXPECT_TRUE(p.IsEmpty());
 }
 
 TEST(PathTest, Modifiers)
@@ -32,8 +44,7 @@ TEST(PathTest, Modifiers)
     p += ".tmp";
     EXPECT_EQ(p.ToString(), "Engine/Source/Core.cpp.tmp");
 
-    Path p2("A/./B/../C");
-    p2.Normalize();
+    Path p2("A/./B/../C"); // 생성자에서 정규화 됨
     EXPECT_EQ(p2.ToString(), "A/C");
 
     Path p3("dir/old.txt");
@@ -59,7 +70,7 @@ TEST(PathTest, Producers)
     EXPECT_EQ(p1.WithExtension(".log").ToString(), "dir/file.log");
 
     Path p2("A/./B/../C");
-    EXPECT_EQ(p2.GetNormalized().ToString(), "A/C");
+    EXPECT_EQ(p2.ToString(), "A/C");
 
     Path p3("/A/B/C");
     auto rel = p3.RelativeTo(Path("/A"));
@@ -132,4 +143,604 @@ TEST(PathTest, Equality)
     EXPECT_FALSE(p == "A/C");
 
     EXPECT_EQ(p <=> Path("A/A"), std::strong_ordering::greater);
+}
+
+
+// =============================================================================
+// 경로 정규화 엣지 케이스 (Normalization Edge Cases)
+// =============================================================================
+
+TEST(PathNormalizationTest, BackslashConversion)
+{
+    // 백슬래시를 포워드 슬래시로 변환
+    Path p("A\\B\\C\\file.txt");
+    EXPECT_EQ(p.ToString(), "A/B/C/file.txt");
+
+    // 혼용된 구분자
+    Path p2("A/B\\C/D\\file.txt");
+    EXPECT_EQ(p2.ToString(), "A/B/C/D/file.txt");
+}
+
+TEST(PathNormalizationTest, MultipleConsecutiveSlashes)
+{
+    // 이중 슬래시 (비-UNC)
+    Path p("A//B///C////file.txt");
+    EXPECT_EQ(p.ToString(), "A/B/C/file.txt");
+
+    // 중간의 이중 슬래시
+    Path p2("dir//file.txt");
+    EXPECT_EQ(p2.ToString(), "dir/file.txt");
+}
+
+TEST(PathNormalizationTest, TrailingSlashRemoval)
+{
+    Path p("dir/subdir/");
+    EXPECT_EQ(p.ToString(), "dir/subdir");
+
+    Path p2("dir/subdir///");
+    EXPECT_EQ(p2.ToString(), "dir/subdir");
+}
+
+TEST(PathNormalizationTest, DotSegments)
+{
+    // 현재 디렉토리 "." 제거
+    Path p1("A/./B/./C");
+    EXPECT_EQ(p1.ToString(), "A/B/C");
+
+    // 단독 "."은 "."으로 유지되어야 함 (상대 경로의 현재 디렉토리)
+    Path p2(".");
+    EXPECT_EQ(p2.ToString(), ".");
+
+    // "./"으로 시작하는 경로
+    Path p3("./A/B");
+    EXPECT_EQ(p3.ToString(), "A/B");
+}
+
+TEST(PathNormalizationTest, DotDotSegments)
+{
+    // 기본 ".." 해소
+    Path p1("A/B/../C");
+    EXPECT_EQ(p1.ToString(), "A/C");
+
+    // 연속 ".."
+    Path p2("A/B/C/../../D");
+    EXPECT_EQ(p2.ToString(), "A/D");
+
+    // 모든 세그먼트를 소진하는 ".." (상대 경로)
+    Path p3("A/B/../../C");
+    EXPECT_EQ(p3.ToString(), "C");
+
+    // 루트 위로 탈출 시도 (절대 경로에서 무시됨)
+    Path p4("/A/../../../B");
+    EXPECT_EQ(p4.ToString(), "/B");
+
+    // 상대 경로에서 루트 위로의 ".."는 보존
+    Path p5("A/../../B");
+    EXPECT_EQ(p5.ToString(), "../B");
+
+    // 상대 경로에서 연속 ".." 보존
+    Path p6("../../A/B");
+    EXPECT_EQ(p6.ToString(), "../../A/B");
+}
+
+TEST(PathNormalizationTest, ComplexDotDotChain)
+{
+    // ".." 뒤에 ".."이 있어 이전 ".."을 pop하지 않는지 확인
+    Path p("../A/../..");
+    EXPECT_EQ(p.ToString(), "../..");
+
+    // 정규화가 모든 세그먼트를 제거하면 "."
+    Path p2("A/..");
+    EXPECT_EQ(p2.ToString(), ".");
+
+    Path p3("A/B/../..");
+    EXPECT_EQ(p3.ToString(), ".");
+}
+
+TEST(PathNormalizationTest, OnlyDotsInFilename)
+{
+    // "..." (3개 점)은 일반 파일명으로 취급
+    Path p("dir/.../file");
+    EXPECT_EQ(p.ToString(), "dir/.../file");
+}
+
+TEST(PathNormalizationTest, EmptyInput)
+{
+    Path p1("");
+    EXPECT_TRUE(p1.IsEmpty());
+
+    Path p2(String{});
+    EXPECT_TRUE(p2.IsEmpty());
+
+    Path p3(StringView{});
+    EXPECT_TRUE(p3.IsEmpty());
+}
+
+
+// =============================================================================
+// Windows 드라이브 경로 (Windows Drive Paths)
+// =============================================================================
+
+TEST(PathWindowsTest, DriveAbsolutePath)
+{
+    Path p("C:/Users/Game/file.txt");
+    EXPECT_TRUE(p.IsAbsolute());
+    EXPECT_EQ(p.ToString(), "C:/Users/Game/file.txt");
+}
+
+TEST(PathWindowsTest, DriveRelativePath)
+{
+    // "C:foo"는 드라이브-상대 경로 (드라이브 C의 현재 디렉토리 기준)
+    // IsAbsolute()는 false여야 함 (C:/ 형태가 아님)
+    Path p("C:foo");
+    EXPECT_FALSE(p.IsAbsolute());
+    EXPECT_TRUE(p.IsRelative());
+}
+
+TEST(PathWindowsTest, DriveWithBackslash)
+{
+    Path p("C:\\Users\\Game\\file.txt");
+    EXPECT_TRUE(p.IsAbsolute());
+    EXPECT_EQ(p.ToString(), "C:/Users/Game/file.txt");
+}
+
+TEST(PathWindowsTest, DriveRootParent)
+{
+    Path p("C:/file.txt");
+    auto parent = p.Parent();
+    ASSERT_TRUE(parent.HasValue());
+    EXPECT_EQ(parent->ToString(), "C:/");
+
+    // 드라이브 루트 자체의 Parent는 NullOpt
+    EXPECT_FALSE(parent->Parent().HasValue());
+}
+
+TEST(PathWindowsTest, DriveRootComponents)
+{
+    Path root("C:/");
+    EXPECT_TRUE(root.IsAbsolute());
+    EXPECT_FALSE(root.Parent().HasValue());
+    EXPECT_FALSE(root.FileName().HasValue());
+    EXPECT_FALSE(root.Extension().HasValue());
+}
+
+TEST(PathWindowsTest, DotDotBeyondDriveRoot)
+{
+    // C:/ 위로 ".." 시도 시 무시됨
+    Path p("C:/A/../../B");
+    EXPECT_EQ(p.ToString(), "C:/B");
+}
+
+TEST(PathWindowsTest, DifferentDriveLetterRelativeTo)
+{
+    // 다른 드라이브 간 RelativeTo는 NullOpt
+    Path p1("C:/A/B");
+    Path p2("D:/A/B");
+    EXPECT_FALSE(p1.RelativeTo(p2).HasValue());
+}
+
+TEST(PathWindowsTest, CaseSensitiveComparison)
+{
+    // 의도적으로 case-sensitive: 크로스 플랫폼 예측 가능성
+    Path p1("C:/Users/Game");
+    Path p2("C:/users/game");
+    EXPECT_NE(p1, p2);
+}
+
+TEST(PathWindowsTest, LowercaseDriveLetter)
+{
+    Path p("c:/Users/file.txt");
+    EXPECT_TRUE(p.IsAbsolute());
+    EXPECT_EQ(p.ToString(), "c:/Users/file.txt");
+}
+
+
+// =============================================================================
+// UNC 경로 (UNC Paths)
+// =============================================================================
+
+TEST(PathUNCTest, BasicUNCPath)
+{
+    Path p("//server/share/dir/file.txt");
+    EXPECT_TRUE(p.IsAbsolute());
+    EXPECT_EQ(p.ToString(), "//server/share/dir/file.txt");
+}
+
+TEST(PathUNCTest, UNCWithBackslash)
+{
+    Path p("\\\\server\\share\\dir\\file.txt");
+    EXPECT_TRUE(p.IsAbsolute());
+    EXPECT_EQ(p.ToString(), "//server/share/dir/file.txt");
+}
+
+TEST(PathUNCTest, UNCParent)
+{
+    Path p("//server/share/dir/file.txt");
+    auto parent = p.Parent();
+    ASSERT_TRUE(parent.HasValue());
+    EXPECT_EQ(parent->ToString(), "//server/share/dir");
+
+    // UNC 루트까지 올라가기
+    Path p2("//server/share/file.txt");
+    auto parent2 = p2.Parent();
+    ASSERT_TRUE(parent2.HasValue());
+    EXPECT_EQ(parent2->ToString(), "//server/share");
+
+    // UNC 루트의 Parent는 NullOpt
+    EXPECT_FALSE(parent2->Parent().HasValue());
+}
+
+TEST(PathUNCTest, UNCDotDotBeyondRoot)
+{
+    // UNC 루트 위로 ".." 시도
+    Path p("//server/share/../../../escape");
+    EXPECT_EQ(p.ToString(), "//server/share/escape");
+}
+
+TEST(PathUNCTest, UNCFileName)
+{
+    Path p("//server/share");
+    // UNC 루트 자체는 파일명 없음
+    EXPECT_FALSE(p.FileName().HasValue());
+}
+
+
+// =============================================================================
+// Unix 절대 경로 (Unix Absolute Paths)
+// =============================================================================
+
+TEST(PathUnixTest, RootPath)
+{
+    Path p("/");
+    EXPECT_TRUE(p.IsAbsolute());
+    EXPECT_FALSE(p.Parent().HasValue());
+    EXPECT_FALSE(p.FileName().HasValue());
+}
+
+TEST(PathUnixTest, SingleFileInRoot)
+{
+    Path p("/file.txt");
+    EXPECT_TRUE(p.IsAbsolute());
+
+    auto parent = p.Parent();
+    ASSERT_TRUE(parent.HasValue());
+    EXPECT_EQ(parent->ToString(), "/");
+
+    auto filename = p.FileName();
+    ASSERT_TRUE(filename.HasValue());
+    EXPECT_EQ(*filename, "file.txt");
+}
+
+
+// =============================================================================
+// 숨김 파일 및 특수 확장자 (Hidden Files & Special Extensions)
+// =============================================================================
+
+TEST(PathHiddenFileTest, DotFileNoExtension)
+{
+    // ".gitignore"는 숨김파일 — 전체가 stem, 확장자 없음
+    Path p("dir/.gitignore");
+    auto stem = p.FileStem();
+    auto ext = p.Extension();
+
+    ASSERT_TRUE(stem.HasValue());
+    EXPECT_EQ(*stem, ".gitignore");
+    EXPECT_FALSE(ext.HasValue());
+}
+
+TEST(PathHiddenFileTest, DotFileWithExtension)
+{
+    // ".bashrc.bak"은 stem=".bashrc", ext=".bak"
+    Path p("dir/.bashrc.bak");
+    auto stem = p.FileStem();
+    auto ext = p.Extension();
+
+    ASSERT_TRUE(stem.HasValue());
+    EXPECT_EQ(*stem, ".bashrc");
+    ASSERT_TRUE(ext.HasValue());
+    EXPECT_EQ(*ext, ".bak");
+}
+
+TEST(PathHiddenFileTest, MultipleExtensions)
+{
+    Path p("archive.tar.gz");
+    auto ext = p.Extension();
+    auto stem = p.FileStem();
+
+    ASSERT_TRUE(ext.HasValue());
+    EXPECT_EQ(*ext, ".gz");
+    ASSERT_TRUE(stem.HasValue());
+    EXPECT_EQ(*stem, "archive.tar");
+}
+
+TEST(PathHiddenFileTest, FileNameWithOnlyDot)
+{
+    Path p("dir/.");
+    // "." 세그먼트는 정규화에서 제거됨
+    EXPECT_EQ(p.ToString(), "dir");
+}
+
+
+// =============================================================================
+// SetExtension 정규화 검증 (SetExtension Normalization)
+// =============================================================================
+
+TEST(PathSetExtensionTest, ExtensionWithPathSeparator)
+{
+    // SetExtension에 경로 구분자가 포함된 경우
+    // 현재 구현에서는 재정규화하지 않으므로 비정규화 상태가 될 수 있음
+    Path p("dir/file.txt");
+    p.SetExtension(".jpg/../../../etc/passwd");
+
+    // BUG: SetExtension은 NormalizePath를 호출하지 않아 path traversal이 가능함.
+    // 이 테스트는 현재 동작을 문서화함. 수정 후 아래 주석의 기대값으로 변경해야 함.
+    // EXPECT_EQ(p.ToString(), "dir/file.jpg/../../../etc/passwd"); // 현재 동작 (비정규화)
+    // 수정 후 기대값 예시: NormalizePath 적용 시 "../../etc/passwd" 또는 유사 결과
+}
+
+TEST(PathSetExtensionTest, RemoveExtension)
+{
+    Path p("dir/file.txt");
+    p.SetExtension("");
+
+    EXPECT_EQ(p.ToString(), "dir/file");
+    EXPECT_FALSE(p.Extension().HasValue());
+}
+
+TEST(PathSetExtensionTest, SetExtensionOnFileWithoutExtension)
+{
+    Path p("dir/README");
+    p.SetExtension(".md");
+
+    EXPECT_EQ(p.ToString(), "dir/README.md");
+}
+
+TEST(PathSetExtensionTest, SetExtensionOnHiddenFile)
+{
+    // 숨김파일(".gitignore")에는 확장자가 없으므로 새 확장자가 추가됨
+    Path p("dir/.gitignore");
+    p.SetExtension(".bak");
+
+    EXPECT_EQ(p.ToString(), "dir/.gitignore.bak");
+}
+
+
+// =============================================================================
+// RelativeTo 엣지 케이스 (RelativeTo Edge Cases)
+// =============================================================================
+
+TEST(PathRelativeToTest, AbsoluteRelativeMismatch)
+{
+    Path abs("/A/B");
+    Path rel("A/B");
+    EXPECT_FALSE(abs.RelativeTo(rel).HasValue());
+    EXPECT_FALSE(rel.RelativeTo(abs).HasValue());
+}
+
+TEST(PathRelativeToTest, SamePath)
+{
+    Path p("/A/B/C");
+    auto rel = p.RelativeTo(p);
+    ASSERT_TRUE(rel.HasValue());
+    EXPECT_EQ(rel->ToString(), ".");
+}
+
+TEST(PathRelativeToTest, ChildPath)
+{
+    Path child("/A/B/C/D");
+    Path base("/A/B");
+    auto rel = child.RelativeTo(base);
+    ASSERT_TRUE(rel.HasValue());
+    EXPECT_EQ(rel->ToString(), "C/D");
+}
+
+TEST(PathRelativeToTest, ParentPath)
+{
+    Path parent("/A");
+    Path child("/A/B/C");
+    auto rel = parent.RelativeTo(child);
+    ASSERT_TRUE(rel.HasValue());
+    EXPECT_EQ(rel->ToString(), "../..");
+}
+
+TEST(PathRelativeToTest, SiblingPath)
+{
+    Path p1("/A/B/C");
+    Path p2("/A/B/D");
+    auto rel = p1.RelativeTo(p2);
+    ASSERT_TRUE(rel.HasValue());
+    EXPECT_EQ(rel->ToString(), "../C");
+}
+
+TEST(PathRelativeToTest, NoCommonPrefix)
+{
+    Path p1("/A/B");
+    Path p2("/C/D");
+    EXPECT_FALSE(p1.RelativeTo(p2).HasValue());
+}
+
+TEST(PathRelativeToTest, RelativeToRoot)
+{
+    Path p("/A/B/C");
+    Path root("/");
+    auto rel = p.RelativeTo(root);
+    ASSERT_TRUE(rel.HasValue());
+    EXPECT_EQ(rel->ToString(), "A/B/C");
+}
+
+TEST(PathRelativeToTest, BothEmpty)
+{
+    Path p1;
+    Path p2;
+    // 빈 경로는 상대 경로로 취급, common=0 양쪽 모두 비어있음 → "."
+    auto rel = p1.RelativeTo(p2);
+    ASSERT_TRUE(rel.HasValue());
+    EXPECT_EQ(rel->ToString(), ".");
+}
+
+
+// =============================================================================
+// Append 엣지 케이스 (Append Edge Cases)
+// =============================================================================
+
+TEST(PathAppendTest, AppendAbsoluteReplacesPath)
+{
+    // std::filesystem::path 동작과 동일: RHS가 절대 경로이면 대체
+    Path p("A/B");
+    p.Append(Path("/C/D"));
+    EXPECT_EQ(p.ToString(), "/C/D");
+}
+
+TEST(PathAppendTest, AppendWindowsAbsoluteReplacesPath)
+{
+    Path p("some/relative/path");
+    p.Append(Path("C:/Absolute/Path"));
+    EXPECT_EQ(p.ToString(), "C:/Absolute/Path");
+}
+
+TEST(PathAppendTest, AppendEmpty)
+{
+    Path p("A/B");
+    p.Append(Path{});
+    EXPECT_EQ(p.ToString(), "A/B");
+}
+
+TEST(PathAppendTest, AppendToEmpty)
+{
+    Path p;
+    p.Append(Path("A/B"));
+    EXPECT_EQ(p.ToString(), "A/B");
+}
+
+TEST(PathAppendTest, AppendWithDotDot)
+{
+    Path p("A/B/C");
+    p.Append(Path("../D"));
+    EXPECT_EQ(p.ToString(), "A/B/D");
+}
+
+
+// =============================================================================
+// UTF-8 / 유니코드 경로 (Unicode Paths)
+// =============================================================================
+
+TEST(PathUnicodeTest, CJKCharacters)
+{
+    // 한국어, 일본어, 중국어 경로
+    Path korean("프로젝트/소스/메인.cpp");
+    EXPECT_EQ(korean.FileName().Value(), "메인.cpp");
+    EXPECT_EQ(korean.FileStem().Value(), "메인");
+    EXPECT_EQ(korean.Extension().Value(), ".cpp");
+
+    Path japanese("プロジェクト/ソース/メイン.cpp");
+    EXPECT_EQ(japanese.FileName().Value(), "メイン.cpp");
+
+    Path chinese("项目/源代码/主文件.cpp");
+    EXPECT_EQ(chinese.FileName().Value(), "主文件.cpp");
+}
+
+TEST(PathUnicodeTest, EmojiInPath)
+{
+    Path p("🎮/📁/🎵.mp3");
+    EXPECT_EQ(p.FileName().Value(), "🎵.mp3");
+    EXPECT_EQ(p.FileStem().Value(), "🎵");
+    EXPECT_EQ(p.Extension().Value(), ".mp3");
+}
+
+TEST(PathUnicodeTest, ArabicRTLPath)
+{
+    // 아랍어 RTL 문자 경로 (바이트 비교이므로 방향 무관)
+    Path p("العربية/ملف.txt");
+    EXPECT_EQ(p.FileName().Value(), "ملف.txt");
+}
+
+TEST(PathUnicodeTest, MixedScripts)
+{
+    // ASCII + Unicode 혼합
+    Path p("Assets/텍스처/player_スプライト.png");
+    EXPECT_EQ(p.FileName().Value(), "player_スプライト.png");
+    EXPECT_EQ(p.Extension().Value(), ".png");
+}
+
+TEST(PathUnicodeTest, SpacesInPath)
+{
+    Path p("My Documents/Game Project/Main Scene.unity");
+    EXPECT_EQ(p.FileName().Value(), "Main Scene.unity");
+    EXPECT_EQ(p.Parent().Value().ToString(), "My Documents/Game Project");
+}
+
+TEST(PathUnicodeTest, SpecialCharactersInFilename)
+{
+    // 파일명에 괄호, 하이픈, 공백
+    Path p("dir/player sprite (1) - copy.png");
+    EXPECT_EQ(p.FileStem().Value(), "player sprite (1) - copy");
+    EXPECT_EQ(p.Extension().Value(), ".png");
+}
+
+
+// =============================================================================
+// IsSubPathOf 엣지 케이스 (Containment Check Edge Cases)
+// =============================================================================
+
+TEST(PathSubPathTest, SamePathIsSubPath)
+{
+    Path p("/A/B");
+    EXPECT_TRUE(p.IsSubPathOf(p));
+}
+
+TEST(PathSubPathTest, DotDotEscapeNotSubPath)
+{
+    // IsSubPathOf는 ".."로 시작하는 상대 경로를 거부해야 함
+    Path p("/A");
+    Path base("/A/B");
+    EXPECT_FALSE(p.IsSubPathOf(base));
+}
+
+TEST(PathSubPathTest, PrefixMatchDoesNotFalsePositive)
+{
+    // "/A/BC"는 "/A/B"의 하위가 아님 (세그먼트 경계 체크)
+    Path p("/A/BC/file.txt");
+    Path base("/A/B");
+    EXPECT_FALSE(p.IsSubPathOf(base));
+}
+
+
+// =============================================================================
+// Swap 및 이동 의미론 (Swap & Move Semantics)
+// =============================================================================
+
+TEST(PathMoveTest, MoveConstruction)
+{
+    Path original("A/B/C");
+    Path moved(std::move(original));
+    EXPECT_EQ(moved.ToString(), "A/B/C");
+}
+
+TEST(PathMoveTest, SwapPaths)
+{
+    Path a("X/Y");
+    Path b("A/B");
+    swap(a, b);
+    EXPECT_EQ(a.ToString(), "A/B");
+    EXPECT_EQ(b.ToString(), "X/Y");
+}
+
+
+// =============================================================================
+// Hash 및 Formatter (Hash & Formatting)
+// =============================================================================
+
+TEST(PathHashTest, EqualPathsHaveSameHash)
+{
+    Path p1("A/B/C");
+    Path p2("A/B/C");
+    EXPECT_EQ(std::hash<Path>{}(p1), std::hash<Path>{}(p2));
+}
+
+TEST(PathHashTest, NormalizedPathsHaveSameHash)
+{
+    Path p1("A/B/C");
+    Path p2("A/./B/../B/C");
+    EXPECT_EQ(p1, p2);
+    EXPECT_EQ(std::hash<Path>{}(p1), std::hash<Path>{}(p2));
 }

--- a/EngineTest/Source/UnitTests/PathTest.cpp
+++ b/EngineTest/Source/UnitTests/PathTest.cpp
@@ -467,15 +467,11 @@ TEST(PathHiddenFileTest, FileNameWithOnlyDot)
 
 TEST(PathSetExtensionTest, ExtensionWithPathSeparator)
 {
-    // SetExtension에 경로 구분자가 포함된 경우
-    // 현재 구현에서는 재정규화하지 않으므로 비정규화 상태가 될 수 있음
+    // "dir/file.jpg/../../../etc/passwd" → 정규화 → "../etc/passwd"
+    // (dir, file.jpg 2개 소진 후 ".." 1개 잔여 → "../etc/passwd")
     Path p("dir/file.txt");
     p.SetExtension(".jpg/../../../etc/passwd");
-
-    // BUG: SetExtension은 NormalizePath를 호출하지 않아 path traversal이 가능함.
-    // 이 테스트는 현재 동작을 문서화함. 수정 후 아래 주석의 기대값으로 변경해야 함.
-    // EXPECT_EQ(p.ToString(), "dir/file.jpg/../../../etc/passwd"); // 현재 동작 (비정규화)
-    // 수정 후 기대값 예시: NormalizePath 적용 시 "../../etc/passwd" 또는 유사 결과
+    EXPECT_EQ(p.ToString(), "../etc/passwd");
 }
 
 TEST(PathSetExtensionTest, RemoveExtension)

--- a/EngineTest/Source/UnitTests/VFSTest.cpp
+++ b/EngineTest/Source/UnitTests/VFSTest.cpp
@@ -248,34 +248,24 @@ protected:
 
 TEST_F(VFSPathTraversalTest, DotDotDoesNotEscapeMountPoint)
 {
-    // RISK-3: "../../../" 패턴으로 마운트 포인트 탈출 시도
-    // Path::operator/가 ".."을 해소하므로 결과가 마운트 포인트 내부로 한정됨
-    // 하지만 해소 결과가 실제로 마운트 포인트 내부인지 확인하는 containment check는 없음
+    // "../../../" 패턴으로 마운트 포인트 탈출 시도
+    // containment check가 이를 차단하여 NullOpt을 반환해야 함
     VPath traversal_path("Sandbox://../../secret.txt");
-
-    // Resolve는 실제 파일이 존재하는지 확인하므로 여기서는 파일이 없으면 NullOpt
     Optional<Path> resolved = VFS::Resolve(traversal_path);
 
-    if (resolved.HasValue())
-    {
-        // resolve가 성공했다면, 결과가 마운트 포인트 내부인지 확인
-        EXPECT_TRUE(resolved->IsSubPathOf(mount_dir.temp_path))
-            << "Path traversal escaped mount point! Resolved to: " << resolved->ToString().CStr();
-    }
+    // 마운트 포인트 외부 경로이므로 resolve 자체가 실패해야 함
+    EXPECT_FALSE(resolved.HasValue());
 }
 
 TEST_F(VFSPathTraversalTest, ToPathWithDotDot)
 {
-    // ToPath는 존재 여부를 확인하지 않으므로 항상 경로를 반환
+    // ToPath도 containment check에 의해 탈출 경로를 거부해야 함
     VPath traversal_path("Sandbox://../../escape");
     Path result = VFS::ToPath(traversal_path);
 
-    if (!result.IsEmpty())
-    {
-        // 결과 경로가 마운트 포인트를 벗어나지 않아야 함
-        EXPECT_TRUE(result.IsSubPathOf(mount_dir.temp_path))
-            << "ToPath escaped mount point! Result: " << result.ToString().CStr();
-    }
+    // 모든 마운트 포인트에서 containment 위반 → 빈 Path 반환
+    EXPECT_TRUE(result.IsEmpty())
+        << "ToPath should return empty for path traversal! Got: " << result.ToString().CStr();
 }
 
 

--- a/EngineTest/Source/UnitTests/VFSTest.cpp
+++ b/EngineTest/Source/UnitTests/VFSTest.cpp
@@ -21,6 +21,8 @@ struct TempDirManager
     TempDirManager(StringView base_name)
     {
         char* pref = SDL_GetPrefPath("SimpleEngine", "Tests");
+        SE_ASSERT(pref != nullptr, "Failed to get SDL_GetPrefPath");
+
         temp_path = Path(pref) / Path(base_name);
         SDL_free(pref);
         FileSystem::CreateDirectories(temp_path);
@@ -257,17 +259,29 @@ TEST_F(VFSPathTraversalTest, DotDotDoesNotEscapeMountPoint)
     EXPECT_FALSE(resolved.HasValue());
 }
 
+TEST_F(VFSPathTraversalTest, ResolveDoesNotEscapeMount)
+{
+    // Sandbox://../TraversalParent/secret.txt
+    // → pref/Tests/TraversalMount/../TraversalParent/secret.txt
+    // → pref/Tests/TraversalParent/secret.txt ← 실제로 존재하는 파일
+    // containment check가 없다면 Resolve가 성공해버리므로 진짜 보안 검사가 됨
+    VPath traversal("Sandbox://../TraversalParent/secret.txt");
+    Optional<Path> result = VFS::Resolve(traversal);
+
+    EXPECT_FALSE(result.HasValue())
+        << "Resolve should reject path traversal! Got: " << result->ToString().CStr();
+}
+
 TEST_F(VFSPathTraversalTest, ToPathWithDotDot)
 {
     // ToPath도 containment check에 의해 탈출 경로를 거부해야 함
-    VPath traversal_path("Sandbox://../../escape");
-    Path result = VFS::ToPath(traversal_path);
+    VPath traversal("Sandbox://../TraversalParent/secret.txt");
+    Path result = VFS::ToPath(traversal);
 
     // 모든 마운트 포인트에서 containment 위반 → 빈 Path 반환
     EXPECT_TRUE(result.IsEmpty())
         << "ToPath should return empty for path traversal! Got: " << result.ToString().CStr();
 }
-
 
 // =============================================================================
 // VFS 마운트 엣지 케이스 (Mount Edge Cases)

--- a/EngineTest/Source/UnitTests/VFSTest.cpp
+++ b/EngineTest/Source/UnitTests/VFSTest.cpp
@@ -1,14 +1,13 @@
 #include "gtest/gtest.h"
 
-#include <filesystem>
-#include <fstream>
-
 #include "SimpleEngine/Core/Container/HashSet.h"
 #include "SimpleEngine/Core/Container/Optional.h"
 #include "SimpleEngine/Core/Container/StringView.h"
-#include "SimpleEngine/Core/Types/StringName.h"
-#include "SimpleEngine/Core/Types/VPath.h"
+#include "SimpleEngine/Core/FileSystem/FileSystem.h"
 #include "SimpleEngine/Core/FileSystem/VFS.h"
+#include "SimpleEngine/Core/Types/VPath.h"
+
+#include "SDL3/SDL_filesystem.h"
 
 using namespace se;
 
@@ -17,27 +16,29 @@ namespace
 {
 struct TempDirManager
 {
-    std::filesystem::path temp_path;
+    Path temp_path;
 
-    TempDirManager(const std::filesystem::path& base_name)
+    TempDirManager(StringView base_name)
     {
-        temp_path = std::filesystem::temp_directory_path() / "SimpleEngineTest" / base_name;
-        std::filesystem::create_directories(temp_path);
+        char* pref = SDL_GetPrefPath("SimpleEngine", "Tests");
+        temp_path = Path(pref) / Path(base_name);
+        SDL_free(pref);
+        FileSystem::CreateDirectories(temp_path);
     }
 
     ~TempDirManager()
     {
-        std::error_code ec;
-        std::filesystem::remove_all(temp_path, ec);
-        // Ignore errors, as cleanup might fail on some platforms
+        FileSystem::RemoveAll(temp_path);
     }
 
-    void CreateDummyFile(const std::filesystem::path& relative_path) const
+    void CreateDummyFile(StringView relative_path) const
     {
-        const auto full_path = temp_path / relative_path;
-        std::filesystem::create_directories(full_path.parent_path());
-        std::ofstream ofs(full_path);
-        ofs << "dummy content";
+        const Path full_path = temp_path / Path(relative_path);
+        if (const auto parent = full_path.Parent())
+        {
+            FileSystem::CreateDirectories(*parent);
+        }
+        FileSystem::WriteString(full_path, "dummy content");
     }
 };
 
@@ -52,7 +53,7 @@ struct VFSGuard
     {
     }
 
-    void Mount(StringView scheme, const std::filesystem::path& physical_path, int32_t priority = 0)
+    void Mount(StringView scheme, const Path& physical_path, int32_t priority = 0)
     {
         vfs.Mount(scheme, physical_path, priority);
         mounted_schemes.Insert(String(scheme));
@@ -102,7 +103,7 @@ TEST_F(VFSTest, ResolveSucceedsIfFileExists)
 
     ASSERT_TRUE(resolved_path.HasValue());
 
-    Path expected_path = std::filesystem::absolute(assets_dir.temp_path / "textures/player.png");
+    Path expected_path = FileSystem::Absolute(assets_dir.temp_path / Path("textures/player.png"));
     EXPECT_EQ(resolved_path, expected_path);
 }
 
@@ -124,7 +125,7 @@ TEST_F(VFSTest, ResolveFailsForPathWithNoScheme)
 
 TEST_F(VFSTest, UnresolveSucceedsForPathWithinMountPoint)
 {
-    Path physical_path = assets_dir.temp_path / "scripts/main.lua";
+    Path physical_path = assets_dir.temp_path / Path("scripts/main.lua");
     Optional<VPath> virtual_path = VFS::Unresolve(physical_path);
 
     ASSERT_TRUE(virtual_path.HasValue());
@@ -133,7 +134,9 @@ TEST_F(VFSTest, UnresolveSucceedsForPathWithinMountPoint)
 
 TEST_F(VFSTest, UnresolveFailsForPathOutsideMountPoint)
 {
-    Path physical_path = std::filesystem::temp_directory_path() / "unrelated_file.txt";
+    char* pref = SDL_GetPrefPath("SimpleEngine", "Tests");
+    Path physical_path = Path(pref) / Path("unrelated_file.txt");
+    SDL_free(pref);
     Optional<VPath> virtual_path = VFS::Unresolve(physical_path);
     EXPECT_FALSE(virtual_path.HasValue());
 }
@@ -167,7 +170,7 @@ TEST_F(VFSPriorityTest, ResolveUsesHigherPriorityPathIfExists)
     Optional<Path> resolved_path = VFS::Resolve(virtual_path);
 
     ASSERT_TRUE(resolved_path.HasValue());
-    Path expected_path = std::filesystem::absolute(mod_override_dir.temp_path / "config/settings.ini");
+    Path expected_path = FileSystem::Absolute(mod_override_dir.temp_path / Path("config/settings.ini"));
     EXPECT_EQ(resolved_path.Value(), expected_path);
 }
 
@@ -178,7 +181,7 @@ TEST_F(VFSPriorityTest, ResolveFallsBackToLowerPriorityPath)
     Optional<Path> resolved_path = VFS::Resolve(virtual_path);
 
     ASSERT_TRUE(resolved_path.HasValue());
-    Path expected_path = std::filesystem::absolute(base_game_dir.temp_path / "config/settings.ini");
+    Path expected_path = FileSystem::Absolute(base_game_dir.temp_path / Path("config/settings.ini"));
     EXPECT_EQ(resolved_path.Value(), expected_path);
 }
 
@@ -200,9 +203,9 @@ protected:
 TEST_F(VFSUnresolvePriorityTest, UnresolvePrefersLongestPathMatch)
 {
     guard.Mount("Generic", common_dir.temp_path, 10);
-    guard.Mount("Specific", common_dir.temp_path / "specific", 0);
+    guard.Mount("Specific", common_dir.temp_path / Path("specific"), 0);
 
-    Path physical_path = common_dir.temp_path / "specific" / "file.txt";
+    Path physical_path = common_dir.temp_path / Path("specific") / Path("file.txt");
     Optional<VPath> virtual_path = VFS::Unresolve(physical_path);
 
     ASSERT_TRUE(virtual_path.HasValue());
@@ -215,10 +218,208 @@ TEST_F(VFSUnresolvePriorityTest, UnresolvePrefersHigherPriorityForSameLengthPath
     guard.Mount("Base", common_dir.temp_path, 0);
     guard.Mount("Mod", common_dir.temp_path, 10);
 
-    Path physical_path = common_dir.temp_path / "file.txt";
+    Path physical_path = common_dir.temp_path / Path("file.txt");
     Optional<VPath> virtual_path = VFS::Unresolve(physical_path);
 
     ASSERT_TRUE(virtual_path.HasValue());
     // 경로 길이가 같으므로 우선순위가 높은 "Mod"를 선택해야 함
     EXPECT_EQ(virtual_path.Value().ToString(), "Mod://file.txt");
+}
+
+
+// =============================================================================
+// Path Traversal 보안 테스트 (RISK-3: Path Traversal via "..")
+// =============================================================================
+
+class VFSPathTraversalTest : public ::testing::Test
+{
+protected:
+    TempDirManager mount_dir{"TraversalMount"};
+    TempDirManager parent_dir{"TraversalParent"};
+    VFSGuard guard{VFS::Get()};
+
+    void SetUp() override
+    {
+        guard.Mount("Sandbox", mount_dir.temp_path);
+        // 마운트 포인트 외부에 파일 생성
+        parent_dir.CreateDummyFile("secret.txt");
+    }
+};
+
+TEST_F(VFSPathTraversalTest, DotDotDoesNotEscapeMountPoint)
+{
+    // RISK-3: "../../../" 패턴으로 마운트 포인트 탈출 시도
+    // Path::operator/가 ".."을 해소하므로 결과가 마운트 포인트 내부로 한정됨
+    // 하지만 해소 결과가 실제로 마운트 포인트 내부인지 확인하는 containment check는 없음
+    VPath traversal_path("Sandbox://../../secret.txt");
+
+    // Resolve는 실제 파일이 존재하는지 확인하므로 여기서는 파일이 없으면 NullOpt
+    Optional<Path> resolved = VFS::Resolve(traversal_path);
+
+    if (resolved.HasValue())
+    {
+        // resolve가 성공했다면, 결과가 마운트 포인트 내부인지 확인
+        EXPECT_TRUE(resolved->IsSubPathOf(mount_dir.temp_path))
+            << "Path traversal escaped mount point! Resolved to: " << resolved->ToString().CStr();
+    }
+}
+
+TEST_F(VFSPathTraversalTest, ToPathWithDotDot)
+{
+    // ToPath는 존재 여부를 확인하지 않으므로 항상 경로를 반환
+    VPath traversal_path("Sandbox://../../escape");
+    Path result = VFS::ToPath(traversal_path);
+
+    if (!result.IsEmpty())
+    {
+        // 결과 경로가 마운트 포인트를 벗어나지 않아야 함
+        EXPECT_TRUE(result.IsSubPathOf(mount_dir.temp_path))
+            << "ToPath escaped mount point! Result: " << result.ToString().CStr();
+    }
+}
+
+
+// =============================================================================
+// VFS 마운트 엣지 케이스 (Mount Edge Cases)
+// =============================================================================
+
+class VFSMountEdgeCaseTest : public ::testing::Test
+{
+protected:
+    TempDirManager temp_dir{"MountEdge"};
+    VFSGuard guard{VFS::Get()};
+};
+
+TEST_F(VFSMountEdgeCaseTest, MountSameSchemeAndPathTwiceIsNoop)
+{
+    guard.Mount("Test", temp_dir.temp_path, 0);
+    guard.Mount("Test", temp_dir.temp_path, 0);  // 중복 마운트
+
+    // 파일 생성 후 resolve
+    temp_dir.CreateDummyFile("file.txt");
+    Optional<Path> resolved = VFS::Resolve(VPath("Test://file.txt"));
+    EXPECT_TRUE(resolved.HasValue());
+}
+
+TEST_F(VFSMountEdgeCaseTest, UnmountNonExistentSchemeDoesNotCrash)
+{
+    // 등록되지 않은 스킴 Unmount는 크래시하지 않아야 함
+    VFS::Get().Unmount("NonExistent");
+    // 크래시 없이 통과하면 성공
+}
+
+TEST_F(VFSMountEdgeCaseTest, ResolveAfterUnmountFails)
+{
+    guard.Mount("Temp", temp_dir.temp_path);
+    temp_dir.CreateDummyFile("file.txt");
+
+    EXPECT_TRUE(VFS::Resolve(VPath("Temp://file.txt")).HasValue());
+
+    VFS::Get().Unmount("Temp");
+
+    EXPECT_FALSE(VFS::Resolve(VPath("Temp://file.txt")).HasValue());
+
+    // guard의 소멸자에서 이중 Unmount가 발생해도 안전해야 함
+}
+
+TEST_F(VFSMountEdgeCaseTest, ExistsReturnsFalseForInvalidVPath)
+{
+    EXPECT_FALSE(VFS::Exists(VPath{}));
+    EXPECT_FALSE(VFS::Exists(VPath("")));
+}
+
+TEST_F(VFSMountEdgeCaseTest, ToPathReturnsEmptyForUnmountedScheme)
+{
+    Path result = VFS::ToPath(VPath("Unknown://file.txt"));
+    EXPECT_TRUE(result.IsEmpty());
+}
+
+
+// =============================================================================
+// VFS Unicode 경로 테스트
+// =============================================================================
+
+class VFSUnicodeTest : public ::testing::Test
+{
+protected:
+    TempDirManager temp_dir{"VFSUnicode"};
+    VFSGuard guard{VFS::Get()};
+
+    void SetUp() override
+    {
+        guard.Mount("Assets", temp_dir.temp_path);
+    }
+};
+
+TEST_F(VFSUnicodeTest, ResolveUnicodeFileName)
+{
+    temp_dir.CreateDummyFile("텍스처/플레이어.png");
+
+    VPath vpath("Assets://텍스처/플레이어.png");
+    Optional<Path> resolved = VFS::Resolve(vpath);
+    ASSERT_TRUE(resolved.HasValue());
+    EXPECT_TRUE(resolved->Exists());
+}
+
+TEST_F(VFSUnicodeTest, UnresolveUnicodePath)
+{
+    Path physical = temp_dir.temp_path / Path("モデル/hero.fbx");
+    Optional<VPath> vpath = VFS::Unresolve(physical);
+
+    ASSERT_TRUE(vpath.HasValue());
+    EXPECT_EQ(vpath->GetScheme(), "Assets");
+    EXPECT_EQ(vpath->GetFilename(), "hero.fbx");
+}
+
+TEST_F(VFSUnicodeTest, ToPathUnicode)
+{
+    Path result = VFS::ToPath(VPath("Assets://日本語/ファイル.dat"));
+    EXPECT_FALSE(result.IsEmpty());
+    EXPECT_EQ(result.FileName().Value(), String("ファイル.dat"));
+}
+
+
+// =============================================================================
+// EnsureDirectories 테스트
+// =============================================================================
+
+class VFSEnsureDirsTest : public ::testing::Test
+{
+protected:
+    TempDirManager temp_dir{"EnsureDirs"};
+    VFSGuard guard{VFS::Get()};
+};
+
+TEST_F(VFSEnsureDirsTest, CreatesNonExistentMountDirectory)
+{
+    Path cache_dir = temp_dir.temp_path / Path("new_cache");
+    guard.Mount("Cache", cache_dir);
+
+    EXPECT_FALSE(cache_dir.Exists());
+
+    Array<StringView> schemes;
+    schemes.Push("Cache");
+    VFS::Get().EnsureDirectories(schemes);
+
+    EXPECT_TRUE(cache_dir.Exists());
+    EXPECT_TRUE(cache_dir.IsDirectory());
+}
+
+TEST_F(VFSEnsureDirsTest, SkipsAlreadyExistingDirectory)
+{
+    guard.Mount("Existing", temp_dir.temp_path);
+
+    Array<StringView> schemes;
+    schemes.Push("Existing");
+    // 이미 존재하는 디렉토리 — 크래시 없이 통과
+    VFS::Get().EnsureDirectories(schemes);
+    EXPECT_TRUE(temp_dir.temp_path.Exists());
+}
+
+TEST_F(VFSEnsureDirsTest, SkipsUnmountedScheme)
+{
+    Array<StringView> schemes;
+    schemes.Push("NotMounted");
+    // 등록되지 않은 스킴은 무시 — 크래시 없이 통과
+    VFS::Get().EnsureDirectories(schemes);
 }

--- a/EngineTest/Source/UnitTests/VPathTest.cpp
+++ b/EngineTest/Source/UnitTests/VPathTest.cpp
@@ -369,18 +369,13 @@ TEST(VPathSlashOpTest, AppendEmptyReturnsOriginal)
 // 숨김 파일 Extension/Stem 불일치 (BUG-4: Hidden File Handling)
 // =============================================================================
 
-TEST(VPathHiddenFileTest, DotFileExtensionInconsistencyWithPath)
+TEST(VPathHiddenFileTest, DotFileExtensionConsistencyWithPath)
 {
-    // VPath의 GetExtension이 Path::Extension()과 동일하게 동작하는지 검증
-    // ".gitignore"는 숨김파일 — Path는 확장자 없음으로 판단
-    // BUG: VPath는 ".gitignore" 전체를 확장자로 반환할 수 있음
+    // ".gitignore"는 숨김파일 — Path와 동일하게 확장자 없음, stem은 전체 파일명
     VPath vp("Assets://.gitignore");
 
-    // Path와 동일한 동작을 기대: 숨김파일은 확장자 없음
-    // 현재 BUG로 인해 GetExtension()이 ".gitignore"를 반환할 수 있음
-    // 수정 후 기대값:
-    // EXPECT_TRUE(vp.GetExtension().IsEmpty());
-    // EXPECT_EQ(vp.GetStem(), ".gitignore");
+    EXPECT_TRUE(vp.GetExtension().IsEmpty());
+    EXPECT_EQ(vp.GetStem(), ".gitignore");
 }
 
 TEST(VPathHiddenFileTest, DotFileWithExtension)

--- a/EngineTest/Source/UnitTests/VPathTest.cpp
+++ b/EngineTest/Source/UnitTests/VPathTest.cpp
@@ -299,3 +299,228 @@ TEST(VPathTest, UnicodeInPath)
     EXPECT_TRUE(p.IsValid());
     EXPECT_EQ(p.GetFilename(), "플레이어.png");
 }
+
+
+// =============================================================================
+// operator/ 메타데이터 보존 (BUG-1: Scheme Metadata After Concatenation)
+// =============================================================================
+
+TEST(VPathSlashOpTest, PreservesSchemeMetadataAfterAppend)
+{
+    // BUG: operator/가 scheme_len과 path_offset을 복사하지 않음
+    VPath base("Assets://Textures");
+    VPath result = base / "Player.png";
+
+    EXPECT_EQ(result.ToString(), "Assets://Textures/Player.png");
+
+    // 이 검증들이 BUG-1이 존재하면 실패함
+    EXPECT_TRUE(result.HasScheme());
+    EXPECT_EQ(result.GetScheme(), "Assets");
+    EXPECT_EQ(result.GetPathPart(), "Textures/Player.png");
+}
+
+TEST(VPathSlashOpTest, PreservesSchemeInChainedAppend)
+{
+    VPath base("Config://");
+    VPath result = base / "settings" / "graphics.toml";
+
+    // 2회 체인 후에도 스킴이 보존되어야 함
+    EXPECT_TRUE(result.HasScheme());
+    EXPECT_EQ(result.GetScheme(), "Config");
+    EXPECT_EQ(result.GetFilename(), "graphics.toml");
+}
+
+TEST(VPathSlashOpTest, GetParentAfterAppendPreservesScheme)
+{
+    VPath base("Assets://Textures");
+    VPath result = base / "Player.png";
+    VPath parent = result.GetParentPath();
+
+    // 부모 경로도 올바른 스킴을 가져야 함
+    EXPECT_TRUE(parent.HasScheme());
+    EXPECT_EQ(parent.GetScheme(), "Assets");
+    EXPECT_EQ(parent.ToString(), "Assets://Textures");
+}
+
+
+// =============================================================================
+// operator/ 이중 슬래시 (BUG-3: Double Slash)
+// =============================================================================
+
+TEST(VPathSlashOpTest, BothTrailingAndLeadingSlash)
+{
+    // base 끝이 '/', relative 시작이 '/' → 이중 슬래시 방지
+    VPath base("Assets://Textures/");
+    VPath result = base / "/Player.png";
+
+    // 이중 슬래시 "Assets://Textures//Player.png"가 되면 안 됨
+    EXPECT_EQ(result.ToString(), "Assets://Textures/Player.png");
+}
+
+TEST(VPathSlashOpTest, AppendEmptyReturnsOriginal)
+{
+    VPath base("Assets://Textures");
+    VPath result = base / "";
+    EXPECT_EQ(result.ToString(), base.ToString());
+}
+
+
+// =============================================================================
+// 숨김 파일 Extension/Stem 불일치 (BUG-4: Hidden File Handling)
+// =============================================================================
+
+TEST(VPathHiddenFileTest, DotFileExtensionInconsistencyWithPath)
+{
+    // VPath의 GetExtension이 Path::Extension()과 동일하게 동작하는지 검증
+    // ".gitignore"는 숨김파일 — Path는 확장자 없음으로 판단
+    // BUG: VPath는 ".gitignore" 전체를 확장자로 반환할 수 있음
+    VPath vp("Assets://.gitignore");
+
+    // Path와 동일한 동작을 기대: 숨김파일은 확장자 없음
+    // 현재 BUG로 인해 GetExtension()이 ".gitignore"를 반환할 수 있음
+    // 수정 후 기대값:
+    // EXPECT_TRUE(vp.GetExtension().IsEmpty());
+    // EXPECT_EQ(vp.GetStem(), ".gitignore");
+}
+
+TEST(VPathHiddenFileTest, DotFileWithExtension)
+{
+    VPath vp("Assets://.bashrc.bak");
+
+    // ".bashrc.bak" → stem=".bashrc", ext=".bak"
+    EXPECT_EQ(vp.GetExtension(), ".bak");
+    EXPECT_EQ(vp.GetStem(), ".bashrc");
+}
+
+
+// =============================================================================
+// ParseAndNormalize 엣지 케이스
+// =============================================================================
+
+TEST(VPathNormalizationTest, DotDotInPathPartNotResolved)
+{
+    // VPath는 ".."을 해소하지 않음 (Path와 다르게)
+    // 이 동작을 문서화하는 테스트
+    VPath p("Assets://A/../B/file.txt");
+    EXPECT_EQ(p.GetPathPart(), "A/../B/file.txt");
+}
+
+TEST(VPathNormalizationTest, MultipleSlashesNotCollapsed)
+{
+    // VPath는 이중 슬래시를 정리하지 않음
+    VPath p("Assets://A//B///file.txt");
+    EXPECT_EQ(p.GetPathPart(), "A//B///file.txt");
+}
+
+TEST(VPathNormalizationTest, ColonSequenceInPathPart)
+{
+    // 경로 부분에 "://"가 있는 경우 — 첫 번째 "://"만 스킴 구분자
+    VPath p("Assets://path/with://colons/file.txt");
+    EXPECT_EQ(p.GetScheme(), "Assets");
+    EXPECT_EQ(p.GetPathPart(), "path/with://colons/file.txt");
+}
+
+TEST(VPathNormalizationTest, SchemeWithNumbers)
+{
+    VPath p("Cache2://data/file.bin");
+    EXPECT_EQ(p.GetScheme(), "Cache2");
+    EXPECT_TRUE(p.HasScheme());
+}
+
+TEST(VPathNormalizationTest, BackslashInScheme)
+{
+    // "Assets:\\" → 정규화 후 "Assets://" (스킴은 여전히 "Assets")
+    VPath p("Assets:\\\\Textures\\file.png");
+    EXPECT_EQ(p.GetScheme(), "Assets");
+}
+
+
+// =============================================================================
+// uint16 오버플로우 테스트
+// =============================================================================
+
+TEST(VPathOverflowTest, VeryLongSchemeName)
+{
+    // 65535자를 초과하는 스킴명 (실제로는 비현실적이지만 안전성 검증)
+    // uint16 한계 내에서의 동작 확인 (현실적 범위)
+    String long_scheme(1000, 'A');  // 1000자 스킴
+    String vpath_str = long_scheme + "://file.txt";
+
+    VPath p(vpath_str);
+    EXPECT_TRUE(p.HasScheme());
+    EXPECT_EQ(p.GetScheme(), StringView(long_scheme));
+}
+
+
+// =============================================================================
+// 유니코드 스킴 및 경로 (Unicode Scheme & Path)
+// =============================================================================
+
+TEST(VPathUnicodeTest, CJKFilenameComponents)
+{
+    VPath p("Assets://텍스처/플레이어_스프라이트.png");
+    EXPECT_EQ(p.GetFilename(), "플레이어_스프라이트.png");
+    EXPECT_EQ(p.GetStem(), "플레이어_스프라이트");
+    EXPECT_EQ(p.GetExtension(), ".png");
+}
+
+TEST(VPathUnicodeTest, EmojiPath)
+{
+    VPath p("Assets://🎮/🎵.mp3");
+    EXPECT_EQ(p.GetFilename(), "🎵.mp3");
+    EXPECT_EQ(p.GetStem(), "🎵");
+}
+
+TEST(VPathUnicodeTest, MixedUnicodeAndAscii)
+{
+    VPath p("Assets://Models/キャラクター/hero_model.fbx");
+    EXPECT_EQ(p.GetScheme(), "Assets");
+    EXPECT_EQ(p.GetFilename(), "hero_model.fbx");
+}
+
+
+// =============================================================================
+// GetParentPath 엣지 케이스
+// =============================================================================
+
+TEST(VPathParentTest, ParentOfSchemeOnlyReturnsInvalid)
+{
+    VPath p("Assets://");
+    VPath parent = p.GetParentPath();
+    // "Assets://"에서 마지막 '/'는 "://" 내부이므로 path_offset 이하
+    // GetParentPath는 path_offset까지의 부분을 반환
+    EXPECT_EQ(parent.ToString(), "Assets://");
+}
+
+TEST(VPathParentTest, ParentOfNoSchemePathWithoutSlash)
+{
+    VPath p("file.txt");
+    VPath parent = p.GetParentPath();
+    // 슬래시가 없으므로 빈 VPath
+    EXPECT_FALSE(parent.IsValid());
+}
+
+TEST(VPathParentTest, ParentOfDeepNestedPath)
+{
+    VPath p("Assets://A/B/C/D/E/file.txt");
+    VPath current = p;
+
+    // 계층 순회: E → D → C → B → A → Assets://
+    current = current.GetParentPath();
+    EXPECT_EQ(current.ToString(), "Assets://A/B/C/D/E");
+
+    current = current.GetParentPath();
+    EXPECT_EQ(current.ToString(), "Assets://A/B/C/D");
+
+    current = current.GetParentPath();
+    EXPECT_EQ(current.ToString(), "Assets://A/B/C");
+
+    current = current.GetParentPath();
+    EXPECT_EQ(current.ToString(), "Assets://A/B");
+
+    current = current.GetParentPath();
+    EXPECT_EQ(current.ToString(), "Assets://A");
+
+    current = current.GetParentPath();
+    EXPECT_EQ(current.ToString(), "Assets://");
+}


### PR DESCRIPTION
> 아래 PR 메시지는 **Claude Sonnet 4.6**을 사용하여 작성되었습니다.

---

## Summary

- `std::filesystem` 전면 제거 후 SDL3 파일 I/O API 및 자체 `Path`/`VPath`/`VFS` 클래스로 교체
- `NormalizePath` O(n) 단일 패스 구현 — UNC, Windows 드라이브, Unix 절대/상대 경로 모두 지원
- VFS 스킴 기반 마운트 시스템 도입 — 우선순위 기반 mod fallback 및 path traversal 보안 차단
- 테스트 807개 전부 통과 (PathTest, VPathTest, VFSTest, FileSystemTest 대폭 확장)

## 변경 내역

### 핵심 클래스 신규 구현

| 클래스 | 역할 |
|--------|------|
| `Path` | 물리 경로. 생성 시점 정규화 불변식, UTF-8, SDL3 백엔드 |
| `VPath` | 가상 경로. `scheme://path` 형식, `scheme_len`/`path_offset` 파싱 |
| `VFS` | 스킴 기반 마운트 싱글톤. `shared_mutex` 스레드 안전, 우선순위 정렬 |
| `FileSystem` | 정적 I/O 유틸리티 — Read/Write/Copy/Rename/ReadChunked 등 |

### 경로 정규화 (`Path::NormalizePath`)

- `\` → `/` 변환, 연속 슬래시 제거, `.` 제거, `..` 해소
- UNC (`//server/share`), Windows 드라이브 (`C:/`, `C:foo`), Unix 루트 (`/`) 모두 처리
- `DetectRootLength`로 루트 접두사를 정확히 판별하여 루트 위 `..` 탈출 방지

### 보안 수정

- **VFS Path Traversal 차단**: `ResolveImpl`/`ToPath`에서 `IsSubPathOf` containment check — `"Assets://../../etc/passwd"` 패턴 차단
- **SetExtension Traversal 방지**: `SetExtension` 후 `NormalizePath` 재호출로 확장자를 통한 경로 조작 방지

### 버그 수정

| 버그 | 수정 |
|------|------|
| `VPath::operator/` 메타데이터 유실 | `VPath new_path = *this`로 `scheme_len`/`path_offset` 보존 |
| `VPath::operator/` 이중 슬래시 | `trail`/`lead` 조건으로 중복 `/` 정규화 |
| `NormalizePath` UNC 세그먼트 연결 오류 | UNC 루트 뒤 첫 세그먼트에 `/` 구분자 보충 |
| `VPath::GetExtension`/`GetStem` 숨김파일 오동작 | `*last_dot == 0` 체크 추가, `Path`와 동일하게 통일 |

### Windows 플랫폼 대응

- `Rename`: `ReplaceFileW` + `MoveFileExW` (덮어쓰기 지원 원자적 이동)
- `ToWideString()` 헬퍼로 UTF-8 → UTF-16 변환 후 Win32 API 호출
- `FileBackend` 로깅: SDL I/O 기반으로 재작성

### 테스트 확장

- **PathTest**: 807 → 정규화 엣지 케이스, UNC, Windows/Unix 경로, 숨김파일, SetExtension, RelativeTo, Append, Unicode/CJK/이모지, IsSubPathOf
- **VPathTest**: operator/ 메타데이터, 이중 슬래시, 숨김파일, uint16 오버플로, 유니코드
- **VFSTest**: Path Traversal 차단, 중복 마운트, Unmount 후 Resolve, 유니코드, EnsureDirectories
- **FileSystemTest**: UTF-8 파일명, ReadChunked 청크 경계, Rename 덮어쓰기, Copy, RemoveAll

## Test Plan

- [x] `UnitTests.exe` 전체 실행 — 807/807 통과 확인
- [x] UNC 경로 (`//server/share/dir/file.txt`) 정규화 검증
- [x] Path Traversal (`Assets://../../etc/passwd`) 차단 검증
- [x] Unicode/CJK 경로 Resolve/Unresolve 검증
- [x] Windows `Rename` 덮어쓰기(atomic) 동작 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)