### PR TITLE
[Feature] 비동기 파일 I/O 시스템 및 코루틴 안전성 강화

### DIFF
--- a/EngineCore/Include/SimpleEngine/Core/Concurrency/AsyncFileIO.h
+++ b/EngineCore/Include/SimpleEngine/Core/Concurrency/AsyncFileIO.h
@@ -1,0 +1,101 @@
+﻿#pragma once
+
+#include "SimpleEngine/Core/Container/Array.h"
+#include "SimpleEngine/Core/Functional/UniqueFunction.h"
+#include "SimpleEngine/Core/HAL/PlatformTypes.h"
+
+#include "SDL3/SDL.h"
+
+#include <thread>
+
+
+namespace se
+{
+// Forward Declaration
+template <typename T>
+class JobTask;
+class Path;
+
+/**
+ * 비동기 I/O 결과를 담는 구조체
+ *
+ * ReadFile / ReadFileAsync의 완료 시 전달되며,
+ * success가 false인 경우 data는 비어 있을 수 있습니다.
+ */
+struct IOResult
+{
+    struct SDLDeleter
+    {
+        void operator()(void* ptr) const
+        {
+            SDL_free(ptr);
+        }
+    };
+
+    /** 읽어들인 파일 데이터 */
+    std::unique_ptr<uint8[], SDLDeleter> data;
+
+    /** 실제로 전송된 바이트 수 */
+    usize bytes_transferred = 0;
+
+    /** I/O 작업의 성공 여부 */
+    bool success = false;
+};
+
+
+/**
+ * SDL3 AsyncIO 기반 비동기 파일 I/O (전역 싱글톤)
+ *
+ * SDL_AsyncIOQueue를 감시하는 Poller Thread가 I/O 완료를 감지하면,
+ * JobSystem의 Compute Worker에 콜백/코루틴 재개를 스케줄링합니다.
+ * Poller Thread는 절대로 사용자 코드를 직접 실행하지 않습니다.
+ */
+class SE_CORE_API AsyncFileIO
+{
+    static AsyncFileIO* instance;
+
+public:
+    explicit AsyncFileIO();
+    ~AsyncFileIO();
+
+    // 복사 & 이동 금지
+    AsyncFileIO(const AsyncFileIO&) = delete;
+    AsyncFileIO& operator=(const AsyncFileIO&) = delete;
+    AsyncFileIO(AsyncFileIO&&) = delete;
+    AsyncFileIO& operator=(AsyncFileIO&&) = delete;
+
+    /** AsyncFileIO 싱글톤 인스턴스를 반환합니다. */
+    static AsyncFileIO& Get();
+
+    /** AsyncFileIO 인스턴스가 초기화되어 있는지 확인합니다. */
+    [[nodiscard]] static bool IsInitialized();
+
+public:
+    /**
+     * 파일 전체를 비동기로 읽고, 완료 시 콜백을 Worker 스레드에서 호출합니다.
+     *
+     * @param path 읽을 파일의 경로 (null-terminated UTF-8 문자열)
+     * @param callback I/O 완료 시 Compute Worker에서 호출될 콜백
+     */
+    void ReadFile(const Path& path, UniqueFunction<void(IOResult)>&& callback);
+
+    /**
+     * 파일 전체를 비동기로 읽어 코루틴으로 결과를 반환합니다.
+     *
+     * @param path 읽을 파일의 경로 (null-terminated UTF-8 문자열)
+     * @return I/O 결과를 담은 JobTask. co_await로 대기합니다.
+     */
+    JobTask<IOResult> ReadFileAsync(const Path& path);
+
+private:
+    /** I/O 완료 큐를 감시하는 Poller Thread의 메인 루프 */
+    void PollerLoop(const std::stop_token& stoken);
+
+private:
+    /** SDL 비동기 I/O 완료 큐 */
+    SDL_AsyncIOQueue* io_queue = nullptr;
+
+    /** I/O 완료 감시 전용 Poller Thread */
+    std::jthread poller_thread;
+};
+} // namespace se

--- a/EngineCore/Include/SimpleEngine/Core/Concurrency/AsyncFileIO.h
+++ b/EngineCore/Include/SimpleEngine/Core/Concurrency/AsyncFileIO.h
@@ -2,10 +2,10 @@
 
 #include "SimpleEngine/Core/Container/Array.h"
 #include "SimpleEngine/Core/Functional/UniqueFunction.h"
-#include "SimpleEngine/Core/HAL/PlatformTypes.h"
 
 #include "SDL3/SDL.h"
 
+#include <memory>
 #include <thread>
 
 

--- a/EngineCore/Include/SimpleEngine/Core/Concurrency/Common.h
+++ b/EngineCore/Include/SimpleEngine/Core/Concurrency/Common.h
@@ -14,10 +14,8 @@ constexpr usize SE_CACHE_LINE = std::hardware_destructive_interference_size;
 /** Job이 실행될 스레드를 지정하는 열거형 */
 enum class EJobThread : uint8
 {
-    Auto,   // 스케줄러가 자동으로 결정 (기본값)
     Main,   // 메인 스레드에서 실행
     Worker, // Compute Worker 스레드에서 실행
-    IO,     // I/O 전용 스레드에서 실행
 };
 
 /** Job의 실행 우선순위를 지정하는 열거형 */

--- a/EngineCore/Include/SimpleEngine/Core/Concurrency/Coroutine/CoroutinePrimitives.h
+++ b/EngineCore/Include/SimpleEngine/Core/Concurrency/Coroutine/CoroutinePrimitives.h
@@ -105,7 +105,7 @@ JobHandle JobSystem::SubmitTask(Fn&& factory, EJobPriority priority)
 {
     static_assert(
         !std::is_class_v<std::remove_cvref_t<Fn>> || std::is_empty_v<std::remove_cvref_t<Fn>>,
-        "[JobSystem Error] DispatchTask requires a stateless (non-capturing) lambda! "
+        "[JobSystem Error] SubmitTask requires a stateless (non-capturing) lambda! "
         "Please use a 'static' lambda: []() static -> JobTask<void> { ... }"
     );
     return SubmitTask(std::invoke(std::forward<Fn>(factory)), priority);

--- a/EngineCore/Include/SimpleEngine/Core/Concurrency/Coroutine/CoroutinePrimitives.h
+++ b/EngineCore/Include/SimpleEngine/Core/Concurrency/Coroutine/CoroutinePrimitives.h
@@ -2,9 +2,13 @@
 
 #include "SimpleEngine/Core/Concurrency/Common.h"
 #include "SimpleEngine/Core/Concurrency/JobHandle.h"
+#include "SimpleEngine/Core/Concurrency/JobSystem.h"
+#include "SimpleEngine/Core/Concurrency/Coroutine/JobTask.h"
 #include "SimpleEngine/Core/Container/Array.h"
 
+#include <concepts>
 #include <coroutine>
+#include <type_traits>
 
 
 namespace se
@@ -90,4 +94,23 @@ public:
 private:
     Array<JobHandle> handles;
 };
+
+
+// JobSystem::SubmitTask / DispatchTask 템플릿 정의
+
+template <typename Fn>
+    requires std::is_invocable_r_v<JobTask<void>, Fn>
+          && std::is_empty_v<std::remove_cvref_t<Fn>> // 캡처가 없는 Functor만 허용
+JobHandle JobSystem::SubmitTask(Fn&& factory, EJobPriority priority)
+{
+    return SubmitTask(std::invoke(std::forward<Fn>(factory)), priority);
+}
+
+template <typename Fn>
+    requires std::is_invocable_r_v<JobTask<void>, Fn>
+          && std::is_empty_v<std::remove_cvref_t<Fn>> // 캡처가 없는 Functor만 허용
+void JobSystem::DispatchTask(Fn&& factory, EJobPriority priority)
+{
+    DispatchTask(std::invoke(std::forward<Fn>(factory)), priority);
+}
 } // namespace se

--- a/EngineCore/Include/SimpleEngine/Core/Concurrency/Coroutine/CoroutinePrimitives.h
+++ b/EngineCore/Include/SimpleEngine/Core/Concurrency/Coroutine/CoroutinePrimitives.h
@@ -99,18 +99,28 @@ private:
 // JobSystem::SubmitTask / DispatchTask 템플릿 정의
 
 template <typename Fn>
-    requires std::is_invocable_r_v<JobTask<void>, Fn>
-          && std::is_empty_v<std::remove_cvref_t<Fn>> // 캡처가 없는 Functor만 허용
+    requires std::invocable<Fn>
+          && std::same_as<std::invoke_result_t<Fn>, JobTask<void>>
 JobHandle JobSystem::SubmitTask(Fn&& factory, EJobPriority priority)
 {
+    static_assert(
+        !std::is_class_v<std::remove_cvref_t<Fn>> || std::is_empty_v<std::remove_cvref_t<Fn>>,
+        "[JobSystem Error] DispatchTask requires a stateless (non-capturing) lambda! "
+        "Please use a 'static' lambda: []() static -> JobTask<void> { ... }"
+    );
     return SubmitTask(std::invoke(std::forward<Fn>(factory)), priority);
 }
 
 template <typename Fn>
-    requires std::is_invocable_r_v<JobTask<void>, Fn>
-          && std::is_empty_v<std::remove_cvref_t<Fn>> // 캡처가 없는 Functor만 허용
+    requires std::invocable<Fn>
+          && std::same_as<std::invoke_result_t<Fn>, JobTask<void>>
 void JobSystem::DispatchTask(Fn&& factory, EJobPriority priority)
 {
+    static_assert(
+        !std::is_class_v<std::remove_cvref_t<Fn>> || std::is_empty_v<std::remove_cvref_t<Fn>>,
+        "[JobSystem Error] DispatchTask requires a stateless (non-capturing) lambda! "
+        "Please use a 'static' lambda: []() static -> JobTask<void> { ... }"
+    );
     DispatchTask(std::invoke(std::forward<Fn>(factory)), priority);
 }
 } // namespace se

--- a/EngineCore/Include/SimpleEngine/Core/Concurrency/Coroutine/JobTask.h
+++ b/EngineCore/Include/SimpleEngine/Core/Concurrency/Coroutine/JobTask.h
@@ -3,7 +3,7 @@
 
 #include "SimpleEngine/Core/Concurrency/JobAllocator.h"
 #include "SimpleEngine/Core/Container/Optional.h"
-#include "SimpleEngine/Core/HAL/PlatformTypes.h"
+#include "SimpleEngine/Traits/TypeTraits.h"
 #include "SimpleEngine/Utility/Debug.h"
 
 #include <concepts>
@@ -74,6 +74,24 @@ struct JobTaskPromise : detail::PromiseReturnMixin<T, JobTaskPromise<T>>
     using StorageType = std::conditional_t<std::is_void_v<T>, EmptyType, Optional<T>>;
 
 public:
+    /** 일반적인 코루틴, static 람다, 일반 함수용 생성자 */
+    JobTaskPromise() = default;
+
+    /** non-static 람다(캡처가 있는 람다)용 생성자 */
+    template <typename ClassType, typename... Args>
+        requires std::invocable<ClassType, Args&&...>
+              && std::same_as<std::invoke_result_t<ClassType, Args&&...>, JobTask<T>>
+              && std::is_class_v<std::remove_cvref_t<ClassType>>
+    JobTaskPromise(ClassType&&, Args&&...)
+    {
+        static_assert(
+            traits::AlwaysFalse<ClassType, Args...>,
+            "[JobTask Error] Stateful (capturing) lambdas are not allowed in JobTask coroutines to prevent dangling references! "
+            "Please use a 'static' lambda and pass required data via parameters. "
+            "(e.g., [](...) static -> JobTask<T> { ... })"
+        );
+    }
+
     /** 코루틴 객체(JobTask)를 생성하여 호출자에게 반환합니다. */
     JobTask<T> get_return_object();
 

--- a/EngineCore/Include/SimpleEngine/Core/Concurrency/Coroutine/JobTask.h
+++ b/EngineCore/Include/SimpleEngine/Core/Concurrency/Coroutine/JobTask.h
@@ -8,14 +8,16 @@
 
 #include <concepts>
 #include <coroutine>
