### PR TITLE
perf: Array trivially copyable 타입에 memmove/memcpy 최적화 적용

### DIFF
--- a/EngineCore/Include/SimpleEngine/Core/Container/Array.inl
+++ b/EngineCore/Include/SimpleEngine/Core/Container/Array.inl
@@ -1,5 +1,6 @@
 ﻿#pragma once
 #include <algorithm>
+#include <cstring>
 #include <memory>
 #include <utility>
 
@@ -412,15 +413,27 @@ void Array<T, Allocator>::Insert(SizeType index, T&& value)
 
     EnsureCapacity(size + 1);
 
-    // 마지막 요소를 비어있는 다음 슬롯으로 이동 생성
-    AllocTraits::construct(allocator, data + size, std::move(BackUnsafe()));
+    if constexpr (std::is_trivially_copyable_v<T>)
+    {
+        // 복사 비용이 없는 타입은 메모리 직접 복사(Bitwise move)로 고속 이동
+        std::memmove(
+            data + index + 1,           // 대상 시작: (index + 1)
+            data + index,               // 소스 시작: (index)
+            (size - index) * sizeof(T)  // 이동 개수: (index부터 끝까지)
+        );
+    }
+    else
+    {
+        // 마지막 요소를 비어있는 다음 슬롯으로 이동 생성
+        AllocTraits::construct(allocator, data + size, std::move(BackUnsafe()));
 
-    // 나머지 요소를 뒤로 한 칸씩 이동
-    std::move_backward(
-        data + index,    // 소스 시작: (index)
-        data + size - 1, // 소스 끝: (size - 1)
-        data + size      // 대상 끝: (size)
-    );
+        // 나머지 요소를 뒤로 한 칸씩 이동
+        std::move_backward(
+            data + index,    // 소스 시작: (index)
+            data + size - 1, // 소스 끝: (size - 1)
+            data + size      // 대상 끝: (size)
+        );
+    }
 
     // index에 새 요소 삽입
     data[index] = std::move(value);
@@ -446,11 +459,24 @@ void Array<T, Allocator>::Insert(SizeType index, It first, It last)
         // 삽입 지점 뒤의 기존 원소들을 뒤로 이동시킬 공간을 생성
         if (index < size)
         {
-            std::uninitialized_move(
-                data + index,
-                data + size,
-                data + index + count
-            );
+            if constexpr (std::is_trivially_copyable_v<T>)
+            {
+                // 복사 비용이 없는 타입은 메모리 직접 복사(Bitwise move)로 고속 이동
+                std::memmove(
+                    data + index + count,      // 대상 시작: (index + count)
+                    data + index,              // 소스 시작: (index)
+                    (size - index) * sizeof(T) // 이동 개수: (index부터 끝까지)
+                );
+            }
+            else
+            {
+                // 이동 생성/대입이 필요한 타입은 초기화되지 않은 영역으로 소유권 이전
+                std::uninitialized_move(
+                    data + index,        // 소스 시작: (index)
+                    data + size,         // 소스 끝: (size)
+                    data + index + count // 대상 시작: (index + count)
+                );
+            }
         }
 
         // 새로운 원소들을 빈 공간에 복사
@@ -490,10 +516,29 @@ void Array<T, Allocator>::RemoveAt(SizeType index)
     SE_ASSERT(index < size, "RemoveAt index out of bounds");
 
     // 제거할 요소 뒤의 모든 요소를 앞으로 한 칸씩 이동
