### PR TITLE
[Feature] Editor 병렬 Cook 기능 및 비동기 에셋 IO 추가

### DIFF
--- a/Editor/Source/Asset/EditorAssetSubsystem.cpp
+++ b/Editor/Source/Asset/EditorAssetSubsystem.cpp
@@ -22,12 +22,11 @@
 #include "SimpleEngine/Core/Subsystem/SubsystemRegistration.h"
 #include "SimpleEngine/Core/Concurrency/JobSystem.h"
 #include "SimpleEngine/Core/Concurrency/Coroutine/CoroutinePrimitives.h"
+#include "SimpleEngine/Utility/ScopedTimer.h"
 #include "SimpleEngine/Utility/SHA256.h"
 #include "SimpleEngine/Utility/SubsystemUtils.h"
 
 #include "tracy/Tracy.hpp"
-
-#include <ranges>
 
 
 namespace se::editor
@@ -35,9 +34,20 @@ namespace se::editor
 namespace
 {
 /** ScanWorkspace에서 Dirty 파일을 병렬로 Cook하기 위한 코루틴 함수 */
-JobTask<void> MakeCookTask(EditorAssetSubsystem& self, VPath vpath)
+JobTask<void> MakeCookTask(EditorAssetSubsystem& self, VPath vpath, std::atomic<usize>& completed, usize total)
 {
-    self.CookAsset(vpath);
+    const ScopedTimer timer;
+    const bool success = self.CookAsset(vpath);
+    const usize n = completed.fetch_add(1, std::memory_order_relaxed) + 1;
+
+    if (success)
+    {
+        ConsoleLog(ELogLevel::Info, "Cooked [{}/{}] {} ({:.1f}ms)", n, total, vpath, timer.ElapsedMs());
+    }
+    else
+    {
+        ConsoleLog(ELogLevel::Warning, "Cook failed [{}/{}] {} ({:.1f}ms)", n, total, vpath, timer.ElapsedMs());
+    }
     co_return;
 }
 } // namespace