+#include <memory>
 #include <utility>
 
 
 namespace se
 {
-// Forward declaration
+// Forward declarations
 template <typename T>
 class JobTask;
+class JobCounter;
 
 namespace detail
 {
@@ -87,11 +89,35 @@ public:
         /** 코루틴을 중단하고, await_suspend에서 호출자(Continuation)로 제어권을 안전하게 전환합니다. */
         bool await_ready() const noexcept { return false; }
 
-        /** 호출자가 있으면 해당 핸들로 전환하고, 없으면 코루틴 실행을 완전히 종료합니다. */
+        /**
+         * 호출자가 있으면 해당 핸들로 전환하고, 없으면 코루틴 실행을 완전히 종료합니다.
+         * Detached 모드(SubmitTask/DispatchTask로 제출된 코루틴)일 경우, 프레임을 자동 소멸하고 완료 카운터를 감소시킵니다.
+         */
         std::coroutine_handle<> await_suspend(std::coroutine_handle<JobTaskPromise> handle) noexcept
         {
-            const JobTaskPromise& promise = handle.promise();
-            return promise.continuation ? promise.continuation : std::noop_coroutine();
+            JobTaskPromise& promise = handle.promise();
+
+            // 부모 코루틴이 있다면 복귀 (Symmetric Transfer)
+            if (promise.continuation)
+            {
+                return promise.continuation;
+            }
+
+            // Detached 모드인 경우 (코루틴 소멸 + 카운터 통지)
+            if (promise.detached)
+            {
+                // 프레임 소멸 전에 카운터를 추출 (destroy시 promise도 같이 사라지기 때문)
+                auto counter = std::move(promise.completion_counter);
+                handle.destroy();
+
+                if (counter)
+                {
+                    counter->Decrement();
+                }
+            }
+
+            // 코루틴 정상 종료
+            return std::noop_coroutine();
         }
 
         /** 재개 직전에 호출되는 함수 */
@@ -117,6 +143,19 @@ public:
 public:
     /** 이 코루틴이 완료된 후 재개할 부모 코루틴 핸들 */
     std::coroutine_handle<> continuation;
+
+    /**
+     * Detached 모드 플래그.
+     * true일 경우 FinalAwaiter에서 코루틴 프레임을 자동 소멸합니다.
+     * SubmitTask() / DispatchTask()에 의해 설정됩니다.
+     */
+    bool detached = false;
+
+    /**
+     * Detached 모드에서 완료 시 Decrement할 카운터.
+     * SubmitTask()에 의해 설정됩니다. DispatchTask()에서는 null입니다.
+     */
+    std::shared_ptr<JobCounter> completion_counter;
 
     /**
      * 코루틴의 반환 값.

--- a/EngineCore/Include/SimpleEngine/Core/Concurrency/JobSystem.h
+++ b/EngineCore/Include/SimpleEngine/Core/Concurrency/JobSystem.h
@@ -20,10 +20,14 @@
 #include <memory>
 #include <mutex>
 #include <thread>
+#include <type_traits>
 
 
 namespace se
 {
+// Forward declaration — Layer 2 (Coroutine) 타입. 전체 정의는 JobTask.h 참조.
+template <typename T>
+class JobTask;
 /**
  * Lambda-Core 기반 Job System (전역 싱글톤)
  *
@@ -83,7 +87,7 @@ public:
      */
     template <typename Fn>
         requires std::invocable<Fn>
-    JobHandle Submit(Fn&& work_func, EJobPriority priority = EJobPriority::Normal);
+    [[nodiscard]] JobHandle Submit(Fn&& work_func, EJobPriority priority = EJobPriority::Normal);
 
     /**
      * 선행 작업들이 모두 완료된 후 실행될 의존성 작업을 제출합니다.
@@ -96,7 +100,7 @@ public:
      */
     template <typename Fn>
         requires std::invocable<Fn>
-    JobHandle Submit(Fn&& work_func, ArrayView<const JobHandle> dependencies, EJobPriority priority = EJobPriority::Normal);
+    [[nodiscard]] JobHandle Submit(Fn&& work_func, ArrayView<const JobHandle> dependencies, EJobPriority priority = EJobPriority::Normal);
 
     /**
      * 지정된 범위를 배치 단위로 분할하여 워커 스레드들에 병렬로 제출합니다.
@@ -110,7 +114,7 @@ public:
      */
     template <typename Fn>
         requires std::invocable<Fn, usize>
-    JobHandle ParallelFor(usize in_count, usize batch_size, Fn work_func, EJobPriority priority = EJobPriority::Normal);
+    [[nodiscard]] JobHandle ParallelFor(usize in_count, usize batch_size, Fn work_func, EJobPriority priority = EJobPriority::Normal);
 
     /**
      * 현재 메인 스레드 큐에 대기 중인 모든 작업을 일괄 실행(Drain)합니다. (메인 스레드 전용)
@@ -119,6 +123,71 @@ public:
      * @warning 반드시 메인 스레드에서만 호출해야 합니다.
      */
     usize ExecuteMainThreadJobs();
+
+public:
+    /**
+     * 코루틴을 워커 스레드에 전송합니다. (Fire-and-Forget)
+     * 코루틴의 소유권이 이전되며, 완료 시 자동으로 소멸됩니다.
+     *
+     * @param task 전송할 코루틴 (rvalue로 소유권 이전)
+     * @param priority 실행 우선순위
+     *
+     * @code
+     *   JobSystem::Get().DispatchTask([]() static -> JobTask<void>
+     *   {
+     *       co_await SomeAsyncWork();
+     *   }());
+     * @endcode
+     */
+    void DispatchTask(JobTask<void>&& task, EJobPriority priority = EJobPriority::Normal);
+
+    /**
+     * 코루틴을 워커 스레드에 제출하고, 완료를 추적할 수 있는 핸들을 반환합니다.
+     * 코루틴의 소유권이 이전되며, 완료 시 자동으로 소멸됩니다.
+     *
+     * @param task 제출할 코루틴 (rvalue로 소유권 이전)
+     * @param priority 실행 우선순위
+     * @return 코루틴 완료를 추적하는 핸들
+     *
+     * @code
+     *   JobHandle h = JobSystem::Get().SubmitTask([]() static -> JobTask<void>
+     *   {
+     *       co_await SomeAsyncWork();
+     *   }());
+     *   h.Wait();
+     * @endcode
+     */
+    [[nodiscard]] JobHandle SubmitTask(JobTask<void>&& task, EJobPriority priority = EJobPriority::Normal);
+
+    /**
+     * void DispatchTask(JobTask<void>&& task, EJobPriority priority) Factory 오버로딩
+     *
+     * @code
+     *   JobSystem::Get().DispatchTask([] static -> JobTask<void>
+     *   {
+     *       co_await SomeWork();
+     *   }); // () 없이 factory만 전달
+     * @endcode
+     */
+    template <typename Fn>
+        requires std::is_invocable_r_v<JobTask<void>, Fn>
+              && std::is_empty_v<std::remove_cvref_t<Fn>> // 캡처가 없는 Functor만 허용
+    void DispatchTask(Fn&& factory, EJobPriority priority = EJobPriority::Normal);
+
+    /**
+     * JobHandle SubmitTask(JobTask<void>&& task, EJobPriority priority) Factory 오버로딩
+     *
+     * @code
+     *   JobHandle h = JobSystem::Get().SubmitTask([] static -> JobTask<void>
+     *   {
+     *       co_await SomeWork();
+     *   }); // () 없이 factory만 전달
+     * @endcode
+     */
+    template <typename Fn>
+        requires std::is_invocable_r_v<JobTask<void>, Fn>
+              && std::is_empty_v<std::remove_cvref_t<Fn>> // 캡처가 없는 Functor만 허용
+    [[nodiscard]] JobHandle SubmitTask(Fn&& factory, EJobPriority priority = EJobPriority::Normal);
 
 public:
     /**

--- a/EngineCore/Include/SimpleEngine/Core/Concurrency/JobSystem.h
+++ b/EngineCore/Include/SimpleEngine/Core/Concurrency/JobSystem.h
@@ -170,8 +170,8 @@ public:
      * @endcode
      */
     template <typename Fn>
-        requires std::is_invocable_r_v<JobTask<void>, Fn>
-              && std::is_empty_v<std::remove_cvref_t<Fn>> // 캡처가 없는 Functor만 허용
+        requires std::invocable<Fn>
+              && std::same_as<std::invoke_result_t<Fn>, JobTask<void>>
     void DispatchTask(Fn&& factory, EJobPriority priority = EJobPriority::Normal);
 
     /**
@@ -185,8 +185,8 @@ public:
      * @endcode
      */
     template <typename Fn>
-        requires std::is_invocable_r_v<JobTask<void>, Fn>
-              && std::is_empty_v<std::remove_cvref_t<Fn>> // 캡처가 없는 Functor만 허용
+        requires std::invocable<Fn>
+              && std::same_as<std::invoke_result_t<Fn>, JobTask<void>>
     [[nodiscard]] JobHandle SubmitTask(Fn&& factory, EJobPriority priority = EJobPriority::Normal);
 
 public:

--- a/EngineCore/Include/SimpleEngine/Core/Engine/Engine.h
+++ b/EngineCore/Include/SimpleEngine/Core/Engine/Engine.h
@@ -10,6 +10,7 @@
 namespace se
 {
 // forward declaration
+class AsyncFileIO;
 class IUpdatable;
 class JobSystem;
 class SubsystemBase;
@@ -99,6 +100,9 @@ private:
 
     // JobSystem의 싱글톤 Instance를 Engine에서 관리하기 위한 포인터
     std::unique_ptr<JobSystem> job_system;
+
+    // AsyncFileIO의 싱글톤 Instance를 Engine에서 관리하기 위한 포인터
+    std::unique_ptr<AsyncFileIO> async_io_service;
 };
 
 

--- a/EngineCore/Source/Core/Concurrency/AsyncFileIO.cpp
+++ b/EngineCore/Source/Core/Concurrency/AsyncFileIO.cpp
@@ -1,0 +1,279 @@
+﻿// ReSharper disable CppMemberFunctionMayBeConst
+#include "SimpleEngine/Core/Concurrency/AsyncFileIO.h"
+#include "SimpleEngine/Core/Concurrency/JobAllocator.h"
+#include "SimpleEngine/Core/Concurrency/JobSystem.h"
+#include "SimpleEngine/Core/Concurrency/Coroutine/JobTask.h"
+#include "SimpleEngine/Core/Container/String.h"
+#include "SimpleEngine/Core/HAL/Platform.h"
+#include "SimpleEngine/Core/Logging/Logging.h"
+#include "SimpleEngine/Utility/Debug.h"
+
+#include <coroutine>
+
+#include "SimpleEngine/Utility/Common.h"
+
+
+namespace se
+{
+namespace
+{
+/**
+ * 비동기 I/O 요청의 컨텍스트
+ *
+ * SDL_AsyncIO에 전달하는 userdata로 사용되며,
+ * Poller Thread가 완료를 감지했을 때 적절한 방식(콜백/코루틴)으로 결과를 전달합니다.
+ */
+struct IORequestContext
+{
+    enum class EMode : uint8
+    {
+        Callback,  // UniqueFunction 콜백 호출
+        Coroutine, // 코루틴 핸들 resume
+    };
+
+    /** 요청 모드 */
+    EMode mode = EMode::Callback;
+
+    /** 콜백 모드에서 I/O 완료 시 호출할 함수 */
+    UniqueFunction<void(IOResult)> callback;
+
+    /** 코루틴 모드에서 I/O 완료 시 재개할 코루틴 핸들 */
+    std::coroutine_handle<> continuation;
+
+    /** 코루틴 모드에서 결과를 저장할 위치 (코루틴 프레임 내부를 가리킴) */
+    IOResult* result_storage = nullptr;
+
+    // JobAllocator 기반 메모리 할당
+    void* operator new(usize size) { return JobAllocator::Allocate(size); }
+    void operator delete(void* ptr) { JobAllocator::Free(ptr); }
+};
+
+
+/**
+ * 비동기 파일 읽기를 위한 코루틴 Awaitable
+ *
+ * await_suspend에서 SDL_LoadFileAsync를 호출하고,
+ * Poller Thread가 완료를 감지하면 result에 데이터를 기록한 뒤 코루틴을 재개합니다.
+ */
+struct AsyncReadAwaitable
+{
+    SDL_AsyncIOQueue* queue;
+    Path path;
+    IOResult result; // 코루틴 프레임에 저장되어 suspension 동안 유효
+
+    bool await_ready() const noexcept
+    {
+        return false;
+    }
+
+    bool await_suspend(std::coroutine_handle<> handle)
+    {
+        IORequestContext* ctx = new IORequestContext{};
+        SE_SCOPE_DEFER_NAMED(ctx_delete) {
+            delete ctx;
+        };
+
+        ctx->mode = IORequestContext::EMode::Coroutine;
+        ctx->continuation = handle;
+        ctx->result_storage = &result;
+
+        const String str_path = path.ToString();
+        if (!SDL_LoadFileAsync(str_path.CStr(), queue, ctx))
+        {
+            // SDL이 요청을 시작조차 하지 못한 경우, suspend하지 않고 즉시 복귀
+            result.success = false;
+            return false;
+        }
+
+        ctx_delete.Discard();
+        return true;
+    }
+
+    IOResult await_resume()
+    {
+        return std::move(result);
+    }
+};
+
+
+/**
+ * SDL_AsyncIOOutcome으로부터 IOResult를 생성합니다.
+ * SDL이 할당한 버퍼의 데이터를 Array<uint8>로 복사한 뒤, SDL 버퍼를 해제합니다.
+ */
+IOResult BuildIOResult(SDL_AsyncIOOutcome&& outcome)
+{
+    IOResult result;
+    result.success = outcome.result == SDL_ASYNCIO_COMPLETE;
+
+    if (result.success && outcome.buffer && outcome.bytes_transferred > 0)
+    {
+        // outcome.buffer의 소유권을 IOResult로 이동
+        result.data.reset(static_cast<uint8*>(outcome.buffer));
+        result.bytes_transferred = static_cast<usize>(outcome.bytes_transferred);
+    }
+    else if (outcome.buffer)
+    {
+        // 실패했거나 바이트가 0일 때만 해제
+        SDL_free(outcome.buffer);
+        outcome.buffer = nullptr;
+    }
+
+    return result;
+}
+} // namespace
+
+
+AsyncFileIO* AsyncFileIO::instance = nullptr;
+
+AsyncFileIO::AsyncFileIO()
+{
+    SE_ASSERT(!AsyncFileIO::instance, "AsyncFileIO instance already exists!");
+    AsyncFileIO::instance = this;
+
+    io_queue = SDL_CreateAsyncIOQueue();
+    SE_ASSERT(io_queue, "Failed to create SDL_AsyncIOQueue");
+
+    poller_thread = std::jthread{ [this](const std::stop_token& stoken)
+    {
+        PollerLoop(stoken);
+    }};
+
+    ConsoleLog(ELogLevel::Info, "AsyncFileIO: Initialized");
+}
+
+AsyncFileIO::~AsyncFileIO()
+{
+    SE_ASSERT(AsyncFileIO::instance == this, "AsyncFileIO instance mismatch!");
+
+    // Poller Thread를 안전하게 종료
+    if (poller_thread.joinable())
+    {
+        poller_thread.request_stop();
+
+        // SDL WaitAsyncIOResult의 블로킹을 즉시 해제
+        if (io_queue)
+        {
+            SDL_SignalAsyncIOQueue(io_queue);
+        }
+
+        poller_thread.join();
+    }
+
+    // SDL 큐 해제 (대기 중인 I/O는 SDL이 내부적으로 처리)
+    if (io_queue)
+    {
+        SDL_DestroyAsyncIOQueue(io_queue);
+        io_queue = nullptr;
+    }
+
+    AsyncFileIO::instance = nullptr;
+    ConsoleLog(ELogLevel::Info, "AsyncFileIO: Destroyed");
+}
+
+AsyncFileIO& AsyncFileIO::Get()
+{
+    SE_ASSERT(AsyncFileIO::instance, "AsyncFileIO instance is not initialized!");
+    return *AsyncFileIO::instance;
+}
+
+bool AsyncFileIO::IsInitialized()
+{
+    return AsyncFileIO::instance != nullptr;
+}
+
+void AsyncFileIO::ReadFile(const Path& path, UniqueFunction<void(IOResult)>&& callback)
+{
+    IORequestContext* ctx = new IORequestContext{};
+    ctx->mode = IORequestContext::EMode::Callback;
+    ctx->callback = std::move(callback);
+
+    const String str_path = path.ToString();
+    if (!SDL_LoadFileAsync(str_path.CStr(), io_queue, ctx))
+    {
+        // Load에 실패한 경우, 에러 결과를 Worker에서 전달 (Poller에서 직접 실행 금지)
+        JobSystem::Get().Dispatch([ctx]
+        {
+            IOResult error_result;
+            error_result.success = false;
+
+            const auto cb = std::move(ctx->callback);
+            delete ctx;
+            cb(std::move(error_result));
+        });
+    }
+}
+
+JobTask<IOResult> AsyncFileIO::ReadFileAsync(const Path& path)
+{
+    co_return co_await AsyncReadAwaitable{ io_queue, path };
+}
+
+void AsyncFileIO::PollerLoop(const std::stop_token& stoken)
+{
+    Platform::SetCurrentThreadName("AsyncIO Poller");
+
+    while (!stoken.stop_requested())
+    {
+        SDL_AsyncIOOutcome outcome{};
+
+        // Signal이 올 때 까지 무한 대기
+        if (!SDL_WaitAsyncIOResult(io_queue, &outcome, -1))
+        {
+            continue;
+        }
+
+        std::unique_ptr<IORequestContext> ctx{ static_cast<IORequestContext*>(outcome.userdata) };
+        if (!ctx)
+        {
+            // userdata가 없는 결과는 무시 (SDL 내부 이벤트 등)
+            if (outcome.buffer)
+            {
+                SDL_free(outcome.buffer);
+            }
+            continue;
+        }
+
+        // SDL 결과를 엔진 IOResult로 변환
+        IOResult result = BuildIOResult(std::move(outcome));
+
+        // Context Mode에 따른 분기
+        switch (ctx->mode)
+        {
+        case IORequestContext::EMode::Callback:
+        {
+            JobSystem::Get().Dispatch([safe_ctx = std::move(ctx), ret = std::move(result)] mutable
+            {
+                const auto cb = std::move(safe_ctx->callback);
+
+                // 콜백을 실행하기 전에 컨텍스트 메모리를 먼저 해제
+                safe_ctx.reset();
+
+                cb(std::move(ret));
+            });
+            break;
+        }
+
+        case IORequestContext::EMode::Coroutine:
+        {
+            // 코루틴 프레임의 result_storage에 결과를 기록
+            // 이후 JobSystem::Dispatch 의한 release/acquire가 happens-before를 보장
+            *ctx->result_storage = std::move(result);
+            const auto handle = ctx->continuation;
+
+            // 콜백을 실행하기 전에 컨텍스트 메모리를 먼저 해제
+            ctx.reset();
+
+            // Worker 스레드에서 코루틴 재개
+            JobSystem::Get().Dispatch([handle]
+            {
+                handle.resume();
+            });
+            break;
+        }
+
+        default:
+            SE_UNREACHABLE();
+        }
+    }
+}
+} // namespace se

--- a/EngineCore/Source/Core/Concurrency/Coroutine/CoroutinePrimitives.cpp
+++ b/EngineCore/Source/Core/Concurrency/Coroutine/CoroutinePrimitives.cpp
@@ -33,7 +33,9 @@ void ScheduleCoroutineResumeOnMain(std::coroutine_handle<> handle)
 
 bool ResumeOn::await_ready() const noexcept
 {
-    // TODO: 현재 스레드가 target이면 true를 반환하도록 최적화
+    // 항상 false를 반환하여 무조건 재스케줄링합니다.
+    // 최적화 여지: TLS CurrentWorkerIndex를 검사하여 이미 target 스레드에 있으면
+    // true를 반환할 수 있으나, Worker간 재분배가 필요한 경우를 고려하여 보류.
     return false;
 }
 

--- a/EngineCore/Source/Core/Concurrency/Coroutine/CoroutinePrimitives.cpp
+++ b/EngineCore/Source/Core/Concurrency/Coroutine/CoroutinePrimitives.cpp
@@ -46,12 +46,6 @@ void ResumeOn::await_suspend(std::coroutine_handle<> handle) const
         break;
 
     case EJobThread::Worker:
-    case EJobThread::Auto:
-        ScheduleCoroutineResume(handle);
-        break;
-
-    case EJobThread::IO:
-        // TODO: SDL3_AsyncIO로 IO 전용 스레드 구현. 일단 Worker로 Fallback
         ScheduleCoroutineResume(handle);
         break;
     }

--- a/EngineCore/Source/Core/Concurrency/JobSystem.cpp
+++ b/EngineCore/Source/Core/Concurrency/JobSystem.cpp
@@ -1,6 +1,7 @@
 ﻿// ReSharper disable CppMemberFunctionMayBeConst
 #include "SimpleEngine/Core/Concurrency/JobSystem.h"
 
+#include "SimpleEngine/Core/Concurrency/Coroutine/JobTask.h"
 #include "SimpleEngine/Core/Container/String.h"
 #include "SimpleEngine/Core/Logging/Logging.h"
 #include "SimpleEngine/Utility/Debug.h"
@@ -378,5 +379,46 @@ JobPayload* JobSystem::TryPopGlobal()
     }
 
     return first_to_run;
