### PR TITLE
[Feature] VFS 스캔 대상을 EditorConfig에서 설정 가능하도록 기능 추가

### DIFF
--- a/Config/EditorConfig.toml
+++ b/Config/EditorConfig.toml
@@ -5,6 +5,9 @@ show_location = true
 show_thread_name = false
 show_timestamp = false
 
+[asset_scan]
+schemes = ['CoreAssets', 'EditorAssets']
+
 [ui]
 font_path = 'CoreAssets://Font/malgun.ttf'
 font_size = 17.0

--- a/Editor/Include/SimpleEditor/Config/EditorSettings.h
+++ b/Editor/Include/SimpleEditor/Config/EditorSettings.h
@@ -107,6 +107,17 @@ struct SE_EDITOR_API SE_ANNOTATION(=meta::SerializeOnly) GraphicsSettings
 
     bool operator==(const GraphicsSettings&) const = default;
 };
+/**
+ * [asset_scan] 섹션 - Import 스캔 대상 VFS 스킴 목록
+ */
+struct SE_EDITOR_API SE_ANNOTATION(=meta::SerializeOnly) AssetScanSettings
+{
+    /** 스캔할 VFS 스킴 이름 목록 */
+    SE_ANNOTATION(=meta::Property)
+    Array<String> schemes = { "CoreAssets", "EditorAssets" };
+
+    bool operator==(const AssetScanSettings&) const = default;
+};
 }  // namespace se::editor
 
 SE_DECLARE_REFLECTION(se::editor::WindowSettings)
@@ -114,3 +125,4 @@ SE_DECLARE_REFLECTION(se::editor::EditorUISettings)
 SE_DECLARE_REFLECTION(se::editor::ConsoleSettings)
 SE_DECLARE_REFLECTION(se::editor::PerformanceSettings)
 SE_DECLARE_REFLECTION(se::editor::GraphicsSettings)
+SE_DECLARE_REFLECTION(se::editor::AssetScanSettings)

--- a/Editor/Source/Asset/EditorAssetSubsystem.cpp
+++ b/Editor/Source/Asset/EditorAssetSubsystem.cpp
@@ -9,19 +9,21 @@
 #include "SimpleEditor/Asset/Pipeline/PipelineProcessorStack.h"
 #include "SimpleEditor/Asset/Pipeline/Factories/StaticMeshFactory.h"
 #include "SimpleEditor/Asset/Pipeline/Translators/AssimpTranslator.h"
+#include "SimpleEditor/Config/EditorSettings.h"
 
 #include "SimpleEngine/Asset/AssetMetadata.h"
 #include "SimpleEngine/Asset/AssetRegistry.h"
 #include "SimpleEngine/Asset/AssetSubsystem.h"
 #include "SimpleEngine/Asset/DerivedDataCache.h"
+#include "SimpleEngine/Core/Concurrency/JobSystem.h"
+#include "SimpleEngine/Core/Concurrency/Coroutine/CoroutinePrimitives.h"
+#include "SimpleEngine/Core/Config/ConfigFile.h"
 #include "SimpleEngine/Core/Container/HashSet.h"
 #include "SimpleEngine/Core/FileSystem/FileSystem.h"
 #include "SimpleEngine/Core/FileSystem/VFS.h"
 #include "SimpleEngine/Core/Logging/Logging.h"
 #include "SimpleEngine/Core/Reflection/TypeRegistry.h"
 #include "SimpleEngine/Core/Subsystem/SubsystemRegistration.h"
-#include "SimpleEngine/Core/Concurrency/JobSystem.h"
-#include "SimpleEngine/Core/Concurrency/Coroutine/CoroutinePrimitives.h"
 #include "SimpleEngine/Utility/ScopedTimer.h"
 #include "SimpleEngine/Utility/SHA256.h"
 #include "SimpleEngine/Utility/SubsystemUtils.h"
@@ -91,11 +93,23 @@ bool EditorAssetSubsystem::Initialize()
     // Registry 스냅샷 복원 시도 (성공 시 Hot Start, 실패 시 Cold Start)
     const bool is_hot_start = LoadRegistrySnapshot();
 
-    // VFS "Assets" 스킴에 마운트된 디렉토리를 스캔
-    // TODO: VisitMounts + Contains 대신 직접 스캔 대상을 설정에서 읽도록 변경
+    // EditorConfig에서 스캔 대상 스킴 목록 로드
+    AssetScanSettings scan_settings;
+    if (auto config_result = ConfigFile::Load("Config://EditorConfig.toml"))
+    {
+        scan_settings = config_result->GetSection<AssetScanSettings>("asset_scan");
+    }
+
+    // 설정된 스킴에 마운트된 디렉토리를 스캔
+    const HashSet<StringView> scan_schemes = HashSet<StringView>::FromRange(
+        scan_settings.schemes | std::views::transform([](const String& scheme) -> StringView
+        {
+            return scheme;
+        })
+    );
     VFS::Get().VisitMounts([&](StringView scheme, const Path& physical_path, int32)
     {
-        if (!scheme.Contains("Assets"))
+        if (!scan_schemes.Contains(scheme))
         {
             return;
         }

--- a/Editor/Source/Config/EditorSettings.cpp
+++ b/Editor/Source/Config/EditorSettings.cpp
@@ -37,4 +37,8 @@ SE_END_REFLECT(PerformanceSettings)
 SE_BEGIN_REFLECT(GraphicsSettings, meta::SerializeOnly)
     SE_REFLECT_PROPERTY(present_mode, meta::Property)
 SE_END_REFLECT(GraphicsSettings)
+
+SE_BEGIN_REFLECT(AssetScanSettings, meta::SerializeOnly)
+    SE_REFLECT_PROPERTY(schemes, meta::Property)
+SE_END_REFLECT(AssetScanSettings)
 } // namespace se::editor


### PR DESCRIPTION
## 주요 변경 사항

- `EditorSettings.h`에 `AssetScanSettings` 섹션 추가
- `EditorConfig.toml`에 `[asset_scan]` 섹션 추가
- `EditorAssetSubsystem::Initialize()`에서 설정을 읽어 스킴 필터로 사용