@@ -251,7 +261,7 @@ void EditorAssetSubsystem::ScanWorkspace(const Path& root_path, bool is_hot_star
         // 새로운 파일인 경우, .meta 파일 생성
         if (!content_opt.HasValue())
         {
-            content_opt = EnsureMetaFile(file_path);
+            content_opt = EnsureMetaFile(file_path); // TODO: 새 파일이 많을 때 여기서 병목이 생김 (Blocking)
 
             // EnsureMetaFile이 실패한 경우 (로그는 내부에서 남김)
             if (!content_opt.HasValue())
@@ -297,6 +307,8 @@ void EditorAssetSubsystem::ScanWorkspace(const Path& root_path, bool is_hot_star
     if (!dirty_vpaths.IsEmpty())
     {
         const usize total_tasks = dirty_vpaths.Len();
+        std::atomic<usize> completed = 0;
+
         ConsoleLog(ELogLevel::Info, "Dispatching {} background cook tasks", total_tasks);
 
         Array<JobHandle> cook_handles;
@@ -304,15 +316,14 @@ void EditorAssetSubsystem::ScanWorkspace(const Path& root_path, bool is_hot_star
 
         for (const VPath& vpath : dirty_vpaths)
         {
-            cook_handles.Push(JobSystem::Get().SubmitTask(MakeCookTask(*this, vpath)));
+            cook_handles.Push(JobSystem::Get().SubmitTask(MakeCookTask(*this, vpath, completed, total_tasks)));
         }
 
-        for (const auto[n, handle] : cook_handles | std::views::enumerate)
+        for (const JobHandle& handle : cook_handles)
         {
             handle.Wait();
-            ConsoleLog(ELogLevel::Debug, "Cooking Progress: [{}/{}]", n + 1, total_tasks);
         }
-        ConsoleLog(ELogLevel::Info, "All cook tasks completed.");
+        ConsoleLog(ELogLevel::Info, "All {} cook tasks completed.", total_tasks);
     }
 
     // === 삭제된 파일 감지 (Hot Start 전용) ===
@@ -603,7 +614,7 @@ bool EditorAssetSubsystem::CookAsset(const VPath& file_vpath)
         ConsoleLog(ELogLevel::Warning, "CookAsset: Failed to update .meta for: {}", file_path);
     }
 
-    ConsoleLog(ELogLevel::Info, "Successfully cooked {} assets from: {}", result.GetCount(), file_path);
+    ConsoleLog(ELogLevel::Debug, "Successfully cooked {} assets from: {}", result.GetCount(), file_path);
     return true;
 }
 

--- a/Editor/Source/Asset/EditorAssetSubsystem.cpp
+++ b/Editor/Source/Asset/EditorAssetSubsystem.cpp
@@ -20,14 +20,29 @@
 #include "SimpleEngine/Core/Logging/Logging.h"
 #include "SimpleEngine/Core/Reflection/TypeRegistry.h"
 #include "SimpleEngine/Core/Subsystem/SubsystemRegistration.h"
+#include "SimpleEngine/Core/Concurrency/JobSystem.h"
+#include "SimpleEngine/Core/Concurrency/Coroutine/CoroutinePrimitives.h"
 #include "SimpleEngine/Utility/SHA256.h"
 #include "SimpleEngine/Utility/SubsystemUtils.h"
 
 #include "tracy/Tracy.hpp"
 
+#include <ranges>
+
 
 namespace se::editor
 {
+namespace
+{
+/** ScanWorkspace에서 Dirty 파일을 병렬로 Cook하기 위한 코루틴 함수 */
+JobTask<void> MakeCookTask(EditorAssetSubsystem& self, VPath vpath)
+{
+    self.CookAsset(vpath);
+    co_return;
+}
+} // namespace
+
+
 SE_REGISTER_SUBSYSTEM(EditorAssetSubsystem)
     .DependsOn<se::asset::AssetSubsystem>();
 
@@ -195,6 +210,9 @@ void EditorAssetSubsystem::ScanWorkspace(const Path& root_path, bool is_hot_star
     uint32 clean_count = 0;
     uint32 moved_count = 0;
 
+    // Background Cook 목록
+    Array<VPath> dirty_vpaths;
+
     for (const Path& file_path : source_files)
     {
         Optional<MetaFileContent> content_opt;
@@ -242,13 +260,22 @@ void EditorAssetSubsystem::ScanWorkspace(const Path& root_path, bool is_hot_star
             }
         }
 
+        // VPath 변환 (Registry 등록 + cook dispatch 모두에 필요)
+        Optional file_vpath = VFS::Unresolve(file_path);
+        if (!file_vpath)
+        {
+            ConsoleLog(ELogLevel::Error, "ScanWorkspace: Fatal error, lost VFS tracking for: {}", file_path);
+            continue;
+        }
+
         const asset::AssetMetadata& meta = content_opt->metadata;
         const bool is_new = meta.sub_assets.IsEmpty();
         const bool is_dirty = !is_new && IsAssetDirty(file_path, meta);
 
         if (is_new || is_dirty)
         {
-            // TODO: BackgroundWorker::PushCookTask(file_vpath) 호출하여 백그라운드에서 DDC 굽기
+            // Background Cook 목록에 Push
+            dirty_vpaths.Push(*file_vpath);
             if (is_new)
             {
                 ++new_count;
@@ -263,15 +290,29 @@ void EditorAssetSubsystem::ScanWorkspace(const Path& root_path, bool is_hot_star
             ++clean_count;
         }
 
-        // 물리 경로 -> VPath 변환 후 Registry에 등록
-        if (Optional file_vpath = VFS::Unresolve(file_path))
+        RegisterFromMeta(*file_vpath, meta);
+    }
+
+    // 백그라운드 병렬 Cook
+    if (!dirty_vpaths.IsEmpty())
+    {
+        const usize total_tasks = dirty_vpaths.Len();
+        ConsoleLog(ELogLevel::Info, "Dispatching {} background cook tasks", total_tasks);
+
+        Array<JobHandle> cook_handles;
+        cook_handles.Reserve(total_tasks);
+
+        for (const VPath& vpath : dirty_vpaths)
         {
-            RegisterFromMeta(*file_vpath, meta);
+            cook_handles.Push(JobSystem::Get().SubmitTask(MakeCookTask(*this, vpath)));
         }
-        else
+
+        for (const auto[n, handle] : cook_handles | std::views::enumerate)
         {
-            ConsoleLog(ELogLevel::Error, "ScanWorkspace: Fatal error, lost VFS tracking for: {}", file_path);
+            handle.Wait();
+            ConsoleLog(ELogLevel::Debug, "Cooking Progress: [{}/{}]", n + 1, total_tasks);
         }
+        ConsoleLog(ELogLevel::Info, "All cook tasks completed.");
     }
 
     // === 삭제된 파일 감지 (Hot Start 전용) ===
@@ -329,8 +370,6 @@ void EditorAssetSubsystem::ScanWorkspace(const Path& root_path, bool is_hot_star
     );
 
     // === DependencyGraph 초기 구축 ===
-    // TODO: BackgroundWorker 전환 시, BuildDependencyGraph()와 CookAsset()이 동시에
-    //       dep_graph을 수정하는 logic race 방지 필요 (incremental update 또는 batch lock)
     BuildDependencyGraph();
 }
 
@@ -380,6 +419,21 @@ Optional<MetaFileContent> EditorAssetSubsystem::EnsureMetaFile(const Path& sourc
 bool EditorAssetSubsystem::CookAsset(const VPath& file_vpath)
 {
     ZoneScopedN("EditorAssetSubsystem::CookAsset");
+
+    // 이중 Cook 방지 (병렬 dispatch 또는 DDC miss handler 동시 호출에 대비)
+    {
+        std::scoped_lock lock{ cooking_mutex };
+        if (currently_cooking.Contains(file_vpath))
+        {
+            ConsoleLog(ELogLevel::Debug, "CookAsset: Already cooking, skipping: {}", file_vpath);
+            return false;
+        }
+        currently_cooking.Insert(file_vpath);
+    }
+    SE_SCOPE_DEFER {
+        std::scoped_lock lock{ cooking_mutex };
+        currently_cooking.Remove(file_vpath);
+    };
 
     // VPath -> 물리 경로 변환 (파일 I/O에 필요)
     const Optional physical_opt = VFS::Resolve(file_vpath);

--- a/Editor/Source/Asset/EditorAssetSubsystem.h
+++ b/Editor/Source/Asset/EditorAssetSubsystem.h
@@ -5,11 +5,15 @@
 
 #include "SimpleEngine/Asset/AssetMetadata.h"
 #include "SimpleEngine/Asset/AssetSubsystem.h"
+#include "SimpleEngine/Core/Container/HashSet.h"
 #include "SimpleEngine/Core/Subsystem/SubsystemBase.h"
 #include "SimpleEngine/Core/Types/Path.h"
 #include "SimpleEngine/Core/Types/VPath.h"
 
+#include "tracy/Tracy.hpp"
+
 #include <memory>
+#include <mutex>
 
 
 namespace se::editor
@@ -111,5 +115,8 @@ private:
     asset::AssetSubsystem* asset_subsystem = nullptr;
     ImportPresetManager preset_manager;
     DependencyGraph dep_graph;
+
+    TracyLockable(std::mutex, cooking_mutex);
+    HashSet<VPath> currently_cooking;
 };
 }  // namespace se::editor

--- a/EngineCore/Include/SimpleEngine/Asset/AssetSubsystem.h
+++ b/EngineCore/Include/SimpleEngine/Asset/AssetSubsystem.h
@@ -3,6 +3,7 @@
 #include "SimpleEngine/Asset/AssetHandle.h"
 #include "SimpleEngine/Asset/AssetPath.h"
 #include "SimpleEngine/Asset/AssetPayload.h"
+#include "SimpleEngine/Core/Concurrency/Coroutine/JobTask.h"
 #include "SimpleEngine/Core/Container/HashSet.h"
 #include "SimpleEngine/Core/Subsystem/SubsystemBase.h"
 #include "SimpleEngine/Core/Types/VPath.h"
@@ -61,6 +62,21 @@ public:
     [[nodiscard]] AssetHandle<T> Load(const AssetPath& asset_path, EScopeLayer scope = EScopeLayer::Scene);
 
     /**
+     * 지정된 경로의 Asset을 비동기로 로드합니다.
+     *
+     * DDC hit 시 AsyncFileIO를 통해 비동기 I/O를 수행합니다.
+     * DDC miss 시 워커 스레드에서 동기 LoadInternal()로 fallback합니다.
+     * 어느 경우든 호출 스레드는 블로킹되지 않습니다.
+     *
+     * @param asset_path Asset 경로 (예: "meshes/model.fbx#Mesh_01")
+     * @param scope 에셋의 수명 범위 및 관리 우선순위 (기본값: Scene)
+     * @return co_await로 대기 가능한 JobTask. 완료 시 AssetHandle<T>를 반환합니다.
+     */
+    template <typename T>
+        requires std::derived_from<T, AssetBase>
+    [[nodiscard]] JobTask<AssetHandle<T>> LoadAsync(const AssetPath& asset_path, EScopeLayer scope = EScopeLayer::Scene);
+
+    /**
      * 캐시에서 Asset을 찾습니다. (Import 수행 안함)
      * @param asset_id Asset의 고유 ID
      */
@@ -91,6 +107,7 @@ public:
 
 private:
     [[nodiscard]] HandleData LoadInternal(const TypeId& expected_type, const AssetPath& source_path, EScopeLayer scope);
+    [[nodiscard]] JobTask<HandleData> LoadAsyncInternal(TypeId expected_type, AssetPath source_path, EScopeLayer scope);
     [[nodiscard]] HandleData FindInternal(const TypeId& expected_type, const AssetId& asset_id) const;
     [[nodiscard]] HandleTable& GetHandleTable() const;
 
@@ -118,6 +135,17 @@ AssetHandle<T> AssetSubsystem::Load(const AssetPath& asset_path, EScopeLayer sco
         return AssetHandle<T>{ handle_data, &GetHandleTable() };
     }
     return {};
+}
+
+template <typename T>
+    requires std::derived_from<T, AssetBase>
+JobTask<AssetHandle<T>> AssetSubsystem::LoadAsync(const AssetPath& asset_path, EScopeLayer scope)
+{
+    if (HandleData handle_data = co_await LoadAsyncInternal(TypeId::Get<T>(), asset_path, scope))
+    {
+        co_return AssetHandle<T>{ handle_data, &GetHandleTable() };
+    }
+    co_return {};
 }
 
 template <typename T>

--- a/EngineCore/Include/SimpleEngine/Asset/AssetSubsystem.h
+++ b/EngineCore/Include/SimpleEngine/Asset/AssetSubsystem.h
@@ -107,10 +107,26 @@ public:
     [[nodiscard]] FORCE_INLINE DerivedDataCache& GetDDC() const { return *ddc; }
 
 private:
+    enum class ESlotAcquireResult : uint8
+    {
+        Loaded,   // 메모리 Cache Hit (handle_data를 즉시 반환 가능)
+        Acquired, // BeginLoad 획득 성공 (DDC 읽기 진행)
+        Failed,   // 타입 불일치
+    };
+
     [[nodiscard]] HandleData LoadInternal(const TypeId& expected_type, const AssetPath& source_path, EScopeLayer scope);
     [[nodiscard]] JobTask<HandleData> LoadAsyncInternal(TypeId expected_type, AssetPath source_path, EScopeLayer scope);
     [[nodiscard]] HandleData FindInternal(const TypeId& expected_type, const AssetId& asset_id) const;
     [[nodiscard]] HandleTable& GetHandleTable() const;
+
+    /**
+     * 슬롯 상태를 확인하고 로딩 권한(BeginLoad)을 획득합니다.
+     * @warning WaitForLoadComplete()가 블로킹이므로 코루틴 컨텍스트에서 호출 시 워커 스레드를 점유합니다.
+     */
+    [[nodiscard]] ESlotAcquireResult AcquireLoadSlot(HandleData handle_data, const TypeId& expected_type);
+
+    /** 역직렬화된 payload를 SlotEntry에 커밋합니다. (메모리 추적 + 상태 전환 + 구 payload 지연 해제) */
+    void CommitLoadedPayload(HandleData handle_data, AssetPayload payload, uint64 payload_size, EScopeLayer scope);
 
 private:
     std::unique_ptr<AssetPool> pool;

--- a/EngineCore/Include/SimpleEngine/Asset/AssetSubsystem.h
+++ b/EngineCore/Include/SimpleEngine/Asset/AssetSubsystem.h
@@ -11,6 +11,7 @@
 #include "tracy/Tracy.hpp"
 
 #include <mutex>
+#include <utility>
 
 
 namespace se::asset
@@ -74,7 +75,7 @@ public:
      */
     template <typename T>
         requires std::derived_from<T, AssetBase>
-    [[nodiscard]] JobTask<AssetHandle<T>> LoadAsync(const AssetPath& asset_path, EScopeLayer scope = EScopeLayer::Scene);
+    [[nodiscard]] JobTask<AssetHandle<T>> LoadAsync(AssetPath asset_path, EScopeLayer scope = EScopeLayer::Scene);
 
     /**
      * 캐시에서 Asset을 찾습니다. (Import 수행 안함)
@@ -139,9 +140,9 @@ AssetHandle<T> AssetSubsystem::Load(const AssetPath& asset_path, EScopeLayer sco
 
 template <typename T>
     requires std::derived_from<T, AssetBase>
-JobTask<AssetHandle<T>> AssetSubsystem::LoadAsync(const AssetPath& asset_path, EScopeLayer scope)
+JobTask<AssetHandle<T>> AssetSubsystem::LoadAsync(AssetPath asset_path, EScopeLayer scope)
 {
-    if (HandleData handle_data = co_await LoadAsyncInternal(TypeId::Get<T>(), asset_path, scope))
+    if (HandleData handle_data = co_await LoadAsyncInternal(TypeId::Get<T>(), std::move(asset_path), scope))
     {
         co_return AssetHandle<T>{ handle_data, &GetHandleTable() };
     }

--- a/EngineCore/Include/SimpleEngine/Asset/DerivedDataCache.h
+++ b/EngineCore/Include/SimpleEngine/Asset/DerivedDataCache.h
@@ -62,6 +62,15 @@ public:
 
 public:
     /**
+     * 메모리 버퍼로부터 캐시 엔트리를 파싱합니다.
+     * AsyncFileIO로 읽은 버퍼를 Load() 없이 직접 파싱할 때 사용합니다.
+     * @param buffer 캐시 파일의 전체 바이너리 데이터
+     * @return 파싱된 CacheEntry. 포맷이 유효하지 않으면 nullopt
+     */
+    [[nodiscard]] static Optional<CacheEntry> ParseFromBuffer(const Array<uint8>& buffer);
+
+public:
+    /**
      * Asset 바이너리를 캐시에 저장합니다.
      * @param guid 캐시 키 (Asset의 GUID)
      * @param entry 캐시에 저장할 Entry
@@ -113,10 +122,10 @@ public:
     /** DDC 루트 경로를 반환합니다. */
     [[nodiscard]] FORCE_INLINE const Path& GetRootPath() const { return root_path; }
 
-private:
     /** GUID로부터 캐시 파일의 전체 경로를 계산합니다. (버킷 디렉토리 포함) */
     [[nodiscard]] Path BuildCachePath(const Guid& guid) const;
 
+private:
     /** GUID로부터 임시 파일의 전체 경로를 계산합니다. (atomic write용) */
     [[nodiscard]] Path BuildTempPath(const Guid& guid) const;
 

--- a/EngineCore/Include/SimpleEngine/Core/Concurrency/AsyncFileIO.h
+++ b/EngineCore/Include/SimpleEngine/Core/Concurrency/AsyncFileIO.h
@@ -5,7 +5,6 @@
 
 #include "SDL3/SDL.h"
 
-#include <memory>
 #include <thread>
 
 
@@ -24,19 +23,8 @@ class Path;
  */
 struct IOResult
 {
-    struct SDLDeleter
-    {
-        void operator()(void* ptr) const
-        {
-            SDL_free(ptr);
-        }
-    };
-
     /** 읽어들인 파일 데이터 */
-    std::unique_ptr<uint8[], SDLDeleter> data;
-
-    /** 실제로 전송된 바이트 수 */
-    usize bytes_transferred = 0;
+    Array<uint8> data;
 
     /** I/O 작업의 성공 여부 */
     bool success = false;

--- a/EngineCore/Include/SimpleEngine/Utility/ScopedTimer.h
+++ b/EngineCore/Include/SimpleEngine/Utility/ScopedTimer.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "SimpleEngine/Core/HAL/PlatformTypes.h"
+
+#include <chrono>
+
+
+namespace se
+{
+/**
+ * RAII 기반 경과 시간 측정 유틸리티
+ *
+ * 생성 시점부터의 경과 시간을 밀리초(double) 또는 초(double)로 반환합니다.
+ * 콜백이나 로깅을 내장하지 않으므로, 호출부에서 자유롭게 출력 형태를 결정할 수 있습니다.
+ *
+ * @code
+ *   ScopedTimer timer;
+ *   DoWork();
+ *   ConsoleLog(ELogLevel::Info, "Elapsed: {:.1f}ms", timer.ElapsedMs());
+ * @endcode
+ */
+class ScopedTimer
+{
+    using Clock = std::chrono::steady_clock;
+
+public:
+    ScopedTimer()
+        : start(Clock::now())
+    {
+    }
+
+    /** 경과 시간을 밀리초(ms)로 반환합니다. */
+    [[nodiscard]] double ElapsedMs() const
+    {
+        const auto elapsed = Clock::now() - start;
+        return std::chrono::duration<double, std::milli>(elapsed).count();
+    }
+
+    /** 경과 시간을 초(s)로 반환합니다. */
+    [[nodiscard]] double ElapsedSec() const
+    {
+        const auto elapsed = Clock::now() - start;
+        return std::chrono::duration<double>(elapsed).count();
+    }
+
+    /** 타이머를 리셋합니다. */
+    void Reset()
+    {
+        start = Clock::now();
+    }
+
+private:
+    Clock::time_point start;
+};
+} // namespace se

--- a/EngineCore/Source/Asset/AssetSubsystem.cpp
+++ b/EngineCore/Source/Asset/AssetSubsystem.cpp
@@ -403,7 +403,7 @@ JobTask<HandleData> AssetSubsystem::LoadAsyncInternal(TypeId expected_type, Asse
 
         if (state == ELoadingState::Loading)
         {
-            // TODO: WaitForLoadComplete는 블로킹 라서,
+            // TODO: WaitForLoadComplete는 블로킹 함수 라서,
             //       만약 병목이 될 경우 co_await 기반의 비동기 대기(SlotEntry에 awaitable notify)로 교체하여
             //       워커 스레드를 양보할 수 있도록 개선.
             get_slot().WaitForLoadComplete();

--- a/EngineCore/Source/Asset/AssetSubsystem.cpp
+++ b/EngineCore/Source/Asset/AssetSubsystem.cpp
@@ -4,6 +4,8 @@
 #include "SimpleEngine/Asset/AssetPool.h"
 #include "SimpleEngine/Asset/AssetRegistry.h"
 #include "SimpleEngine/Asset/DerivedDataCache.h"
+#include "SimpleEngine/Core/Concurrency/AsyncFileIO.h"
+#include "SimpleEngine/Core/Concurrency/Coroutine/CoroutinePrimitives.h"
 #include "SimpleEngine/Core/FileSystem/FileSystem.h"
 #include "SimpleEngine/Core/FileSystem/VFS.h"
 #include "SimpleEngine/Core/Logging/Logging.h"
@@ -73,7 +75,7 @@ void AssetSubsystem::DeferRelease(AssetPayload payload)
         return;
     }
 
-    pool->DeferDestroy(std::move(payload), frame_count);
+    pool->DeferDestroy(payload, frame_count);
 }
 
 void AssetSubsystem::EndFrame()
@@ -120,18 +122,21 @@ AssetPayload AssetSubsystem::DeserializeAssetPayload(const TypeId& type_id, cons
     MemoryReader reader(payload);
     info_opt->serialize(reader, raw);
 
-    return AssetPayload{ static_cast<AssetBase*>(raw), info_opt->destructor };
+    return {
+        .ptr = static_cast<AssetBase*>(raw),
+        .destructor = info_opt->destructor
+    };
 }
 
 HandleData AssetSubsystem::LoadInternal(const TypeId& expected_type, const AssetPath& source_path, EScopeLayer scope)
 {
     ZoneScopedN("AssetSubsystem::LoadInternal");
-    {
+    SE_DEBUG_EXPRESSION({
         const String zone_text = String::Format("{} | {}", expected_type.GetName(), source_path.ToString());
         ZoneText(zone_text.CStr(), zone_text.ByteLen());
-    }
+    })
 
-    VPath file_vpath = source_path.GetFilePath();
+    const VPath& file_vpath = source_path.GetFilePath();
     const bool has_sub_name = source_path.HasSubAsset();
 
     // Registry에서 AssetId 조회
@@ -208,12 +213,12 @@ HandleData AssetSubsystem::LoadInternal(const TypeId& expected_type, const Asset
             {
                 if (auto entry_opt = ddc->Load(current_id.GetGuid()))
                 {
-                    if (AssetPayload payload = DeserializeAssetPayload(expected_type, entry_opt->payload))
+                    if (const AssetPayload payload = DeserializeAssetPayload(expected_type, entry_opt->payload))
                     {
                         SlotEntry& current_slot = get_slot();
 
                         // 기존 슬롯에 있던 Asset을 교체
-                        AssetPayload old_payload = current_slot.ExchangePayload(std::move(payload)); // ownership transferred to SlotEntry
+                        const AssetPayload old_payload = current_slot.ExchangePayload(payload); // ownership transferred to SlotEntry
 
                         // Eviction 메타데이터 설정
                         const uint64 old_size = current_slot.asset_size_bytes;
@@ -236,7 +241,7 @@ HandleData AssetSubsystem::LoadInternal(const TypeId& expected_type, const Asset
 
                         if (old_payload)
                         {
-                            DeferRelease(std::move(old_payload));
+                            DeferRelease(old_payload);
                         }
                         ConsoleLog(ELogLevel::Debug, "Loaded from DDC: {}", source_path.ToString());
                         return handle_data;
@@ -340,6 +345,140 @@ HandleData AssetSubsystem::FindInternal(const TypeId& expected_type, const Asset
     }
 
     return handle_data;
+}
+
+JobTask<HandleData> AssetSubsystem::LoadAsyncInternal(TypeId expected_type, AssetPath source_path, EScopeLayer scope)
+{
+    // Worker 스레드로 전환 (호출 스레드 비블로킹 보장)
+    co_await ResumeOn{ EJobThread::Worker };
+
+    ZoneScopedN("AssetSubsystem::LoadAsyncInternal");
+    SE_DEBUG_EXPRESSION({
+        const String zone_text = String::Format("{} | {}", expected_type.GetName(), source_path.ToString());
+        ZoneText(zone_text.CStr(), zone_text.ByteLen());
+    })
+
+    const VPath& file_vpath = source_path.GetFilePath();
+    const bool has_sub_name = source_path.HasSubAsset();
+
+    // Registry에서 AssetId 조회
+    auto find_asset_id = [&] -> Optional<AssetId>
+    {
+        if (has_sub_name)
+        {
+            return registry->GetAssetId(source_path);
+        }
+        return registry->FindFirstOfType(file_vpath, expected_type);
+    };
+
+    const Optional id_opt = find_asset_id();
+    if (!id_opt)
+    {
+        // Registry에 없으면 동기 fallback (DDC miss handler가 Import를 수행할 수 있음)
+        co_return LoadInternal(expected_type, source_path, scope);
+    }
+
+    const AssetId& asset_id = id_opt.Value();
+    HandleData handle_data = pool->FindOrCreate(asset_id, expected_type, source_path);
+    HandleTable& table = pool->GetTable();
+
+    const auto get_slot = [&] -> SlotEntry&
+    {
+        return table.GetSlot(handle_data.index);
+    };
+
+    // 메모리 캐시 hit 또는 다른 스레드가 로딩 중이면 대기
+    while (true)
+    {
+        const ELoadingState state = get_slot().GetState();
+        if (state == ELoadingState::Loaded)
+        {
+            if (get_slot().asset_type == expected_type)
+            {
+                co_return handle_data;
+            }
+            ConsoleLog(ELogLevel::Error, "Asset Type Mismatch!");
+            co_return HandleData{};
+        }
+
+        if (state == ELoadingState::Loading)
+        {
+            // TODO: WaitForLoadComplete는 블로킹 라서,
+            //       만약 병목이 될 경우 co_await 기반의 비동기 대기(SlotEntry에 awaitable notify)로 교체하여
+            //       워커 스레드를 양보할 수 있도록 개선.
+            get_slot().WaitForLoadComplete();
+            continue;
+        }
+
+        if (get_slot().BeginLoad())
+        {
+            break;
+        }
+    }
+
+    // DDC validity 확인
+    String source_hash;
+    uint32 cache_version;
+    const bool has_meta = registry->ReadRecord(asset_id, [&source_hash, &cache_version](const AssetRecord& record)
+    {
+        source_hash = record.metadata.source_hash;
+        cache_version = record.metadata.cache_version;
+    });
+
+    if (has_meta && ddc->IsValid(asset_id.GetGuid(), source_hash, cache_version))
+    {
+        // 비동기 I/O로 DDC 캐시 파일 읽기
+        const Path cache_path = ddc->BuildCachePath(asset_id.GetGuid());
+
+        if (AsyncFileIO::IsInitialized())
+        {
+            IOResult io_result = co_await AsyncFileIO::Get().ReadFileAsync(cache_path);
+
+            if (io_result.success && !io_result.data.IsEmpty())
+            {
+                if (Optional<CacheEntry> entry_opt = DerivedDataCache::ParseFromBuffer(io_result.data))
+                {
+                    if (const AssetPayload payload = DeserializeAssetPayload(expected_type, entry_opt->payload))
+                    {
+                        SlotEntry& current_slot = get_slot();
+
+                        AssetPayload old_payload = current_slot.ExchangePayload(payload);
+
+                        const uint64 old_size = current_slot.asset_size_bytes;
+                        const uint64 new_size = entry_opt->payload.Len();
+                        current_slot.asset_size_bytes = new_size;
+                        current_slot.last_access_frame.store(frame_count, std::memory_order_relaxed);
+                        current_slot.scope = scope;
+
+                        if (new_size > old_size)
+                        {
+                            table.TrackMemoryUsage(new_size - old_size);
+                        }
+                        else if (new_size < old_size)
+                        {
+                            table.UntrackMemoryUsage(old_size - new_size);
+                        }
+
+                        current_slot.SetState(ELoadingState::Loaded);
+
+                        if (old_payload)
+                        {
+                            DeferRelease(old_payload);
+                        }
+                        ConsoleLog(ELogLevel::Debug, "LoadAsync: Loaded from DDC (async I/O): {}", source_path.ToString());
+                        co_return handle_data;
+                    }
+                }
+            }
+        }
+    }
+
+    // DDC miss 또는 비동기 I/O 실패 -> 동기 fallback
+    // BeginLoad 상태를 되돌려서 LoadInternal이 다시 획득할 수 있게 함
+    get_slot().SetState(ELoadingState::Unloaded);
+
+    ConsoleLog(ELogLevel::Debug, "LoadAsync: Falling back to sync LoadInternal: {}", source_path.ToString());
+    co_return LoadInternal(expected_type, source_path, scope);
 }
 
 HandleTable& AssetSubsystem::GetHandleTable() const

--- a/EngineCore/Source/Asset/AssetSubsystem.cpp
+++ b/EngineCore/Source/Asset/AssetSubsystem.cpp
@@ -75,7 +75,7 @@ void AssetSubsystem::DeferRelease(AssetPayload payload)
         return;
     }
 
-    pool->DeferDestroy(payload, frame_count);
+    pool->DeferDestroy(std::move(payload), frame_count);
 }
 
 void AssetSubsystem::EndFrame()
@@ -122,10 +122,7 @@ AssetPayload AssetSubsystem::DeserializeAssetPayload(const TypeId& type_id, cons
     MemoryReader reader(payload);
     info_opt->serialize(reader, raw);
 
-    return {
-        .ptr = static_cast<AssetBase*>(raw),
-        .destructor = info_opt->destructor
-    };
+    return AssetPayload{ static_cast<AssetBase*>(raw), info_opt->destructor };
 }
 
 HandleData AssetSubsystem::LoadInternal(const TypeId& expected_type, const AssetPath& source_path, EScopeLayer scope)
@@ -172,32 +169,16 @@ HandleData AssetSubsystem::LoadInternal(const TypeId& expected_type, const Asset
             handle_data = pool->FindOrCreate(current_id, expected_type, source_path);
 
             // [Slot-Level Lock] 로딩 상태 동기화
-            while (true)
+            switch (AcquireLoadSlot(handle_data, expected_type))
             {
-                const ELoadingState state = get_slot().GetState();
-                if (state == ELoadingState::Loaded)
-                {
-                    // 메모리 Cache Hit
-                    if (get_slot().asset_type == expected_type)
-                    {
-                        return handle_data;
-                    }
-                    ConsoleLog(ELogLevel::Error, "Asset Type Mismatch!");
-                    return {};
-                }
-
-                if (state == ELoadingState::Loading)
-                {
-                    // 다른 스레드가 DDC를 읽거나 Import 중이므로 Sleep
-                    get_slot().WaitForLoadComplete();
-                    continue; // 깨어나면 상태를 다시 확인
-                }
-
-                // Unloaded 또는 Failed 라면, 현재 스레드에서 로딩 시작
-                if (get_slot().BeginLoad())
-                {
-                    break;
-                }
+            case ESlotAcquireResult::Loaded:
+                return handle_data;
+            case ESlotAcquireResult::Failed:
+                return {};
+            case ESlotAcquireResult::Acquired:
+                break;
+            default:
+                SE_UNREACHABLE();
             }
 
             // DDC Hit 검사 및 로드 수행
@@ -213,36 +194,9 @@ HandleData AssetSubsystem::LoadInternal(const TypeId& expected_type, const Asset
             {
                 if (auto entry_opt = ddc->Load(current_id.GetGuid()))
                 {
-                    if (const AssetPayload payload = DeserializeAssetPayload(expected_type, entry_opt->payload))
+                    if (AssetPayload payload = DeserializeAssetPayload(expected_type, entry_opt->payload))
                     {
-                        SlotEntry& current_slot = get_slot();
-
-                        // 기존 슬롯에 있던 Asset을 교체
-                        const AssetPayload old_payload = current_slot.ExchangePayload(payload); // ownership transferred to SlotEntry
-
-                        // Eviction 메타데이터 설정
-                        const uint64 old_size = current_slot.asset_size_bytes;
-                        const uint64 new_size = entry_opt->payload.Len();
-                        current_slot.asset_size_bytes = new_size;
-                        current_slot.last_access_frame.store(frame_count, std::memory_order_relaxed);
-                        current_slot.scope = scope;
-
-                        if (new_size > old_size)
-                        {
-                            table.TrackMemoryUsage(new_size - old_size);
-                        }
-                        else if (new_size < old_size)
-                        {
-                            table.UntrackMemoryUsage(old_size - new_size);
-                        }
-
-                        // 로딩 완료
-                        current_slot.SetState(ELoadingState::Loaded);
-
-                        if (old_payload)
-                        {
-                            DeferRelease(old_payload);
-                        }
+                        CommitLoadedPayload(handle_data, std::move(payload), entry_opt->payload.Len(), scope);
                         ConsoleLog(ELogLevel::Debug, "Loaded from DDC: {}", source_path.ToString());
                         return handle_data;
                     }
@@ -324,6 +278,71 @@ HandleData AssetSubsystem::LoadInternal(const TypeId& expected_type, const Asset
     return {};
 }
 
+// ReSharper disable once CppMemberFunctionMayBeConst
+AssetSubsystem::ESlotAcquireResult AssetSubsystem::AcquireLoadSlot(HandleData handle_data, const TypeId& expected_type)
+{
+    HandleTable& table = pool->GetTable();
+    while (true)
+    {
+        SlotEntry& slot = table.GetSlot(handle_data.index);
+        const ELoadingState state = slot.GetState();
+
+        if (state == ELoadingState::Loaded)
+        {
+            if (slot.asset_type == expected_type)
+            {
+                return ESlotAcquireResult::Loaded;
+            }
+            ConsoleLog(ELogLevel::Error, "Asset Type Mismatch!");
+            return ESlotAcquireResult::Failed;
+        }
+
+        if (state == ELoadingState::Loading)
+        {
+            // TODO: WaitForLoadComplete는 블로킹 함수라서,
+            //       만약 병목이 될 경우 co_await 기반의 비동기 대기(SlotEntry에 awaitable notify)로 교체하여
+            //       워커 스레드를 양보할 수 있도록 개선.
+            slot.WaitForLoadComplete();
+            continue;
+        }
+
+        if (slot.BeginLoad())
+        {
+            return ESlotAcquireResult::Acquired;
+        }
+    }
+}
+
+void AssetSubsystem::CommitLoadedPayload(HandleData handle_data, AssetPayload payload, uint64 payload_size, EScopeLayer scope)
+{
+    HandleTable& table = pool->GetTable();
+    SlotEntry& current_slot = table.GetSlot(handle_data.index);
+
+    AssetPayload old_payload = current_slot.ExchangePayload(std::move(payload));
+
+    const uint64 old_size = current_slot.asset_size_bytes;
+    const uint64 new_size = payload_size;
+    current_slot.asset_size_bytes = new_size;
+    current_slot.last_access_frame.store(frame_count, std::memory_order_relaxed);
+    current_slot.scope = scope;
+
+    if (new_size > old_size)
+    {
+        table.TrackMemoryUsage(new_size - old_size);
+    }
+    else if (new_size < old_size)
+    {
+        table.UntrackMemoryUsage(old_size - new_size);
+    }
+
+    current_slot.SetState(ELoadingState::Loaded);
+
+    if (old_payload)
+    {
+        DeferRelease(std::move(old_payload));
+    }
+}
+
 HandleData AssetSubsystem::FindInternal(const TypeId& expected_type, const AssetId& asset_id) const
 {
     Optional<HandleData> handle_opt = pool->Find(asset_id);
@@ -380,40 +399,18 @@ JobTask<HandleData> AssetSubsystem::LoadAsyncInternal(TypeId expected_type, Asse
 
     const AssetId& asset_id = id_opt.Value();
     HandleData handle_data = pool->FindOrCreate(asset_id, expected_type, source_path);
-    HandleTable& table = pool->GetTable();
-
-    const auto get_slot = [&] -> SlotEntry&
-    {
-        return table.GetSlot(handle_data.index);
-    };
 
     // 메모리 캐시 hit 또는 다른 스레드가 로딩 중이면 대기
-    while (true)
+    switch (AcquireLoadSlot(handle_data, expected_type))
     {
-        const ELoadingState state = get_slot().GetState();
-        if (state == ELoadingState::Loaded)
-        {
-            if (get_slot().asset_type == expected_type)
-            {
-                co_return handle_data;
-            }
-            ConsoleLog(ELogLevel::Error, "Asset Type Mismatch!");
-            co_return HandleData{};
-        }
-
-        if (state == ELoadingState::Loading)
-        {
-            // TODO: WaitForLoadComplete는 블로킹 함수 라서,
-            //       만약 병목이 될 경우 co_await 기반의 비동기 대기(SlotEntry에 awaitable notify)로 교체하여
-            //       워커 스레드를 양보할 수 있도록 개선.
-            get_slot().WaitForLoadComplete();
-            continue;
-        }
-
-        if (get_slot().BeginLoad())
-        {
-            break;
-        }
+    case ESlotAcquireResult::Loaded:
+        co_return handle_data;
+    case ESlotAcquireResult::Failed:
+        co_return HandleData{};
+    case ESlotAcquireResult::Acquired:
+        break;
+    default:
+        SE_UNREACHABLE();
     }
 
     // DDC validity 확인
@@ -438,33 +435,9 @@ JobTask<HandleData> AssetSubsystem::LoadAsyncInternal(TypeId expected_type, Asse
             {
                 if (Optional<CacheEntry> entry_opt = DerivedDataCache::ParseFromBuffer(io_result.data))
                 {
-                    if (const AssetPayload payload = DeserializeAssetPayload(expected_type, entry_opt->payload))
+                    if (AssetPayload payload = DeserializeAssetPayload(expected_type, entry_opt->payload))
                     {
-                        SlotEntry& current_slot = get_slot();
-
-                        AssetPayload old_payload = current_slot.ExchangePayload(payload);
-
-                        const uint64 old_size = current_slot.asset_size_bytes;
-                        const uint64 new_size = entry_opt->payload.Len();
-                        current_slot.asset_size_bytes = new_size;
-                        current_slot.last_access_frame.store(frame_count, std::memory_order_relaxed);
-                        current_slot.scope = scope;
-
-                        if (new_size > old_size)
-                        {
-                            table.TrackMemoryUsage(new_size - old_size);
-                        }
-                        else if (new_size < old_size)
-                        {
-                            table.UntrackMemoryUsage(old_size - new_size);
-                        }
-
-                        current_slot.SetState(ELoadingState::Loaded);
-
-                        if (old_payload)
-                        {
-                            DeferRelease(old_payload);
-                        }
+                        CommitLoadedPayload(handle_data, std::move(payload), entry_opt->payload.Len(), scope);
                         ConsoleLog(ELogLevel::Debug, "LoadAsync: Loaded from DDC (async I/O): {}", source_path.ToString());
                         co_return handle_data;
                     }
@@ -475,7 +448,7 @@ JobTask<HandleData> AssetSubsystem::LoadAsyncInternal(TypeId expected_type, Asse
 
     // DDC miss 또는 비동기 I/O 실패 -> 동기 fallback
     // BeginLoad 상태를 되돌려서 LoadInternal이 다시 획득할 수 있게 함
-    get_slot().SetState(ELoadingState::Unloaded);
+    pool->GetTable().GetSlot(handle_data.index).SetState(ELoadingState::Unloaded);
 
     ConsoleLog(ELogLevel::Debug, "LoadAsync: Falling back to sync LoadInternal: {}", source_path.ToString());
     co_return LoadInternal(expected_type, source_path, scope);

--- a/EngineCore/Source/Asset/DerivedDataCache.cpp
+++ b/EngineCore/Source/Asset/DerivedDataCache.cpp
@@ -214,13 +214,14 @@ Optional<CacheEntry> DerivedDataCache::Load(const Guid& guid) const
 
     const Path cache_path = BuildCachePath(guid);
 
-    const auto buffer_opt = FileSystem::ReadBytes(cache_path);
-    if (!buffer_opt.HasValue())
+    const FileResult<Array<uint8>> buffer_result = FileSystem::ReadBytes(cache_path);
+    if (buffer_result)
     {
-        return NullOpt;
+        return ParseFromBuffer(buffer_result.Value());
     }
 
-    return ParseFromBuffer(buffer_opt.Value());
+    ConsoleLog(ELogLevel::Warning, "DDC::Load - Failed to read cache file: {}, Err: {}", cache_path, buffer_result.Error().What());
+    return NullOpt;
 }
 
 // source_hash와 cache_version이 모두 일치해야 유효한 것으로 판단.

--- a/EngineCore/Source/Asset/DerivedDataCache.cpp
+++ b/EngineCore/Source/Asset/DerivedDataCache.cpp
@@ -120,6 +120,48 @@ DerivedDataCache::DerivedDataCache(Path in_root_path)
     }
 }
 
+Optional<CacheEntry> DerivedDataCache::ParseFromBuffer(const Array<uint8>& buffer)
+{
+    MemoryReader reader{ buffer };
+    DDC_CacheEntryInternal cache_internal;
+
+    // Header 역직렬화
+    reader << cache_internal.header;
+
+    if (reader.HasError())
+    {
+        ConsoleLog(ELogLevel::Warning, "DDC::ParseFromBuffer - Header deserialization failed");
+        return NullOpt;
+    }
+
+    // Magic 검증
+    if (cache_internal.header.magic != CACHE_MAGIC)
+    {
+        ConsoleLog(ELogLevel::Warning, "DDC::ParseFromBuffer - Invalid magic: {:#x}", cache_internal.header.magic);
+        return NullOpt;
+    }
+
+    // Format Version 검증
+    if (cache_internal.header.format_version != CACHE_FORMAT_VERSION)
+    {
+        ConsoleLog(
+            ELogLevel::Warning,
+            "DDC::ParseFromBuffer - Format version mismatch (expected: {}, got: {})",
+            CACHE_FORMAT_VERSION, cache_internal.header.format_version
+        );
+        return NullOpt;
+    }
+
+    // Payload 역직렬화
+    reader << cache_internal.payload;
+
+    return CacheEntry{
+        .source_hash = std::move(cache_internal.header.source_hash),
+        .cache_version = cache_internal.header.cache_version,
+        .payload = std::move(cache_internal.payload),
+    };
+}
+
 bool DerivedDataCache::Store(const Guid& guid, CacheEntry&& entry)
 {
     ZoneScopedN("DDC::Store");
@@ -178,44 +220,7 @@ Optional<CacheEntry> DerivedDataCache::Load(const Guid& guid) const
         return NullOpt;
     }
 
-    MemoryReader reader(buffer_opt.Value());
-    DDC_CacheEntryInternal cache_internal;
-
-    // Header 불러오기
-    reader << cache_internal.header;
-
-    if (reader.HasError())
-    {
-        ConsoleLog(ELogLevel::Warning, "DDC::Load - Serialization error: {} in {}", reader.GetError(), cache_path);
-        return NullOpt;
-    }
-
-    // Magic 검증
-    if (cache_internal.header.magic != CACHE_MAGIC)
-    {
-        ConsoleLog(ELogLevel::Warning, "DDC::Load - Invalid magic in: {}", cache_path);
-        return NullOpt;
-    }
-
-    // Format Version 검증
-    if (cache_internal.header.format_version != CACHE_FORMAT_VERSION)
-    {
-        ConsoleLog(
-            ELogLevel::Warning,
-            "DDC::Load - Format version mismatch (expected: {}, got: {}): {}",
-            CACHE_FORMAT_VERSION, cache_internal.header.format_version, cache_path
-        );
-        return NullOpt;
-    }
-
-    // Payload 역직렬화
-    reader << cache_internal.payload;
-
-    return CacheEntry{
-        .source_hash = std::move(cache_internal.header.source_hash),
-        .cache_version = cache_internal.header.cache_version,
-        .payload = std::move(cache_internal.payload),
-    };
+    return ParseFromBuffer(buffer_opt.Value());
 }
 
 // source_hash와 cache_version이 모두 일치해야 유효한 것으로 판단.
@@ -289,4 +294,4 @@ Path DerivedDataCache::BuildTempPath(const Guid& guid) const
 
     return root_path / bucket / filename;
 }
-}  // namespace se::asset
+} // namespace se::asset

--- a/EngineCore/Source/Core/Concurrency/AsyncFileIO.cpp
+++ b/EngineCore/Source/Core/Concurrency/AsyncFileIO.cpp
@@ -189,8 +189,7 @@ void AsyncFileIO::ReadFile(const Path& path, UniqueFunction<void(IOResult)>&& ca
     ctx->mode = IORequestContext::EMode::Callback;
     ctx->callback = std::move(callback);
 
-    const String str_path = path.ToString();
-    if (!SDL_LoadFileAsync(str_path.CStr(), io_queue, ctx))
+    if (!SDL_LoadFileAsync(path.CStr(), io_queue, ctx))
     {
         // Load에 실패한 경우, 에러 결과를 Worker에서 전달 (Poller에서 직접 실행 금지)
         JobSystem::Get().Dispatch([ctx]
@@ -198,7 +197,7 @@ void AsyncFileIO::ReadFile(const Path& path, UniqueFunction<void(IOResult)>&& ca
             IOResult error_result;
             error_result.success = false;
 
-            const auto cb = std::move(ctx->callback);
+            const UniqueFunction<void(IOResult)> cb = std::move(ctx->callback);
             delete ctx;
             cb(std::move(error_result));
         });
@@ -207,7 +206,10 @@ void AsyncFileIO::ReadFile(const Path& path, UniqueFunction<void(IOResult)>&& ca
 
 JobTask<IOResult> AsyncFileIO::ReadFileAsync(const Path& path)
 {
-    co_return co_await AsyncReadAwaitable{ io_queue, path };
+    co_return co_await AsyncReadAwaitable{
+        .queue = io_queue,
+        .path = path
+    };
 }
 
 void AsyncFileIO::PollerLoop(const std::stop_token& stoken)
@@ -236,7 +238,7 @@ void AsyncFileIO::PollerLoop(const std::stop_token& stoken)
         }
 
         // SDL 결과를 엔진 IOResult로 변환
-        IOResult result = BuildIOResult(std::move(outcome));
+        IOResult result = BuildIOResult(std::move(outcome)); // NOLINT(*-move-const-arg)
 
         // Context Mode에 따른 분기
         switch (ctx->mode)

--- a/EngineCore/Source/Core/Concurrency/AsyncFileIO.cpp
+++ b/EngineCore/Source/Core/Concurrency/AsyncFileIO.cpp
@@ -102,20 +102,22 @@ struct AsyncReadAwaitable
  */
 IOResult BuildIOResult(SDL_AsyncIOOutcome&& outcome)
 {
+    SE_SCOPE_DEFER {
+        if (outcome.buffer)
+        {
+            SDL_free(outcome.buffer);
+            outcome.buffer = nullptr;
+        }
+    };
+
     IOResult result;
     result.success = outcome.result == SDL_ASYNCIO_COMPLETE;
 
     if (result.success && outcome.buffer && outcome.bytes_transferred > 0)
     {
-        // outcome.buffer의 소유권을 IOResult로 이동
-        result.data.reset(static_cast<uint8*>(outcome.buffer));
-        result.bytes_transferred = static_cast<usize>(outcome.bytes_transferred);
-    }
-    else if (outcome.buffer)
-    {
-        // 실패했거나 바이트가 0일 때만 해제
-        SDL_free(outcome.buffer);
-        outcome.buffer = nullptr;
+        const usize size = static_cast<usize>(outcome.bytes_transferred);
+        result.data.ResizeUninitialized(size);
+        std::memcpy(result.data.Data(), outcome.buffer, size);
     }
 
     return result;

--- a/EngineTest/Source/UnitTests/AsyncFileIOTest.cpp
+++ b/EngineTest/Source/UnitTests/AsyncFileIOTest.cpp
@@ -82,8 +82,8 @@ TEST_F(AsyncFileIOTest, ReadFile_Callback_Success)
     const IOResult result = future.get();
 
     EXPECT_TRUE(result.success);
-    EXPECT_EQ(result.bytes_transferred, std::strlen(test_content));
-    EXPECT_EQ(std::memcmp(result.data.get(), test_content, result.bytes_transferred), 0);
+    EXPECT_EQ(result.data.Len(), std::strlen(test_content));
+    EXPECT_EQ(std::memcmp(result.data.Data(), test_content, result.data.Len()), 0);
 }
 
 TEST_F(AsyncFileIOTest, ReadFile_Callback_NonExistent)
@@ -141,8 +141,8 @@ TEST_F(AsyncFileIOTest, ReadFileAsync_Success)
     h.Wait();
 
     EXPECT_TRUE(captured_result.success);
-    EXPECT_EQ(captured_result.bytes_transferred, std::strlen(test_content));
-    EXPECT_EQ(std::memcmp(captured_result.data.get(), test_content, captured_result.bytes_transferred), 0);
+    EXPECT_EQ(captured_result.data.Len(), std::strlen(test_content));
+    EXPECT_EQ(std::memcmp(captured_result.data.Data(), test_content, captured_result.data.Len()), 0);
 }
 
 TEST_F(AsyncFileIOTest, ReadFileAsync_NonExistent)


### PR DESCRIPTION
## 주요 변경 사항

- RAII 기반 `SocpedTimer`를 추가하였습니다.
- 에디터 시작 시, ScanWorkspace에서 새로운 `.meta`파일에 대해서 병렬적으로 DDC Cook을 하도록 기능을 추가하였습니다.
- `IOResult`의 내부 구조를 다시 `Array<uint8>`의 형태로 변경하였습니다.
- `DerivedDataCache::Load`에서 파싱을 담당하는 로직을 `static ParseFromBuffer`로 추출하였습니다. (비동기 IO로 가져온 데이터로 불러오기 위함)
- `AssetSubsystem`에 비동기 에셋 로딩을 지원하는 `LoadAsync()`를 추가하였습니다.

## 추후 할 일

1. `.meta` 생성 로직과 DDC Cook을 완전 Background Cook으로 변경