+}
+
+void JobSystem::DispatchTask(JobTask<void>&& task, EJobPriority priority)
+{
+    SE_ASSERT(task.handle, "Cannot dispatch an empty JobTask");
+    SE_ASSERT(!task.handle.done(), "Cannot dispatch an already completed JobTask");
+
+    task.handle.promise().detached = true;
+
+    // 소유권 이전
+    auto coro = std::exchange(task.handle, nullptr);
+
+    // 워커 스레드에서 코루틴 시작
+    Dispatch([coro]
+    {
+        coro.resume();
+    }, priority);
+}
+
+JobHandle JobSystem::SubmitTask(JobTask<void>&& task, EJobPriority priority)
+{
+    SE_ASSERT(task.handle, "Cannot submit an empty JobTask");
+    SE_ASSERT(!task.handle.done(), "Cannot submit an already completed JobTask");
+
+    auto& promise = task.handle.promise();
+    promise.detached = true;
+
+    // 완료 추적용 카운터 생성
+    JobHandle handle = JobHandle::Create(1);
+    promise.completion_counter = handle.GetSharedCounter();
+
+    // task의 handle을 빼내어 RAII 파괴를 방지 (소유권 이전)
+    auto coro = std::exchange(task.handle, nullptr);
+
+    // 워커 스레드에서 코루틴 시작
+    Dispatch([coro]
+    {
+        coro.resume();
+    }, priority);
+
+    return handle;
 }
 } // namespace se

--- a/EngineCore/Source/Core/Engine/Engine.cpp
+++ b/EngineCore/Source/Core/Engine/Engine.cpp
@@ -2,6 +2,7 @@
 
 #include <ranges>
 
+#include "SimpleEngine/Core/Concurrency/AsyncFileIO.h"
 #include "SimpleEngine/Core/Concurrency/JobSystem.h"
 #include "SimpleEngine/Core/Config/ConfigFile.h"
 #include "SimpleEngine/Core/Container/Array.h"
@@ -139,6 +140,7 @@ bool Engine::Initialize()
     }
 
     job_system = std::make_unique<JobSystem>();
+    async_io_service = std::make_unique<AsyncFileIO>();
 
     // 의존성에 따라서 정렬
     if (!SortSubsystems())
@@ -162,6 +164,7 @@ void Engine::Release()
     sorted_subsystems.Clear();
     subsystems.Clear();
 
+    async_io_service.reset();
     job_system.reset();
     JobAllocator::Shutdown();
 

--- a/EngineCore/Source/Core/Logging/Backends/FileBackend.cpp
+++ b/EngineCore/Source/Core/Logging/Backends/FileBackend.cpp
@@ -2,6 +2,8 @@
 #include "SimpleEngine/Core/FileSystem/FileSystem.h"
 #include "SimpleEngine/Core/HAL/Platform.h"
 