-    std::move(data + index + 1, data + size, data + index);
+    if constexpr (std::is_trivially_copyable_v<T>)
+    {
+        // 복사 비용이 없는 타입은 메모리 직접 복사(Bitwise move)로 고속 덮어쓰기
+        std::memmove(
+            data + index,                  // 대상 시작: (index)
+            data + index + 1,              // 소스 시작: (index + 1)
+            (size - index - 1) * sizeof(T) // 이동 개수: (삭제 지점 다음부터 끝까지)
+        );
+    }
+    else
+    {
+        // 이동 생성/대입이 필요한 타입은 소유권을 앞으로 이동시킨 후 마지막 슬롯 정리
+        std::move(
+            data + index + 1, // 소스 시작: (index + 1)
+            data + size,      // 소스 끝: (size)
+            data + index      // 대상 시작: (index)
+        );
+
+        // 이동 후 남겨진 마지막 요소의 소멸자 호출
+        AllocTraits::destroy(allocator, data + size - 1);
+    }
 
     size -= 1;
-    AllocTraits::destroy(allocator, data + size);
 }
 
 template <typename T, typename Allocator>
@@ -506,14 +551,27 @@ void Array<T, Allocator>::RemoveRange(SizeType index, SizeType count)
     }
 
     // 제거할 범위 뒤의 모든 요소를 앞으로 이동
-    T* const result = std::move(
-        data + index + count,
-        data + size,
-        data + index
-    );
+    if constexpr (std::is_trivially_copyable_v<T>)
+    {
+        // 복사 비용이 없는 타입은 메모리 직접 복사(Bitwise move)로 고속 덮어쓰기
+        std::memmove(
+            data + index,                      // 대상 시작: (index)
+            data + index + count,              // 소스 시작: (index + count)
+            (size - index - count) * sizeof(T) // 이동 개수: (삭제 범위 다음부터 끝까지)
+        );
+    }
+    else
+    {
+        // 이동 생성/대입이 필요한 타입은 소유권을 앞으로 이동시킨 후 남겨진 슬롯들 정리
+        T* const result = std::move(
+            data + index + count, // 소스 시작: (index + count)
+            data + size,          // 소스 끝: (size)
+            data + index          // 대상 시작: (index)
+        );
 
+        std::destroy(result, data + size);
+    }
     size -= count;
-    std::destroy(result, data + size);
 }
 
 template <typename T, typename Allocator>