+#include "SDL3/SDL.h"
+
 
 namespace se
 {

--- a/EngineTest/Source/UnitTests/AsyncFileIOTest.cpp
+++ b/EngineTest/Source/UnitTests/AsyncFileIOTest.cpp
@@ -129,26 +129,14 @@ TEST_F(AsyncFileIOTest, ReadFile_Callback_ExecutedOnWorker)
 
 TEST_F(AsyncFileIOTest, ReadFileAsync_Success)
 {
-    std::atomic<bool> done = false;
     IOResult captured_result;
 
-    JobHandle h = JobSystem::Get().SubmitTask(
-        [](std::string path, IOResult& captured_result, std::atomic<bool>& done) static -> JobTask<void>
-        {
-            IOResult result = co_await AsyncFileIO::Get().ReadFileAsync(Path{ path.c_str() });
-            captured_result = std::move(result);
-            done.store(true, std::memory_order_release);
-        }(test_file_path, captured_result, done));
-
-    const auto start = std::chrono::steady_clock::now();
-    while (!done.load(std::memory_order_acquire))
+    JobHandle h = JobSystem::Get().SubmitTask([](std::string path, IOResult& captured_result) static -> JobTask<void>
     {
-        if (std::chrono::steady_clock::now() - start > 5s)
-        {
-            FAIL() << "ReadFileAsync 타임아웃";
-        }
-        std::this_thread::yield();
-    }
+        IOResult result = co_await AsyncFileIO::Get().ReadFileAsync(Path{ path.c_str() });
+        captured_result = std::move(result);
+        co_return;
+    }(test_file_path, captured_result));
 
     h.Wait();
 

--- a/EngineTest/Source/UnitTests/AsyncFileIOTest.cpp
+++ b/EngineTest/Source/UnitTests/AsyncFileIOTest.cpp
@@ -1,0 +1,281 @@
+﻿#include "gtest/gtest.h"
+
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <future>
+#include <thread>
+
+#include "SimpleEngine/Core/Concurrency/AsyncFileIO.h"
+#include "SimpleEngine/Core/Concurrency/Coroutine/JobTask.h"
+#include "SimpleEngine/Core/Concurrency/JobSystem.h"
+#include "SimpleEngine/Core/Types/Path.h"
+
+using namespace se;
+using namespace std::chrono_literals;
+
+
+// ═══════════════════════════════════════════════════════════════════
+//  Test Fixture: AsyncFileIO 기반 비동기 I/O 테스트
+// ═══════════════════════════════════════════════════════════════════
+
+class AsyncFileIOTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        job_system = std::make_unique<JobSystem>(4);
+        async_io = std::make_unique<AsyncFileIO>();
+
+        // 테스트용 임시 파일 생성
+        test_file_path = (std::filesystem::temp_directory_path() / "se_asyncio_test.txt").string();
+        std::ofstream ofs(test_file_path);
+        ofs << test_content;
+        ofs.close();
+    }
+
+    void TearDown() override
+    {
+        async_io.reset();
+        job_system.reset();
+
+        // 임시 파일 정리
+        std::filesystem::remove(test_file_path);
+    }
+
+    template <typename T>
+    static void WaitForDone(const JobTask<T>& task, std::chrono::milliseconds timeout = 5s)
+    {
+        const auto start = std::chrono::steady_clock::now();
+        while (!task.handle.done())
+        {
+            if (std::chrono::steady_clock::now() - start > timeout)
+            {
+                FAIL() << "코루틴이 타임아웃 내에 완료되지 않았습니다.";
+            }
+            std::this_thread::yield();
+        }
+    }
+
+    std::unique_ptr<JobSystem> job_system;
+    std::unique_ptr<AsyncFileIO> async_io;
+
+    std::string test_file_path;
+    static constexpr const char* test_content = "Hello, AsyncIO!";
+};
+
+
+// ═══════════════════════════════════════════════════════════════════
+//  싱글톤 기본 동작
+// ═══════════════════════════════════════════════════════════════════
+
+TEST_F(AsyncFileIOTest, SingletonLifetime)
+{
+    EXPECT_TRUE(AsyncFileIO::IsInitialized());
+    EXPECT_NO_THROW(AsyncFileIO::Get());
+}
+
+
+// ═══════════════════════════════════════════════════════════════════
+//  ReadFile: 콜백 기반 비동기 읽기
+// ═══════════════════════════════════════════════════════════════════
+
+TEST_F(AsyncFileIOTest, ReadFile_Callback_Success)
+{
+    std::promise<IOResult> promise;
+    auto future = promise.get_future();
+
+    async_io->ReadFile(Path{ test_file_path.c_str() }, [&promise](IOResult result)
+    {
+        promise.set_value(std::move(result));
+    });
+
+    ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
+    const IOResult result = future.get();
+
+    EXPECT_TRUE(result.success);
+    EXPECT_EQ(result.bytes_transferred, std::strlen(test_content));
+    EXPECT_EQ(std::memcmp(result.data.get(), test_content, result.bytes_transferred), 0);
+}
+
+TEST_F(AsyncFileIOTest, ReadFile_Callback_NonExistent)
+{
+    std::promise<IOResult> promise;
+    auto future = promise.get_future();
+
+    async_io->ReadFile("__non_existent_file_12345__.txt", [&promise](IOResult result)
+    {
+        promise.set_value(std::move(result));
+    });
+
+    ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
+    const IOResult result = future.get();
+
+    EXPECT_FALSE(result.success);
+}
+
+TEST_F(AsyncFileIOTest, ReadFile_Callback_ExecutedOnWorker)
+{
+    // 콜백이 Poller Thread가 아닌 Worker 스레드에서 실행되는지 확인
+    std::promise<std::thread::id> promise;
+    auto future = promise.get_future();
+
+    const auto main_thread_id = std::this_thread::get_id();
+
+    async_io->ReadFile(Path{ test_file_path.c_str() }, [&promise](IOResult)
+    {
+        promise.set_value(std::this_thread::get_id());
+    });
+
+    ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
+    const auto callback_thread_id = future.get();
+
+    // 콜백은 메인 스레드에서 실행되지 않아야 한다 (Worker에서 실행)
+    EXPECT_NE(callback_thread_id, main_thread_id);
+}
+
+
+// ═══════════════════════════════════════════════════════════════════
+//  ReadFileAsync: 코루틴 기반 비동기 읽기
+// ═══════════════════════════════════════════════════════════════════
+
+TEST_F(AsyncFileIOTest, ReadFileAsync_Success)
+{
+    std::atomic<bool> done = false;
+    IOResult captured_result;
+
+    auto task = [&]() -> JobTask<void>
+    {
+        IOResult result = co_await AsyncFileIO::Get().ReadFileAsync(Path{ test_file_path.c_str() });
+        captured_result = std::move(result);
+        done.store(true, std::memory_order_release);
+    }();
+
+    // 코루틴을 시작 (Lazy Start이므로 수동 resume 필요)
+    task.handle.resume();
+
+    const auto start = std::chrono::steady_clock::now();
+    while (!done.load(std::memory_order_acquire))
+    {
+        if (std::chrono::steady_clock::now() - start > 5s)
+        {
+            FAIL() << "ReadFileAsync 타임아웃";
+        }
+        std::this_thread::yield();
+    }
+
+    WaitForDone(task);
+
+    EXPECT_TRUE(captured_result.success);
+    EXPECT_EQ(captured_result.bytes_transferred, std::strlen(test_content));
+    EXPECT_EQ(std::memcmp(captured_result.data.get(), test_content, captured_result.bytes_transferred), 0);
+}
+
+TEST_F(AsyncFileIOTest, ReadFileAsync_NonExistent)
+{
+    std::atomic<bool> done = false;
+    IOResult captured_result;
+
+    auto task = [&]() -> JobTask<void>
+    {
+        IOResult result = co_await AsyncFileIO::Get().ReadFileAsync("__non_existent_file_99999__.txt");
+        captured_result = std::move(result);
+        done.store(true, std::memory_order_release);
+    }();
+
+    task.handle.resume();
+
+    const auto start = std::chrono::steady_clock::now();
+    while (!done.load(std::memory_order_acquire))
+    {
+        if (std::chrono::steady_clock::now() - start > 5s)
+        {
+            FAIL() << "ReadFileAsync(non-existent) 타임아웃";
+        }
+        std::this_thread::yield();
+    }
+
+    WaitForDone(task);
+
+    EXPECT_FALSE(captured_result.success);
+}
+
+
+// ═══════════════════════════════════════════════════════════════════
+//  동시 다중 요청
+// ═══════════════════════════════════════════════════════════════════
+
+TEST_F(AsyncFileIOTest, ReadFile_MultipleRequests)
+{
+    constexpr int NUM_REQUESTS = 10;
+    std::atomic<int> completed_count = 0;
+
+    for (int i = 0; i < NUM_REQUESTS; ++i)
+    {
+        async_io->ReadFile(Path{ test_file_path.c_str() }, [&completed_count](IOResult result)
+        {
+            if (result.success)
+            {
+                completed_count.fetch_add(1, std::memory_order_relaxed);
+            }
+        });
+    }
+
+    const auto start = std::chrono::steady_clock::now();
+    while (completed_count.load(std::memory_order_relaxed) < NUM_REQUESTS)
+    {
+        if (std::chrono::steady_clock::now() - start > 10s)
+        {
+            FAIL() << "다중 요청 타임아웃. 완료: " << completed_count.load();
+        }
+        std::this_thread::yield();
+    }
+
+    EXPECT_EQ(completed_count.load(), NUM_REQUESTS);
+}
+
+TEST_F(AsyncFileIOTest, ReadFileAsync_MultipleCoroutines)
+{
+    constexpr int NUM_REQUESTS = 5;
+    std::atomic<int> completed_count = 0;
+
+    Array<JobTask<void>> tasks;
+    tasks.Reserve(NUM_REQUESTS);
+
+    for (int i = 0; i < NUM_REQUESTS; ++i)
+    {
+        tasks.Emplace([&]() -> JobTask<void>
+        {
+            IOResult result = co_await AsyncFileIO::Get().ReadFileAsync(Path{ test_file_path.c_str() });
+            if (result.success)
+            {
+                completed_count.fetch_add(1, std::memory_order_relaxed);
+            }
+        }());
+    }
+
+    // 모든 코루틴을 시작
+    for (auto& task : tasks)
+    {
+        task.handle.resume();
+    }
+
+    const auto start = std::chrono::steady_clock::now();
+    while (completed_count.load(std::memory_order_relaxed) < NUM_REQUESTS)
+    {
+        if (std::chrono::steady_clock::now() - start > 10s)
+        {
+            FAIL() << "다중 코루틴 타임아웃. 완료: " << completed_count.load();
+        }
+        std::this_thread::yield();
+    }
+
+    // 모든 코루틴이 정상 종료될 때까지 대기
+    for (const auto& task : tasks)
+    {
+        WaitForDone(task);
+    }
+
+    EXPECT_EQ(completed_count.load(), NUM_REQUESTS);
+}

--- a/EngineTest/Source/UnitTests/AsyncFileIOTest.cpp
+++ b/EngineTest/Source/UnitTests/AsyncFileIOTest.cpp
@@ -8,6 +8,7 @@
 #include <thread>
 
 #include "SimpleEngine/Core/Concurrency/AsyncFileIO.h"
+#include "SimpleEngine/Core/Concurrency/Coroutine/CoroutinePrimitives.h"
 #include "SimpleEngine/Core/Concurrency/Coroutine/JobTask.h"
 #include "SimpleEngine/Core/Concurrency/JobSystem.h"
 #include "SimpleEngine/Core/Types/Path.h"
@@ -42,20 +43,6 @@ protected:
 
         // 임시 파일 정리
         std::filesystem::remove(test_file_path);
-    }
-
-    template <typename T>
-    static void WaitForDone(const JobTask<T>& task, std::chrono::milliseconds timeout = 5s)
-    {
-        const auto start = std::chrono::steady_clock::now();
-        while (!task.handle.done())
-        {
-            if (std::chrono::steady_clock::now() - start > timeout)
-            {
-                FAIL() << "코루틴이 타임아웃 내에 완료되지 않았습니다.";
-            }
-            std::this_thread::yield();
-        }
     }
 
     std::unique_ptr<JobSystem> job_system;
@@ -145,15 +132,12 @@ TEST_F(AsyncFileIOTest, ReadFileAsync_Success)
     std::atomic<bool> done = false;
     IOResult captured_result;
 
-    auto task = [&]() -> JobTask<void>
+    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
     {
         IOResult result = co_await AsyncFileIO::Get().ReadFileAsync(Path{ test_file_path.c_str() });
         captured_result = std::move(result);
         done.store(true, std::memory_order_release);
-    }();
-
-    // 코루틴을 시작 (Lazy Start이므로 수동 resume 필요)
-    task.handle.resume();
+    }());
 
     const auto start = std::chrono::steady_clock::now();
     while (!done.load(std::memory_order_acquire))
@@ -165,7 +149,7 @@ TEST_F(AsyncFileIOTest, ReadFileAsync_Success)
         std::this_thread::yield();
     }
 
-    WaitForDone(task);
+    h.Wait();
 
     EXPECT_TRUE(captured_result.success);
     EXPECT_EQ(captured_result.bytes_transferred, std::strlen(test_content));
@@ -177,14 +161,12 @@ TEST_F(AsyncFileIOTest, ReadFileAsync_NonExistent)
     std::atomic<bool> done = false;
     IOResult captured_result;
 
-    auto task = [&]() -> JobTask<void>
+    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
     {
         IOResult result = co_await AsyncFileIO::Get().ReadFileAsync("__non_existent_file_99999__.txt");
         captured_result = std::move(result);
         done.store(true, std::memory_order_release);
-    }();
-
-    task.handle.resume();
+    }());
 
     const auto start = std::chrono::steady_clock::now();
     while (!done.load(std::memory_order_acquire))
@@ -196,7 +178,7 @@ TEST_F(AsyncFileIOTest, ReadFileAsync_NonExistent)
         std::this_thread::yield();
     }
 
-    WaitForDone(task);
+    h.Wait();
 
     EXPECT_FALSE(captured_result.success);
 }
@@ -240,25 +222,19 @@ TEST_F(AsyncFileIOTest, ReadFileAsync_MultipleCoroutines)
     constexpr int NUM_REQUESTS = 5;
     std::atomic<int> completed_count = 0;
 
-    Array<JobTask<void>> tasks;
-    tasks.Reserve(NUM_REQUESTS);
+    Array<JobHandle> handles;
+    handles.Reserve(NUM_REQUESTS);
 
     for (int i = 0; i < NUM_REQUESTS; ++i)
     {
-        tasks.Emplace([&]() -> JobTask<void>
+        handles.Push(JobSystem::Get().SubmitTask([&]() -> JobTask<void>
         {
             IOResult result = co_await AsyncFileIO::Get().ReadFileAsync(Path{ test_file_path.c_str() });
             if (result.success)
             {
                 completed_count.fetch_add(1, std::memory_order_relaxed);
             }
-        }());
-    }
-
-    // 모든 코루틴을 시작
-    for (auto& task : tasks)
-    {
-        task.handle.resume();
+        }()));
     }
 
     const auto start = std::chrono::steady_clock::now();
@@ -272,9 +248,9 @@ TEST_F(AsyncFileIOTest, ReadFileAsync_MultipleCoroutines)
     }
 
     // 모든 코루틴이 정상 종료될 때까지 대기
-    for (const auto& task : tasks)
+    for (const auto& h : handles)
     {
-        WaitForDone(task);
+        h.Wait();
     }
 
     EXPECT_EQ(completed_count.load(), NUM_REQUESTS);

--- a/EngineTest/Source/UnitTests/AsyncFileIOTest.cpp
+++ b/EngineTest/Source/UnitTests/AsyncFileIOTest.cpp
@@ -132,12 +132,13 @@ TEST_F(AsyncFileIOTest, ReadFileAsync_Success)
     std::atomic<bool> done = false;
     IOResult captured_result;
 
-    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
-    {
-        IOResult result = co_await AsyncFileIO::Get().ReadFileAsync(Path{ test_file_path.c_str() });
-        captured_result = std::move(result);
-        done.store(true, std::memory_order_release);
-    }());
+    JobHandle h = JobSystem::Get().SubmitTask(
+        [](std::string path, IOResult& captured_result, std::atomic<bool>& done) static -> JobTask<void>
+        {
+            IOResult result = co_await AsyncFileIO::Get().ReadFileAsync(Path{ path.c_str() });
+            captured_result = std::move(result);
+            done.store(true, std::memory_order_release);
+        }(test_file_path, captured_result, done));
 
     const auto start = std::chrono::steady_clock::now();
     while (!done.load(std::memory_order_acquire))
@@ -161,12 +162,13 @@ TEST_F(AsyncFileIOTest, ReadFileAsync_NonExistent)
     std::atomic<bool> done = false;
     IOResult captured_result;
 
-    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
-    {
-        IOResult result = co_await AsyncFileIO::Get().ReadFileAsync("__non_existent_file_99999__.txt");
-        captured_result = std::move(result);
-        done.store(true, std::memory_order_release);
-    }());
+    JobHandle h = JobSystem::Get().SubmitTask(
+        [](IOResult& captured_result, std::atomic<bool>& done) static -> JobTask<void>
+        {
+            IOResult result = co_await AsyncFileIO::Get().ReadFileAsync("__non_existent_file_99999__.txt");
+            captured_result = std::move(result);
+            done.store(true, std::memory_order_release);
+        }(captured_result, done));
 
     const auto start = std::chrono::steady_clock::now();
     while (!done.load(std::memory_order_acquire))
@@ -227,14 +229,15 @@ TEST_F(AsyncFileIOTest, ReadFileAsync_MultipleCoroutines)
 
     for (int i = 0; i < NUM_REQUESTS; ++i)
     {
-        handles.Push(JobSystem::Get().SubmitTask([&]() -> JobTask<void>
-        {
-            IOResult result = co_await AsyncFileIO::Get().ReadFileAsync(Path{ test_file_path.c_str() });
-            if (result.success)
+        handles.Push(JobSystem::Get().SubmitTask(
+            [](std::string path, std::atomic<int>& count) static -> JobTask<void>
             {
-                completed_count.fetch_add(1, std::memory_order_relaxed);
-            }
-        }()));
+                IOResult result = co_await AsyncFileIO::Get().ReadFileAsync(Path{ path.c_str() });
+                if (result.success)
+                {
+                    count.fetch_add(1, std::memory_order_relaxed);
+                }
+            }(test_file_path, completed_count)));
     }
 
     const auto start = std::chrono::steady_clock::now();

--- a/EngineTest/Source/UnitTests/CoroutineTest.cpp
+++ b/EngineTest/Source/UnitTests/CoroutineTest.cpp
@@ -30,24 +30,6 @@ protected:
         system.reset();
     }
 
-    /**
-     * 코루틴이 final_suspend에 도달할 때까지 대기합니다.
-     * 코루틴 프레임을 안전하게 소멸하기 위해 테스트 종료 전에 호출합니다.
-     */
-    template <typename T>
-    static void WaitForDone(const JobTask<T>& task, std::chrono::milliseconds timeout = 5s)
-    {
-        const auto start = std::chrono::steady_clock::now();
-        while (!task.handle.done())
-        {
-            if (std::chrono::steady_clock::now() - start > timeout)
-            {
-                FAIL() << "코루틴이 타임아웃 내에 완료되지 않았습니다.";
-            }
-            std::this_thread::yield();
-        }
-    }
-
     std::unique_ptr<JobSystem> system;
 };
 
@@ -203,32 +185,28 @@ TEST_F(CoroutineTest, ResumeOn_Worker)
     std::promise<std::thread::id> promise;
     auto future = promise.get_future();
 
-    auto task = [&]() -> JobTask<void>
+    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
     {
         co_await ResumeOn{ EJobThread::Worker };
         promise.set_value(std::this_thread::get_id());
         co_return;
-    }();
-
-    task.handle.resume();
+    }());
 
     ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
     EXPECT_NE(future.get(), std::this_thread::get_id());
-    WaitForDone(task);
+    h.Wait();
 }
 
 TEST_F(CoroutineTest, ResumeOn_Main)
 {
     std::atomic<bool> executed = false;
 
-    auto task = [&]() -> JobTask<void>
+    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
     {
         co_await ResumeOn{ EJobThread::Main };
         executed.store(true, std::memory_order_release);
         co_return;
-    }();
-
-    task.handle.resume();
+    }());
 
     // 메인 큐를 드레인하기 전에는 실행되지 않습니다
     std::this_thread::sleep_for(10ms);
@@ -238,7 +216,7 @@ TEST_F(CoroutineTest, ResumeOn_Main)
     JobSystem::Get().ExecuteMainThreadJobs();
     EXPECT_TRUE(executed.load(std::memory_order_acquire));
 
-    while (!task.handle.done())
+    while (!h.IsComplete())
     {
         JobSystem::Get().ExecuteMainThreadJobs();
         std::this_thread::yield();
@@ -252,7 +230,7 @@ TEST_F(CoroutineTest, ResumeOn_PreservesThreadAfterChildReturn)
     std::promise<bool> promise;
     auto future = promise.get_future();
 
-    auto task = [&]() -> JobTask<void>
+    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
     {
         co_await ResumeOn{ EJobThread::Worker };
         auto tid_before = std::this_thread::get_id();
@@ -263,13 +241,11 @@ TEST_F(CoroutineTest, ResumeOn_PreservesThreadAfterChildReturn)
         // Symmetric Transfer이므로 스레드가 유지됩니다
         promise.set_value(std::this_thread::get_id() == tid_before);
         co_return;
-    }();
-
-    task.handle.resume();
+    }());
 
     ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
     EXPECT_TRUE(future.get());
-    WaitForDone(task);
+    h.Wait();
 }
 
 
@@ -288,18 +264,16 @@ TEST_F(CoroutineTest, WhenAll_MultipleJobs)
     std::promise<int> promise;
     auto future = promise.get_future();
 
-    auto task = [&]() -> JobTask<void>
+    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
     {
         co_await WhenAll{ { a, b, c } };
         promise.set_value(counter.load(std::memory_order_relaxed));
         co_return;
-    }();
-
-    task.handle.resume();
+    }());
 
     ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
     EXPECT_EQ(future.get(), 111);
-    WaitForDone(task);
+    h.Wait();
 }
 
 TEST_F(CoroutineTest, WhenAll_AlreadyComplete)
@@ -310,18 +284,16 @@ TEST_F(CoroutineTest, WhenAll_AlreadyComplete)
     std::promise<bool> promise;
     auto future = promise.get_future();
 
-    auto task = [&]() -> JobTask<void>
+    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
     {
         co_await WhenAll{ { handle } };
         promise.set_value(true);
         co_return;
-    }();
-
-    task.handle.resume();
+    }());
 
     ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
     EXPECT_TRUE(future.get());
-    WaitForDone(task);
+    h.Wait();
 }
 
 TEST_F(CoroutineTest, WhenAll_Empty)
@@ -353,18 +325,16 @@ TEST_F(CoroutineTest, WhenAll_AllAlreadyComplete)
     std::promise<bool> promise;
     auto future = promise.get_future();
 
-    auto task = [&]() -> JobTask<void>
+    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
     {
         co_await WhenAll{ { h1, h2, h3 } };
         promise.set_value(true);
         co_return;
-    }();
-
-    task.handle.resume();
+    }());
 
     ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
     EXPECT_TRUE(future.get());
-    WaitForDone(task);
+    h.Wait();
 }
 
 TEST_F(CoroutineTest, WhenAll_MixedComplete)
@@ -379,18 +349,16 @@ TEST_F(CoroutineTest, WhenAll_MixedComplete)
     std::promise<bool> promise;
     auto future = promise.get_future();
 
-    auto task = [&]() -> JobTask<void>
+    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
     {
         co_await WhenAll{ { already_done, pending } };
         promise.set_value(counter.load(std::memory_order_relaxed) == 1);
         co_return;
-    }();
-
-    task.handle.resume();
+    }());
 
     ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
     EXPECT_TRUE(future.get());
-    WaitForDone(task);
+    h.Wait();
 }
 
 
@@ -414,21 +382,19 @@ TEST_F(CoroutineTest, WhenAny_FirstComplete)
     std::promise<bool> promise;
     auto future = promise.get_future();
 
-    auto task = [&]() -> JobTask<void>
+    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
     {
         co_await WhenAny{ { fast, slow } };
         promise.set_value(true);
         co_return;
-    }();
-
-    task.handle.resume();
+    }());
 
     ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
     EXPECT_TRUE(future.get());
 
     slow_done.store(true, std::memory_order_release);
     slow.Wait();
-    WaitForDone(task);
+    h.Wait();
 }
 
 TEST_F(CoroutineTest, WhenAny_ConcurrentStress)
@@ -446,18 +412,16 @@ TEST_F(CoroutineTest, WhenAny_ConcurrentStress)
     std::promise<bool> promise;
     auto future = promise.get_future();
 
-    auto task = [&]() -> JobTask<void>
+    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
     {
         co_await WhenAny{ std::move(handles) };
         promise.set_value(true);
         co_return;
-    }();
-
-    task.handle.resume();
+    }());
 
     ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
     EXPECT_TRUE(future.get());
-    WaitForDone(task);
+    h.Wait();
 }
 
 TEST_F(CoroutineTest, WhenAny_AlreadyComplete)
@@ -468,18 +432,16 @@ TEST_F(CoroutineTest, WhenAny_AlreadyComplete)
     std::promise<bool> promise;
     auto future = promise.get_future();
 
-    auto task = [&]() -> JobTask<void>
+    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
     {
         co_await WhenAny{ { handle } };
         promise.set_value(true);
         co_return;
-    }();
-
-    task.handle.resume();
+    }());
 
     ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
     EXPECT_TRUE(future.get());
-    WaitForDone(task);
+    h.Wait();
 }
 
 TEST_F(CoroutineTest, WhenAny_EmptyArray_MustCompleteImmediately)
@@ -540,14 +502,12 @@ TEST_F(CoroutineTest, WhenAny_MixedInvalidAndPending_ResumesOnPendingCompletion)
         }
     });
 
-    auto task = [&]() -> JobTask<void>
+    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
     {
         co_await WhenAny{ { invalid, pending } };
         promise.set_value(true);
         co_return;
-    }();
-
-    task.handle.resume();
+    }());
 
     EXPECT_EQ(future.wait_for(50ms), std::future_status::timeout)
         << "WhenAny must not complete before pending handle is done";
@@ -556,7 +516,7 @@ TEST_F(CoroutineTest, WhenAny_MixedInvalidAndPending_ResumesOnPendingCompletion)
     ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
     EXPECT_TRUE(future.get());
     pending.Wait();
-    WaitForDone(task);
+    h.Wait();
 }
 
 TEST_F(CoroutineTest, WhenAny_ResumeExactlyOnce_UnderBurstCompletion)