@@ -638,12 +696,28 @@ void Array<T, Allocator>::Reallocate(SizeType new_capacity)
 {
     SE_ASSERT(new_capacity >= size, "Reallocate new_capacity must be greater than or equal to size");
 
+    // 새로운 메모리 블록 할당
     T* new_data = AllocTraits::allocate(allocator, new_capacity);
 
     if (data)
     {
-        std::uninitialized_move_n(data, size, new_data);
-        std::destroy_n(data, size);
+        if constexpr (std::is_trivially_copyable_v<T>)
+        {
+            // 복사 비용이 없는 타입은 메모리 직접 복사(Bitwise copy)로 고속 이전
+            std::memcpy(
+                new_data,        // 대상 시작: (새 메모리)
+                data,            // 소스 시작: (기존 메모리)
+                size * sizeof(T) // 복사 크기: (전체 데이터)
+            );
+        }
+        else
+        {
+            // 이동 생성/대입이 필요한 타입은 새로운 영역으로 소유권 이전 후 기존 객체 파괴
+            std::uninitialized_move_n(data, size, new_data);
+            std::destroy_n(data, size);
+        }
+
+        // 기존 메모리 블록 해제
         AllocTraits::deallocate(allocator, data, capacity);
     }
 

--- a/EngineTest/Source/Benchmark/ArrayBenchmark.cpp
+++ b/EngineTest/Source/Benchmark/ArrayBenchmark.cpp
@@ -6,6 +6,166 @@
 
 namespace se::benchmark_test
 {
+
+// ============================================================
+// memmove 최적화 효과 측정
+// 대상 연산: Reallocate(Push realloc path), RemoveAt(0), Insert(0, ...)
+//
+// LargePod        — trivially copyable (최적화 대상)
+// LargeNonTrivial — non-trivially copyable (변화 없어야 하는 baseline)
+// ============================================================
+
+struct alignas(16) LargePod
+{
+    int data[8] = {};
+};
+static_assert(std::is_trivially_copyable_v<LargePod>);
+
+struct LargeNonTrivial
+{
+    int data[8] = {};
+    ~LargeNonTrivial() {}
+};
+static_assert(!std::is_trivially_copyable_v<LargeNonTrivial>);
+
+// ---- 1. Reallocate path: Push without Reserve -> 1.5x 재할당 반복 ----
+
+static void BM_Array_PushRealloc_Int(benchmark::State& state)
+{
+    const int n = static_cast<int>(state.range(0));
+    for (auto _ : state)
+    {
+        Array<int> arr;
+        for (int i = 0; i < n; ++i)
+            arr.Push(i);
+        benchmark::DoNotOptimize(arr.Data());
+    }
+}
+BENCHMARK(BM_Array_PushRealloc_Int)->Range(64, 4096);
+
+static void BM_Array_PushRealloc_LargePod(benchmark::State& state)
+{
+    const int n = static_cast<int>(state.range(0));
+    for (auto _ : state)
+    {
+        Array<LargePod> arr;
+        for (int i = 0; i < n; ++i)
+            arr.Push(LargePod{});
+        benchmark::DoNotOptimize(arr.Data());
+    }
+}
+BENCHMARK(BM_Array_PushRealloc_LargePod)->Range(64, 4096);
+
+static void BM_Array_PushRealloc_LargeNonTrivial(benchmark::State& state)
+{
+    const int n = static_cast<int>(state.range(0));
+    for (auto _ : state)
+    {
+        Array<LargeNonTrivial> arr;
+        for (int i = 0; i < n; ++i)
+            arr.Push(LargeNonTrivial{});
+        benchmark::DoNotOptimize(arr.Data());
+    }
+}
+BENCHMARK(BM_Array_PushRealloc_LargeNonTrivial)->Range(64, 4096);
+
+// ---- 2. RemoveAt(0) — worst-case O(n) shift left ----
+
+static void BM_Array_RemoveAtFront_Int(benchmark::State& state)
+{
+    const int n = static_cast<int>(state.range(0));
+    for (auto _ : state)
+    {
+        state.PauseTiming();
+        Array<int> arr;
+        arr.Reserve(n);
+        for (int i = 0; i < n; ++i) arr.Push(i);
+        state.ResumeTiming();
+
+        while (!arr.IsEmpty())
+            arr.RemoveAt(0);
+    }
+}
+BENCHMARK(BM_Array_RemoveAtFront_Int)->Range(64, 4096);
+
+static void BM_Array_RemoveAtFront_LargePod(benchmark::State& state)
+{
+    const int n = static_cast<int>(state.range(0));
+    for (auto _ : state)
+    {
+        state.PauseTiming();
+        Array<LargePod> arr;
+        arr.Reserve(n);
+        for (int i = 0; i < n; ++i) arr.Push(LargePod{});
+        state.ResumeTiming();
+
+        while (!arr.IsEmpty())
+            arr.RemoveAt(0);
+    }
+}
+BENCHMARK(BM_Array_RemoveAtFront_LargePod)->Range(64, 4096);
+
+static void BM_Array_RemoveAtFront_LargeNonTrivial(benchmark::State& state)
+{
+    const int n = static_cast<int>(state.range(0));
+    for (auto _ : state)
+    {
+        state.PauseTiming();
+        Array<LargeNonTrivial> arr;
+        arr.Reserve(n);
+        for (int i = 0; i < n; ++i) arr.Push(LargeNonTrivial{});
+        state.ResumeTiming();
+
+        while (!arr.IsEmpty())
+            arr.RemoveAt(0);
+    }
+}
+BENCHMARK(BM_Array_RemoveAtFront_LargeNonTrivial)->Range(64, 4096);
+
+// ---- 3. Insert(0, ...) — worst-case O(n) shift right ----
+
+static void BM_Array_InsertFront_Int(benchmark::State& state)
+{
+    const int n = static_cast<int>(state.range(0));
+    for (auto _ : state)
+    {
+        Array<int> arr;
+        arr.Reserve(n);
+        for (int i = 0; i < n; ++i)
+            arr.Insert(0, i);
+        benchmark::DoNotOptimize(arr.Data());
+    }
+}
+BENCHMARK(BM_Array_InsertFront_Int)->Range(64, 4096);
+
+static void BM_Array_InsertFront_LargePod(benchmark::State& state)
+{
+    const int n = static_cast<int>(state.range(0));
+    for (auto _ : state)
+    {
+        Array<LargePod> arr;
+        arr.Reserve(n);
+        for (int i = 0; i < n; ++i)
+            arr.Insert(0, LargePod{});
+        benchmark::DoNotOptimize(arr.Data());
+    }
+}
+BENCHMARK(BM_Array_InsertFront_LargePod)->Range(64, 4096);
+
+static void BM_Array_InsertFront_LargeNonTrivial(benchmark::State& state)
+{
+    const int n = static_cast<int>(state.range(0));
+    for (auto _ : state)
+    {
+        Array<LargeNonTrivial> arr;
+        arr.Reserve(n);
+        for (int i = 0; i < n; ++i)
+            arr.Insert(0, LargeNonTrivial{});
+        benchmark::DoNotOptimize(arr.Data());
+    }
+}
+BENCHMARK(BM_Array_InsertFront_LargeNonTrivial)->Range(64, 4096);
+
     // --- Array vs std::vector ---
 
     static void BM_SE_Array_Push(benchmark::State& state)

--- a/Tools/Scripts/compare_benchmarks.py
+++ b/Tools/Scripts/compare_benchmarks.py
@@ -1,0 +1,159 @@
+"""
+compare_benchmarks.py — before/after JSON 비교 도구
+
+사용법:
+    python compare_benchmarks.py before.json after.json
+    python compare_benchmarks.py before.json after.json --output result.png --filter MyBench
+"""
+
+import json
+import os
+import argparse
+import pandas as pd
+import matplotlib.pyplot as plt
+import matplotlib.ticker as ticker
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Google Benchmark before/after 비교 도구")
+    parser.add_argument("before", help="최적화 전 JSON 파일")
+    parser.add_argument("after",  help="최적화 후 JSON 파일")
+    parser.add_argument("--output", "-o", default=None, help="이미지 저장 경로")
+    parser.add_argument("--filter", "-f", default="",   help="벤치마크 이름 필터 (정규식)")
+    return parser.parse_args()
+
+
+def load(filepath):
+    if not os.path.exists(filepath):
+        raise FileNotFoundError(f"File not found: {filepath}")
+    with open(filepath, encoding="utf-8") as f:
+        data = json.load(f)
+    df = pd.DataFrame(data["benchmarks"])[["name", "cpu_time"]]
+    if df["name"].str.contains("/").any():
+        split = df["name"].str.split("/", n=1, expand=True)
+        df["base_name"] = split[0]
+        df["size"] = pd.to_numeric(split[1], errors="coerce").fillna(0).astype(int)
+    else:
+        df["base_name"] = df["name"]
+        df["size"] = 0
+    return df
+
+
+def build_comparison(df_before, df_after, filter_str):
+    if filter_str:
+        df_before = df_before[df_before["name"].str.contains(filter_str, case=False)]
+        df_after  = df_after[df_after["name"].str.contains(filter_str, case=False)]
+
+    merged = df_before.merge(df_after, on="name", suffixes=("_before", "_after"))
+    merged["speedup"]  = merged["cpu_time_before"] / merged["cpu_time_after"]
+    merged["base_name"] = merged["base_name_before"]
+    merged["size"]      = merged["size_before"]
+    return merged
+
+
+def plot(merged, output_path):
+    has_sizes = (merged["size"] > 0).any()
+    colors    = plt.cm.tab10.colors
+
+    if not has_sizes:
+        # 크기 변수 없을 때: 단순 가로 막대 speedup
+        fig, ax = plt.subplots(figsize=(10, max(4, len(merged) * 0.4 + 2)))
+        fig.suptitle("Before vs After - Speedup", fontsize=13, fontweight="bold")
+        bars = ax.barh(merged["name"], merged["speedup"],
+                       color=[colors[i % len(colors)] for i in range(len(merged))])
+        ax.bar_label(bars, fmt="%.2fx", padding=4, fontsize=8)
+        ax.axvline(1.0, color="gray", ls=":", linewidth=1.2)
+        ax.invert_yaxis()
+        ax.set_xlabel("Speedup  (before / after)", fontsize=11)
+        ax.grid(True, axis="x", alpha=0.2)
+        fig.tight_layout()
+        if output_path:
+            plt.savefig(output_path, bbox_inches="tight", dpi=150)
+            print(f"Saved: {output_path}")
+        plt.show()
+        return
+
+    # base_name의 마지막 _ 로 (group, label) 분리 — 표시용 휴리스틱
+    # 예) BM_Array_InsertFront_LargePod → group=BM_Array_InsertFront, label=LargePod
+    merged = merged.copy()
+    parts             = merged["base_name"].str.rsplit("_", n=1, expand=True)
+    merged["group"]   = parts[0]
+    merged["label"]   = parts[1]
+
+    groups = list(dict.fromkeys(merged["group"]))   # 순서 유지
+    labels = list(dict.fromkeys(merged["label"]))
+    label_color = {lb: colors[i % len(colors)] for i, lb in enumerate(labels)}
+
+    n_cols = len(groups)
+    fig, axes = plt.subplots(2, n_cols, figsize=(5.5 * n_cols, 8), squeeze=False)
+
+    # 공통 제목 + 범례 설명
+    fig.suptitle("Before vs After\n"
+                 "top: CPU time  (solid = before,  dashed = after)  |  "
+                 "bottom: speedup  (>1.0 = faster after)",
+                 fontsize=11, fontweight="bold")
+
+    for col, grp in enumerate(groups):
+        ax_t = axes[0][col]
+        ax_s = axes[1][col]
+
+        # 서브플롯 제목: 공통 접두사(BM_/BM_XXX_) 제거
+        title = grp
+        for prefix in ("BM_Array_", "BM_SE_", "BM_STL_", "BM_"):
+            title = title.replace(prefix, "")
+        ax_t.set_title(title, fontsize=11, fontweight="bold")
+
+        ax_s.axhline(1.0, color="gray", ls=":", linewidth=1.2, zorder=0)
+        ax_s.set_xlabel("N", fontsize=9)
+
+        sub = merged[merged["group"] == grp]
+        for lb in labels:
+            g = sub[sub["label"] == lb].sort_values("size")
+            if g.empty:
+                continue
+            c = label_color[lb]
+            ax_t.plot(g["size"], g["cpu_time_before"], marker="o", color=c,
+                      linewidth=2, label=lb)
+            ax_t.plot(g["size"], g["cpu_time_after"], marker="o", color=c,
+                      linewidth=1.3, ls="--", alpha=0.45)
+            ax_s.plot(g["size"], g["speedup"], marker="s", color=c,
+                      linewidth=2, label=lb)
+
+        for ax in (ax_t, ax_s):
+            ax.set_xscale("log", base=2)
+            ax.grid(True, which="both", alpha=0.15)
+            ax.legend(fontsize=8, loc="lower right", framealpha=0.88)
+
+        ax_t.set_yscale("log")
+        ax_s.set_ylim(bottom=0)
+
+        if col == 0:
+            ax_t.set_ylabel("CPU Time (ns)  [lower = better]", fontsize=10)
+            ax_s.set_ylabel("Speedup  [higher = better]", fontsize=10)
+
+    fig.tight_layout()
+
+    if output_path:
+        plt.savefig(output_path, bbox_inches="tight", dpi=150)
+        print(f"Saved: {output_path}")
+    plt.show()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    df_before = load(args.before)
+    df_after  = load(args.after)
+    merged    = build_comparison(df_before, df_after, args.filter)
+
+    if merged.empty:
+        print("No matching benchmarks found.")
+        exit(1)
+
+    # 터미널 요약 출력
+    print(f"\n{'Benchmark':<55} {'Before':>10} {'After':>10} {'Speedup':>8}")
+    print("-" * 88)
+    for _, row in merged.iterrows():
+        label = row["name"] if row["size"] == 0 else f"{row['base_name']}/{row['size']}"
+        print(f"{label:<55} {row['cpu_time_before']:>9.0f}ns {row['cpu_time_after']:>9.0f}ns  {row['speedup']:>6.2f}x")
+
+    plot(merged, args.output)


### PR DESCRIPTION
> 아래 PR 메시지는 Claude Sonnet 4.6을 사용하여 작성되었습니다.

## Summary

`std::is_trivially_copyable_v<T>`인 타입에 대해 요소 이동 연산을 `memmove`/`memcpy`로 교체합니다.

기존 코드는 `std::uninitialized_move_n`, `std::move`, `std::move_backward` 등 요소 단위 루프를 사용했습니다. trivially copyable 타입은 생성자·소멸자가 없으므로 바이트 단위 복사로 대체해도 의미상 동일하며, 컴파일러의 SIMD 최적화 여지가 커집니다. non-trivially copyable 경로는 변경 없습니다.

### 변경 연산

| 연산 | 이전 | 이후 (trivially copyable) |
|---|---|---|
| `Reallocate` | `uninitialized_move_n` + `destroy_n` | `memcpy` |
| `RemoveAt` | `std::move` + `destroy` | `memmove` |
| `RemoveRange` | `std::move` + `destroy` | `memmove` |
| `Insert(T&&)` | `construct` + `move_backward` | `memmove` |
| `Insert(It, It)` shift | `uninitialized_move` | `memmove` |

> `RemoveRange`의 non-trivially copyable 경로에서 `std::destroy` 호출 순서 버그도 함께 수정했습니다 (`size` 감소 전에 호출해야 zombie 원소가 올바르게 소멸됨).

## Benchmark (Release build)

<img width="2458" height="1180" alt="memmove_benchmark" src="https://github.com/user-attachments/assets/fc6df475-7312-4296-b6d3-850ef5d2af55" />

| Benchmark | Before | After | Speedup |
|---|---|---|---|
| RemoveAtFront / Int / 64 | 562 ns | 360 ns | **1.56x** |
| RemoveAtFront / Int / 512 | 4492 ns | 3613 ns | **1.24x** |
| RemoveAtFront / Int / 4096 | 172631 ns | 156948 ns | **1.10x** |
| RemoveAtFront / LargePod / 64 | 531 ns | 485 ns | 1.09x |
| PushRealloc / Int / 4096 | 3048 ns | 2916 ns | 1.05x |
| InsertFront / * | ~same | ~same | ~1.0x |
| PushRealloc / * | ~same | ~same | ~1.0x |

**결론**: Release 빌드에서 컴파일러가 `std::move` 루프를 이미 벡터화하기 때문에 `InsertFront`·`PushRealloc`은 개선 폭이 노이즈 수준입니다. `RemoveAt`은 소~중간 크기에서 유의미한 개선이 있습니다. Debug 빌드에서는 전 연산에 걸쳐 1.5–2.3x 개선됩니다.

## Test plan

- [x] 기존 `UnitTests` 통과 확인
- [ ] `LargeNonTrivial` speedup이 ~1.0× 유지되는지 확인 (non-trivially copyable 경로 무변경 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)