@@ -582,21 +542,20 @@ TEST_F(CoroutineTest, WhenAny_ResumeExactlyOnce_UnderBurstCompletion)
     std::promise<bool> promise;
     auto future = promise.get_future();
 
-    auto task = [&]() -> JobTask<void>
+    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
     {
         co_await WhenAny{ std::move(handles) };
         const int count = resume_count.fetch_add(1, std::memory_order_relaxed) + 1;
         promise.set_value(count == 1);
         co_return;
-    }();
+    }());
 
-    task.handle.resume();
     release.store(true, std::memory_order_release);
 
     ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
     EXPECT_TRUE(future.get());
     EXPECT_EQ(resume_count.load(std::memory_order_relaxed), 1);
-    WaitForDone(task);
+    h.Wait();
 }
 
 
@@ -612,7 +571,7 @@ TEST_F(CoroutineTest, ParallelFor_CoAwaitJobHandle)
     std::promise<bool> promise;
     auto future = promise.get_future();
 
-    auto task = [&]() -> JobTask<void>
+    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
     {
         co_await JobSystem::Get().ParallelFor(COUNT, 100, [&](usize i)
         {
@@ -620,13 +579,11 @@ TEST_F(CoroutineTest, ParallelFor_CoAwaitJobHandle)
         });
         promise.set_value(true);
         co_return;
-    }();
-
-    task.handle.resume();
+    }());
 
     ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
     EXPECT_EQ(sum.load(std::memory_order_relaxed), static_cast<usize>(499500));
-    WaitForDone(task);
+    h.Wait();
 }
 
 TEST_F(CoroutineTest, CoAwait_TemporaryJobHandle)
@@ -635,7 +592,7 @@ TEST_F(CoroutineTest, CoAwait_TemporaryJobHandle)
     std::promise<bool> promise;
     auto future = promise.get_future();
 
-    auto task = [&]() -> JobTask<void>
+    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
     {
         co_await JobSystem::Get().Submit([&value]
         {
@@ -644,13 +601,11 @@ TEST_F(CoroutineTest, CoAwait_TemporaryJobHandle)
 
         promise.set_value(value.load(std::memory_order_acquire) == 42);
         co_return;
-    }();
-
-    task.handle.resume();
+    }());
 
     ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
     EXPECT_TRUE(future.get());
-    WaitForDone(task);
+    h.Wait();
 }
 
 TEST_F(CoroutineTest, DeepChain_CoAwaitJobHandle)
@@ -661,7 +616,7 @@ TEST_F(CoroutineTest, DeepChain_CoAwaitJobHandle)
     std::promise<bool> promise;
     auto future = promise.get_future();
 
-    auto task = [&]() -> JobTask<void>
+    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
     {
         for (usize i = 0; i < CHAIN_DEPTH; ++i)
         {
@@ -673,11 +628,110 @@ TEST_F(CoroutineTest, DeepChain_CoAwaitJobHandle)
 
         promise.set_value(progressed.load(std::memory_order_relaxed) == CHAIN_DEPTH);
         co_return;
-    }();
-
-    task.handle.resume();
+    }());
 
     ASSERT_EQ(future.wait_for(10s), std::future_status::ready);
     EXPECT_TRUE(future.get());
-    WaitForDone(task, 10s);
+    h.Wait();
+}
+
+
+// ═══════════════════════════════════════════════════════════════════
+//  SubmitTask / DispatchTask: Launch API
+// ═══════════════════════════════════════════════════════════════════
+
+TEST_F(CoroutineTest, SubmitTask_TrackedCompletion)
+{
+    // SubmitTask로 제출한 코루틴을 JobHandle.Wait()로 대기
+    std::atomic<int> value = 0;
+
+    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
+    {
+        value.store(42, std::memory_order_release);
+        co_return;
+    }());
+
+    h.Wait();
+    EXPECT_EQ(value.load(std::memory_order_acquire), 42);
+}
+
+TEST_F(CoroutineTest, SubmitTask_CoAwaitHandle)
+{
+    // 코루틴 내에서 SubmitTask의 JobHandle을 co_await
+    std::atomic<int> value = 0;
+
+    std::promise<bool> promise;
+    auto future = promise.get_future();
+
+    JobHandle outer = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
+    {
+        JobHandle inner = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
+        {
+            value.store(99, std::memory_order_release);
+            co_return;
+        }());
+
+        co_await inner;
+        promise.set_value(value.load(std::memory_order_acquire) == 99);
+        co_return;
+    }());
+
+    ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
+    EXPECT_TRUE(future.get());
+    outer.Wait();
+}
+
+TEST_F(CoroutineTest, DispatchTask_FireAndForget)
+{
+    // DispatchTask fire-and-forget, 부작용 확인
+    std::atomic<int> value = 0;
+    std::promise<void> promise;
+    auto future = promise.get_future();
+
+    JobSystem::Get().DispatchTask([&]() -> JobTask<void>
+    {
+        value.store(77, std::memory_order_release);
+        promise.set_value();
+        co_return;
+    }());
+
+    ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
+    EXPECT_EQ(value.load(std::memory_order_acquire), 77);
+}
+
+TEST_F(CoroutineTest, SubmitTask_FactoryOverload)
+{
+    // Factory 람다 오버로드 (()를 호출하지 않고 factory 전달)
+    std::atomic<int> value = 0;
+
+    JobHandle h = JobSystem::Get().SubmitTask([](std::atomic<int>& v) static -> JobTask<void>
+    {
+        v.store(55, std::memory_order_release);
+        co_return;
+    }(value));
+
+    h.Wait();
+    EXPECT_EQ(value.load(std::memory_order_acquire), 55);
+}
+
+TEST_F(CoroutineTest, SubmitTask_WithSuspend)
+{
+    // 중간에 co_await가 있는 코루틴
+    std::atomic<int> sum = 0;
+
+    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
+    {
+        sum.fetch_add(10, std::memory_order_relaxed);
+
+        co_await JobSystem::Get().Submit([&]
+        {
+            sum.fetch_add(20, std::memory_order_relaxed);
+        });
+
+        sum.fetch_add(30, std::memory_order_relaxed);
+        co_return;
+    }());
+
+    h.Wait();
+    EXPECT_EQ(sum.load(std::memory_order_relaxed), 60);
 }

--- a/EngineTest/Source/UnitTests/CoroutineTest.cpp
+++ b/EngineTest/Source/UnitTests/CoroutineTest.cpp
@@ -1,4 +1,4 @@
-﻿#include "gtest/gtest.h"
+#include "gtest/gtest.h"
 
 #include <atomic>
 #include <chrono>
@@ -42,7 +42,7 @@ TEST_F(CoroutineTest, Promise_AllocatedViaJobAllocator)
 {
     // 코루틴 프레임이 JobAllocator를 통해 할당/해제됩니다.
     // 크래시 없이 생성/소멸되면 성공입니다.
-    auto task = []() -> JobTask<int> { co_return 42; }();
+    auto task = []() static -> JobTask<int> { co_return 42; }();
     task.handle.resume();
 
     EXPECT_TRUE(task.handle.done());
@@ -57,7 +57,7 @@ TEST_F(CoroutineTest, Promise_AllocatedViaJobAllocator)
 
 TEST_F(CoroutineTest, JobTask_CoReturnInt)
 {
-    auto task = []() -> JobTask<int> { co_return 123; }();
+    auto task = []() static -> JobTask<int> { co_return 123; }();
     task.handle.resume();
 
     EXPECT_TRUE(task.handle.done());
@@ -67,11 +67,11 @@ TEST_F(CoroutineTest, JobTask_CoReturnInt)
 TEST_F(CoroutineTest, JobTask_CoReturnVoid)
 {
     std::atomic<bool> executed = false;
-    auto task = [&]() -> JobTask<void>
+    auto task = [](std::atomic<bool>& executed) static -> JobTask<void>
     {
         executed.store(true, std::memory_order_release);
         co_return;
-    }();
+    }(executed);
 
     task.handle.resume();
 
@@ -88,9 +88,9 @@ TEST_F(CoroutineTest, JobTask_SymmetricTransfer_NestedCoAwait)
 {
     // 부모-자식 co_await가 Symmetric Transfer로 동작하여
     // JobSystem 큐잉 없이 동일 스레드에서 실행됩니다.
-    auto task = []() -> JobTask<int>
+    auto task = []() static -> JobTask<int>
     {
-        auto child = []() -> JobTask<int> { co_return 42; };
+        auto child = []() static -> JobTask<int> { co_return 42; };
         int val = co_await child();
         co_return val;
     }();
@@ -104,11 +104,11 @@ TEST_F(CoroutineTest, JobTask_SymmetricTransfer_NestedCoAwait)
 
 TEST_F(CoroutineTest, JobTask_SymmetricTransfer_DeepNesting)
 {
-    auto task = []() -> JobTask<int>
+    auto task = []() static -> JobTask<int>
     {
-        auto grandchild = []() -> JobTask<int> { co_return 10; };
-        auto child = [&]() -> JobTask<int>
+        auto child = []() static -> JobTask<int>
         {
+            auto grandchild = []() static -> JobTask<int> { co_return 10; };
             int val = co_await grandchild();
             co_return val * 2;
         };
@@ -130,21 +130,21 @@ TEST_F(CoroutineTest, JobTask_SymmetricTransfer_SameThread)
     std::thread::id parent_tid;
     std::thread::id child_tid;
 
-    auto task = [&]() -> JobTask<void>
+    auto task = [](std::thread::id& parent_tid, std::thread::id& child_tid) static -> JobTask<void>
     {
         parent_tid = std::this_thread::get_id();
 
-        auto child = [&]() -> JobTask<void>
+        auto child = [](std::thread::id& tid) static -> JobTask<void>
         {
-            child_tid = std::this_thread::get_id();
+            tid = std::this_thread::get_id();
             co_return;
         };
 
-        co_await child();
+        co_await child(child_tid);
         // FinalAwaiter에 의해 부모로 돌아온 뒤에도 같은 스레드
         EXPECT_EQ(std::this_thread::get_id(), parent_tid);
         co_return;
-    }();
+    }(parent_tid, child_tid);
 
     task.handle.resume();
 
@@ -156,17 +156,17 @@ TEST_F(CoroutineTest, JobTask_SymmetricTransfer_VoidChild)
 {
     std::atomic<bool> child_executed = false;
 
-    auto task = [&]() -> JobTask<int>
+    auto task = [](std::atomic<bool>& child_executed) static -> JobTask<int>
     {
-        auto void_child = [&]() -> JobTask<void>
+        auto void_child = [](std::atomic<bool>& flag) static -> JobTask<void>
         {
-            child_executed.store(true, std::memory_order_release);
+            flag.store(true, std::memory_order_release);
             co_return;
         };
 
-        co_await void_child();
+        co_await void_child(child_executed);
         co_return 99;
-    }();
+    }(child_executed);
 
     task.handle.resume();
 
@@ -185,12 +185,13 @@ TEST_F(CoroutineTest, ResumeOn_Worker)
     std::promise<std::thread::id> promise;
     auto future = promise.get_future();
 
-    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
-    {
-        co_await ResumeOn{ EJobThread::Worker };
-        promise.set_value(std::this_thread::get_id());
-        co_return;
-    }());
+    JobHandle h = JobSystem::Get().SubmitTask(
+        [](std::promise<std::thread::id>& p) static -> JobTask<void>
+        {
+            co_await ResumeOn{ EJobThread::Worker };
+            p.set_value(std::this_thread::get_id());
+            co_return;
+        }(promise));
 
     ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
     EXPECT_NE(future.get(), std::this_thread::get_id());
@@ -201,12 +202,13 @@ TEST_F(CoroutineTest, ResumeOn_Main)
 {
     std::atomic<bool> executed = false;
 
-    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
-    {
-        co_await ResumeOn{ EJobThread::Main };
-        executed.store(true, std::memory_order_release);
-        co_return;
-    }());
+    JobHandle h = JobSystem::Get().SubmitTask(
+        [](std::atomic<bool>& executed) static -> JobTask<void>
+        {
+            co_await ResumeOn{ EJobThread::Main };
+            executed.store(true, std::memory_order_release);
+            co_return;
+        }(executed));
 
     // 메인 큐를 드레인하기 전에는 실행되지 않습니다
     std::this_thread::sleep_for(10ms);
@@ -230,18 +232,19 @@ TEST_F(CoroutineTest, ResumeOn_PreservesThreadAfterChildReturn)
     std::promise<bool> promise;
     auto future = promise.get_future();
 
-    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
-    {
-        co_await ResumeOn{ EJobThread::Worker };
-        auto tid_before = std::this_thread::get_id();
+    JobHandle h = JobSystem::Get().SubmitTask(
+        [](std::promise<bool>& p) static -> JobTask<void>
+        {
+            co_await ResumeOn{ EJobThread::Worker };
+            auto tid_before = std::this_thread::get_id();
 
-        auto child = []() -> JobTask<int> { co_return 1; };
-        co_await child();
+            auto child = []() static -> JobTask<int> { co_return 1; };
+            co_await child();
 
-        // Symmetric Transfer이므로 스레드가 유지됩니다
-        promise.set_value(std::this_thread::get_id() == tid_before);
-        co_return;
-    }());
+            // Symmetric Transfer이므로 스레드가 유지됩니다
+            p.set_value(std::this_thread::get_id() == tid_before);
+            co_return;
+        }(promise));
 
     ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
     EXPECT_TRUE(future.get());
@@ -264,12 +267,13 @@ TEST_F(CoroutineTest, WhenAll_MultipleJobs)
     std::promise<int> promise;
     auto future = promise.get_future();
 
-    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
-    {
-        co_await WhenAll{ { a, b, c } };
-        promise.set_value(counter.load(std::memory_order_relaxed));
-        co_return;
-    }());
+    JobHandle h = JobSystem::Get().SubmitTask(
+        [](std::promise<int>& p, std::atomic<int>& cnt, JobHandle a, JobHandle b, JobHandle c) static -> JobTask<void>
+        {
+            co_await WhenAll{ { a, b, c } };
+            p.set_value(cnt.load(std::memory_order_relaxed));
+            co_return;
+        }(promise, counter, a, b, c));
 
     ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
     EXPECT_EQ(future.get(), 111);
@@ -284,12 +288,13 @@ TEST_F(CoroutineTest, WhenAll_AlreadyComplete)
     std::promise<bool> promise;
     auto future = promise.get_future();
 
-    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
-    {
-        co_await WhenAll{ { handle } };
-        promise.set_value(true);
-        co_return;
-    }());
+    JobHandle h = JobSystem::Get().SubmitTask(
+        [](std::promise<bool>& p, JobHandle handle) static -> JobTask<void>
+        {
+            co_await WhenAll{ { handle } };
+            p.set_value(true);
+            co_return;
+        }(promise, handle));
 
     ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
     EXPECT_TRUE(future.get());
@@ -298,7 +303,7 @@ TEST_F(CoroutineTest, WhenAll_AlreadyComplete)
 
 TEST_F(CoroutineTest, WhenAll_Empty)
 {
-    auto task = []() -> JobTask<int>
+    auto task = []() static -> JobTask<int>
     {
         co_await WhenAll{ {} };
         co_return 1;
@@ -325,12 +330,13 @@ TEST_F(CoroutineTest, WhenAll_AllAlreadyComplete)
     std::promise<bool> promise;
     auto future = promise.get_future();
 
-    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
-    {
-        co_await WhenAll{ { h1, h2, h3 } };
-        promise.set_value(true);
-        co_return;
-    }());
+    JobHandle h = JobSystem::Get().SubmitTask(
+        [](std::promise<bool>& p, JobHandle h1, JobHandle h2, JobHandle h3) static -> JobTask<void>
+        {
+            co_await WhenAll{ { h1, h2, h3 } };
+            p.set_value(true);
+            co_return;
+        }(promise, h1, h2, h3));
 
     ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
     EXPECT_TRUE(future.get());
@@ -349,12 +355,13 @@ TEST_F(CoroutineTest, WhenAll_MixedComplete)
     std::promise<bool> promise;
     auto future = promise.get_future();
 
-    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
-    {
-        co_await WhenAll{ { already_done, pending } };
-        promise.set_value(counter.load(std::memory_order_relaxed) == 1);
-        co_return;
-    }());
+    JobHandle h = JobSystem::Get().SubmitTask(
+        [](std::promise<bool>& p, std::atomic<int>& cnt, JobHandle done, JobHandle pend) static -> JobTask<void>
+        {
+            co_await WhenAll{ { done, pend } };
+            p.set_value(cnt.load(std::memory_order_relaxed) == 1);
+            co_return;
+        }(promise, counter, already_done, pending));
 
     ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
     EXPECT_TRUE(future.get());
@@ -382,12 +389,13 @@ TEST_F(CoroutineTest, WhenAny_FirstComplete)
     std::promise<bool> promise;
     auto future = promise.get_future();
 
-    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
-    {
-        co_await WhenAny{ { fast, slow } };
-        promise.set_value(true);
-        co_return;
-    }());
+    JobHandle h = JobSystem::Get().SubmitTask(
+        [](std::promise<bool>& p, JobHandle fast, JobHandle slow) static -> JobTask<void>
+        {
+            co_await WhenAny{ { fast, slow } };
+            p.set_value(true);
+            co_return;
+        }(promise, fast, slow));
 
     ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
     EXPECT_TRUE(future.get());
@@ -412,12 +420,13 @@ TEST_F(CoroutineTest, WhenAny_ConcurrentStress)
     std::promise<bool> promise;
     auto future = promise.get_future();
 
-    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
-    {
-        co_await WhenAny{ std::move(handles) };
-        promise.set_value(true);
-        co_return;
-    }());
+    JobHandle h = JobSystem::Get().SubmitTask(
+        [](std::promise<bool>& p, Array<JobHandle> handles) static -> JobTask<void>
+        {
+            co_await WhenAny{ std::move(handles) };
+            p.set_value(true);
+            co_return;
+        }(promise, std::move(handles)));
 
     ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
     EXPECT_TRUE(future.get());
@@ -432,12 +441,13 @@ TEST_F(CoroutineTest, WhenAny_AlreadyComplete)
     std::promise<bool> promise;
     auto future = promise.get_future();
 
-    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
-    {
-        co_await WhenAny{ { handle } };
-        promise.set_value(true);
-        co_return;
-    }());
+    JobHandle h = JobSystem::Get().SubmitTask(
+        [](std::promise<bool>& p, JobHandle handle) static -> JobTask<void>
+        {
+            co_await WhenAny{ { handle } };
+            p.set_value(true);
+            co_return;
+        }(promise, handle));
 
     ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
     EXPECT_TRUE(future.get());
@@ -449,12 +459,12 @@ TEST_F(CoroutineTest, WhenAny_EmptyArray_MustCompleteImmediately)
     std::promise<bool> promise;
     auto future = promise.get_future();
 
-    auto task = [&]() -> JobTask<void>
+    auto task = [](std::promise<bool>& p) static -> JobTask<void>
     {
         co_await WhenAny{ {} };
-        promise.set_value(true);
+        p.set_value(true);
         co_return;
-    }();
+    }(promise);
 
     task.handle.resume();
 
@@ -470,14 +480,14 @@ TEST_F(CoroutineTest, WhenAny_AllInvalidHandles_MustNotSuspend)
     std::promise<bool> promise;
     auto future = promise.get_future();
 
-    auto task = [&]() -> JobTask<void>
+    auto task = [](std::promise<bool>& p) static -> JobTask<void>
     {
         JobHandle invalid_a;
         JobHandle invalid_b;
         co_await WhenAny{ { invalid_a, invalid_b } };
-        promise.set_value(true);
+        p.set_value(true);
         co_return;
-    }();
+    }(promise);
 
     task.handle.resume();
 
@@ -502,12 +512,13 @@ TEST_F(CoroutineTest, WhenAny_MixedInvalidAndPending_ResumesOnPendingCompletion)
         }
     });
 
-    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
-    {
-        co_await WhenAny{ { invalid, pending } };
-        promise.set_value(true);
-        co_return;
-    }());
+    JobHandle h = JobSystem::Get().SubmitTask(
+        [](std::promise<bool>& p, JobHandle invalid, JobHandle pending) static -> JobTask<void>
+        {
+            co_await WhenAny{ { invalid, pending } };
+            p.set_value(true);
+            co_return;
+        }(promise, invalid, pending));
 
     EXPECT_EQ(future.wait_for(50ms), std::future_status::timeout)
         << "WhenAny must not complete before pending handle is done";
@@ -542,13 +553,14 @@ TEST_F(CoroutineTest, WhenAny_ResumeExactlyOnce_UnderBurstCompletion)
     std::promise<bool> promise;
     auto future = promise.get_future();
 
-    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
-    {
-        co_await WhenAny{ std::move(handles) };
-        const int count = resume_count.fetch_add(1, std::memory_order_relaxed) + 1;
-        promise.set_value(count == 1);
-        co_return;
-    }());
+    JobHandle h = JobSystem::Get().SubmitTask(
+        [](std::promise<bool>& p, std::atomic<int>& rc, Array<JobHandle> handles) static -> JobTask<void>
+        {
+            co_await WhenAny{ std::move(handles) };
+            const int count = rc.fetch_add(1, std::memory_order_relaxed) + 1;
+            p.set_value(count == 1);
+            co_return;
+        }(promise, resume_count, std::move(handles)));
 
     release.store(true, std::memory_order_release);
 
@@ -565,21 +577,22 @@ TEST_F(CoroutineTest, WhenAny_ResumeExactlyOnce_UnderBurstCompletion)
 
 TEST_F(CoroutineTest, ParallelFor_CoAwaitJobHandle)
 {
-    constexpr usize COUNT = 1000;
     std::atomic<usize> sum = 0;
 
     std::promise<bool> promise;
     auto future = promise.get_future();
 
-    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
-    {
-        co_await JobSystem::Get().ParallelFor(COUNT, 100, [&](usize i)
+    JobHandle h = JobSystem::Get().SubmitTask(
+        [](std::atomic<usize>& sum, std::promise<bool>& p) static -> JobTask<void>
         {
-            sum.fetch_add(i, std::memory_order_relaxed);
-        });
-        promise.set_value(true);
-        co_return;
-    }());
+            constexpr usize COUNT = 1000;
+            co_await JobSystem::Get().ParallelFor(COUNT, static_cast<usize>(100), [&sum](usize i)
+            {
+                sum.fetch_add(i, std::memory_order_relaxed);
+            });
+            p.set_value(true);
+            co_return;
+        }(sum, promise));
 
     ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
     EXPECT_EQ(sum.load(std::memory_order_relaxed), static_cast<usize>(499500));
@@ -592,16 +605,17 @@ TEST_F(CoroutineTest, CoAwait_TemporaryJobHandle)
     std::promise<bool> promise;
     auto future = promise.get_future();
 
-    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
-    {
-        co_await JobSystem::Get().Submit([&value]
+    JobHandle h = JobSystem::Get().SubmitTask(
+        [](std::atomic<int>& value, std::promise<bool>& p) static -> JobTask<void>
         {
-            value.store(42, std::memory_order_release);
-        });
+            co_await JobSystem::Get().Submit([&value]
+            {
+                value.store(42, std::memory_order_release);
+            });
 
-        promise.set_value(value.load(std::memory_order_acquire) == 42);
-        co_return;
-    }());
+            p.set_value(value.load(std::memory_order_acquire) == 42);
+            co_return;
+        }(value, promise));
 
     ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
     EXPECT_TRUE(future.get());
@@ -610,25 +624,26 @@ TEST_F(CoroutineTest, CoAwait_TemporaryJobHandle)
 
 TEST_F(CoroutineTest, DeepChain_CoAwaitJobHandle)
 {
-    constexpr usize CHAIN_DEPTH = 2048;
     std::atomic<usize> progressed = 0;
 
     std::promise<bool> promise;
     auto future = promise.get_future();
 
-    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
-    {
-        for (usize i = 0; i < CHAIN_DEPTH; ++i)
+    JobHandle h = JobSystem::Get().SubmitTask(
+        [](std::atomic<usize>& prog, std::promise<bool>& p) static -> JobTask<void>
         {
-            co_await JobSystem::Get().Submit([&progressed]
+            constexpr usize CHAIN_DEPTH = 2048;
+            for (usize i = 0; i < CHAIN_DEPTH; ++i)
             {
-                progressed.fetch_add(1, std::memory_order_relaxed);
-            });
-        }
+                co_await JobSystem::Get().Submit([&prog]
+                {
+                    prog.fetch_add(1, std::memory_order_relaxed);
+                });
+            }
 
-        promise.set_value(progressed.load(std::memory_order_relaxed) == CHAIN_DEPTH);
-        co_return;
-    }());
+            p.set_value(prog.load(std::memory_order_relaxed) == CHAIN_DEPTH);
+            co_return;
+        }(progressed, promise));
 
     ASSERT_EQ(future.wait_for(10s), std::future_status::ready);
     EXPECT_TRUE(future.get());
@@ -645,11 +660,12 @@ TEST_F(CoroutineTest, SubmitTask_TrackedCompletion)
     // SubmitTask로 제출한 코루틴을 JobHandle.Wait()로 대기
     std::atomic<int> value = 0;
 
-    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
-    {
-        value.store(42, std::memory_order_release);
-        co_return;
-    }());
+    JobHandle h = JobSystem::Get().SubmitTask(
+        [](std::atomic<int>& v) static -> JobTask<void>
+        {
+            v.store(42, std::memory_order_release);
+            co_return;
+        }(value));
 
     h.Wait();
     EXPECT_EQ(value.load(std::memory_order_acquire), 42);
@@ -663,18 +679,20 @@ TEST_F(CoroutineTest, SubmitTask_CoAwaitHandle)
     std::promise<bool> promise;
     auto future = promise.get_future();
 
-    JobHandle outer = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
-    {
-        JobHandle inner = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
+    JobHandle outer = JobSystem::Get().SubmitTask(
+        [](std::atomic<int>& v, std::promise<bool>& p) static -> JobTask<void>
         {
-            value.store(99, std::memory_order_release);
-            co_return;
-        }());
+            JobHandle inner = JobSystem::Get().SubmitTask(
+                [](std::atomic<int>& val) static -> JobTask<void>
+                {
+                    val.store(99, std::memory_order_release);
+                    co_return;
+                }(v));
 
-        co_await inner;
-        promise.set_value(value.load(std::memory_order_acquire) == 99);
-        co_return;
-    }());
+            co_await inner;
+            p.set_value(v.load(std::memory_order_acquire) == 99);
+            co_return;
+        }(value, promise));
 
     ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
     EXPECT_TRUE(future.get());
@@ -688,12 +706,13 @@ TEST_F(CoroutineTest, DispatchTask_FireAndForget)
     std::promise<void> promise;
     auto future = promise.get_future();
 
-    JobSystem::Get().DispatchTask([&]() -> JobTask<void>
-    {
-        value.store(77, std::memory_order_release);
-        promise.set_value();
-        co_return;
-    }());
+    JobSystem::Get().DispatchTask(
+        [](std::atomic<int>& v, std::promise<void>& p) static -> JobTask<void>
+        {
+            v.store(77, std::memory_order_release);
+            p.set_value();
+            co_return;
+        }(value, promise));
 
     ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
     EXPECT_EQ(value.load(std::memory_order_acquire), 77);
@@ -701,7 +720,7 @@ TEST_F(CoroutineTest, DispatchTask_FireAndForget)
 
 TEST_F(CoroutineTest, SubmitTask_FactoryOverload)
 {
-    // Factory 람다 오버로드 (()를 호출하지 않고 factory 전달)
+    // Factory 람다 오버로드 테스트
     std::atomic<int> value = 0;
 
     JobHandle h = JobSystem::Get().SubmitTask([](std::atomic<int>& v) static -> JobTask<void>
@@ -719,18 +738,19 @@ TEST_F(CoroutineTest, SubmitTask_WithSuspend)
     // 중간에 co_await가 있는 코루틴
     std::atomic<int> sum = 0;
 
-    JobHandle h = JobSystem::Get().SubmitTask([&]() -> JobTask<void>
-    {
-        sum.fetch_add(10, std::memory_order_relaxed);
-
-        co_await JobSystem::Get().Submit([&]
+    JobHandle h = JobSystem::Get().SubmitTask(
+        [](std::atomic<int>& sum) static -> JobTask<void>
         {
-            sum.fetch_add(20, std::memory_order_relaxed);
-        });
+            sum.fetch_add(10, std::memory_order_relaxed);
 
-        sum.fetch_add(30, std::memory_order_relaxed);
-        co_return;
-    }());
+            co_await JobSystem::Get().Submit([&sum]
+            {
+                sum.fetch_add(20, std::memory_order_relaxed);
+            });
+
+            sum.fetch_add(30, std::memory_order_relaxed);
+            co_return;
+        }(sum));
 
     h.Wait();
     EXPECT_EQ(sum.load(std::memory_order_relaxed), 60);


### PR DESCRIPTION
> 아래 PR 메시지는 Claude Sonnet 4.6을(를) 사용하여 작성되었습니다.

## 개요

이 PR은 `feature/async_io` 브랜치의 전체 작업을 `main`에 병합합니다.

**핵심 동기**: 코루틴(`JobTask<T>`) 내부에서 캡처 람다(`[&]`)를 사용하면, 람다의 참조 대상이 코루틴 프레임에 묶이므로 호출자의 스택 프레임이 먼저 소멸될 경우 **댕글링 참조(Dangling Reference)** → Use-After-Free(UAF)로 이어집니다. 특히 `JobSystem`에서 워커 스레드로 코루틴을 디스패치하는 경우 이 위험이 즉각적이며 재현이 어렵습니다.

이번 작업은 이를 **컴파일 타임에 완전히 차단**하고, 코루틴 작업을 시작하는 일급(first-class) API를 제공합니다.

---

## 변경 범위

```
13 files changed, 1,129 insertions(+), 211 deletions(-)
```

| 파일 | 변경 내용 |
|------|-----------|
| `AsyncFileIO.h/.cpp` | **신규**: SDL AsyncIO 기반 크로스플랫폼 비동기 파일 I/O 시스템 |
| `JobTask.h` | Promise Trap 생성자 추가, Detached 모드 추가 |
| `JobSystem.h/.cpp` | `SubmitTask` / `DispatchTask` 코루틴 Launch API 추가 |
| `CoroutinePrimitives.h/.cpp` | 팩토리 오버로드 `static_assert` 추가, 템플릿 정의 이전 |
| `Common.h` | `EJobThread::Auto` / `IO` 제거 |
| `Engine.h/.cpp` | `AsyncFileIO` 싱글톤 관리 통합 |
| `CoroutineTest.cpp` | 30개 테스트 전체 `static` 람다 패턴으로 리팩터링 + 5개 신규 |
| `AsyncFileIOTest.cpp` | **신규**: 8개 비동기 I/O 테스트 (콜백 + 코루틴 기반) |

---

## 기술적 세부 사항

### 1. 비동기 파일 I/O 시스템 (`AsyncFileIO`)

SDL AsyncIO(`SDL_LoadFileAsync` / `SDL_AsyncIOQueue` / `SDL_WaitAsyncIOResult`) 기반의 크로스플랫폼 비동기 파일 I/O를 제공합니다. 콜백 API와 코루틴 `co_await` 두 가지 방식을 모두 지원합니다.

```cpp
// 콜백 방식
AsyncFileIO::Get().ReadFile(path, [](IOResult result) { ... });

// 코루틴 방식 (워커 스레드에서 자연스럽게 await)
IOResult result = co_await AsyncFileIO::Get().ReadFileAsync(path);
```

SDL 폴러 스레드(`SDL_WaitAsyncIOResult`)가 I/O 완료를 감지하면, 완료된 콜백 실행을 `JobSystem` 워커 스레드에 위임하여 메인 루프를 차단하지 않습니다.

### 2. 코루틴 Launch API: `SubmitTask` / `DispatchTask`

기존 `task.handle.resume()` 직접 호출 방식은 `JobSystem`과의 통합이 불가능하고, Fire-and-Forget이나 `JobHandle` 추적이 지원되지 않는 취약한 패턴이었습니다. `JobSystem`의 기존 `Submit` / `Dispatch` API와 대칭되는 코루틴 전용 Launch API를 추가했습니다.

```cpp
// Tracked: 완료를 JobHandle로 대기
JobHandle h = JobSystem::Get().SubmitTask(
    [](std::atomic<int>& v) static -> JobTask<void> {
        v.store(42, std::memory_order_release);
        co_return;
    }(value));
h.Wait();

// Fire-and-Forget: 완료 추적 불필요
JobSystem::Get().DispatchTask(
    []() static -> JobTask<void> {
        co_await SomeBackgroundWork();
    }());
```

**소유권 모델 (Self-Destruct Detached)**: `SubmitTask`/`DispatchTask`에 코루틴이 제출되면 `promise.detached = true`로 설정됩니다. `FinalAwaiter::await_suspend`에서 continuation이 없고 `detached == true`이면, `handle.destroy()`로 코루틴 프레임을 자동 소멸한 뒤 `JobCounter::Decrement()`를 호출합니다. 추가 힙 할당 없이 수명을 안전하게 관리합니다.

### 3. 코루틴 안전성 강화: `static` 람다 규칙 시행

**3중 방어막**을 통해 캡처 람다가 코루틴 프레임에 들어가는 것을 컴파일 타임에 차단합니다.

**[1층] Promise Trap Constructor** (`JobTask.h`):

C++ 코루틴 표준([dcl.fct.def.coroutine]/4)에 따르면, 비정적(non-static) 멤버 함수가 코루틴인 경우 컴파일러는 `promise_type(ClassType&&, Args&&...)` 오버로드를 우선 탐색합니다. 이를 이용해 non-static 람다가 코루틴을 생성하는 순간 `static_assert`를 발동시킵니다.

```cpp
template <typename ClassType, typename... Args>
    requires std::invocable<ClassType, Args&&...>
          && std::same_as<std::invoke_result_t<ClassType, Args&&...>, JobTask<T>>
          && std::is_class_v<std::remove_cvref_t<ClassType>>
JobTaskPromise(ClassType&&, Args&&...)
{
    static_assert(
        traits::AlwaysFalse<ClassType, Args...>,
        "[JobTask Error] Stateful (capturing) lambdas are not allowed..."
    );
}
```

**오탐(False Positive) 방지**: `std::same_as<invoke_result_t<ClassType, Args&&...>, JobTask<T>>` 제약으로, 일반 함수의 첫 번째 인자가 callable 타입인 경우에는 트랩이 발동되지 않습니다.

**[2층] API 경계 `static_assert`** (`CoroutinePrimitives.h`):

팩토리 오버로드(`SubmitTask(Fn&&)`, `DispatchTask(Fn&&)`)에서 `std::is_empty_v` 검사를 통해 상태 있는 팩토리 람다를 차단합니다.

```cpp
template <typename Fn>
    requires std::is_invocable_r_v<JobTask<void>, Fn>
JobHandle JobSystem::SubmitTask(Fn&& factory, EJobPriority priority)
{
    static_assert(
        !std::is_class_v<std::remove_cvref_t<Fn>>
            || std::is_empty_v<std::remove_cvref_t<Fn>>,
        "[JobSystem Error] DispatchTask requires a stateless (non-capturing) lambda!"
    );
    return SubmitTask(std::invoke(std::forward<Fn>(factory)), priority);
}
```

**[3층] 테스트 코드 전면 리팩터링**: 약 28곳의 캡처 람다를 `static` 람다 + 명시적 파라미터 전달(IIFE) 패턴으로 변환하여, 규칙을 코드베이스 전체에서 일관되게 적용했습니다.

---

## 마이그레이션 가이드

`JobTask` 코루틴을 작성할 때 반드시 다음 규칙을 따라야 합니다.

**❌ 금지 패턴 (컴파일 에러 발생)**

```cpp
// 캡처 람다 사용 — Promise Trap에 의해 컴파일 타임 차단
JobSystem::Get().SubmitTask([&]() -> JobTask<void> {
    value = 42; // 댕글링 위험
    co_return;
}());
```

**✅ 올바른 패턴 1: 명시적 파라미터 전달 (IIFE)**

```cpp
JobSystem::Get().SubmitTask(
    [](std::atomic<int>& v) static -> JobTask<void> {
        v.store(42, std::memory_order_release);
        co_return;
    }(value));  // ← value의 수명은 호출자가 보장해야 함
```

**✅ 올바른 패턴 2: 무상태 `static` 람다 (팩토리 오버로드)**

```cpp
JobSystem::Get().DispatchTask([]() static -> JobTask<void> {
    co_await SomeIndependentWork();
});
```

**✅ 올바른 패턴 3: 일반 함수**

```cpp
static JobTask<void> ProcessDataAsync(DataRef data) {
    co_await data.Load();
    co_return;
}
JobSystem::Get().SubmitTask(ProcessDataAsync(ref));
```

---

## 검증 결과

| 항목 | 결과 |
|------|------|
| 빌드 경고 | **0건** |
| 전체 테스트 | **821 / 821 PASS** |
| StressTest 반복 (30회) | **210 / 210 PASS** |
| 캡처 람다 JobTask 패턴 잔존 | **0건** |

---

## 관련 커밋

```
39faeb25  feat: JobSystem 작업 디스패치 방식 리팩터링 및 코루틴 테스트 개선
c0d1eeb3  note: ResumeOn await_ready 최적화 옵션 메모 추가
cfc390f3  test: 코루틴 작업 처리 방식 개선 및 테스트 코드 리팩터링
b318a772  feat: 코루틴 기반 작업 디스패치 및 추적 기능 추가
deee7d73  feat: AsyncFileIO 싱글톤 관리 로직 엔진에 추가
91a4c661  feat: 비동기 파일 I/O 시스템 및 단위 테스트 추가
3f65d3ca  refactor: EJobThread 열거형에서 Auto와 IO 제거 및 관련 로직 간소화
7a9aa3e5  feat: SDL 기반 파일 시스템으로 대체 및 경로 처리 최적화
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)