### PR TITLE
feat: OS Drag & Drop 파일 Import 및 PropertyPanel Asset D&D 지원

### DIFF
--- a/Editor/Source/Asset/EditorAssetSubsystem.cpp
+++ b/Editor/Source/Asset/EditorAssetSubsystem.cpp
@@ -10,6 +10,7 @@
 #include "SimpleEditor/Asset/Pipeline/Factories/StaticMeshFactory.h"
 #include "SimpleEditor/Asset/Pipeline/Translators/AssimpTranslator.h"
 #include "SimpleEditor/Config/EditorSettings.h"
+#include "SimpleEditor/UI/PropertyDrawer/PropertyDrawer.h"
 
 #include "SimpleEngine/Asset/AssetMetadata.h"
 #include "SimpleEngine/Asset/AssetRegistry.h"
@@ -21,6 +22,7 @@
 #include "SimpleEngine/Core/Container/HashSet.h"
 #include "SimpleEngine/Core/FileSystem/FileSystem.h"
 #include "SimpleEngine/Core/FileSystem/VFS.h"
+#include "SimpleEngine/Core/HAL/EventSubsystem.h"
 #include "SimpleEngine/Core/Logging/Logging.h"
 #include "SimpleEngine/Core/Reflection/TypeRegistry.h"
 #include "SimpleEngine/Core/Subsystem/SubsystemRegistration.h"
@@ -117,6 +119,33 @@ bool EditorAssetSubsystem::Initialize()
         ScanWorkspace(physical_path, is_hot_start);
     });
 
+    // OS 파일 드롭 이벤트 구독
+    EventSubsystem& event_subsystem = GetSubsystemChecked<EventSubsystem>();
+    file_drop_handle = event_subsystem.on_file_dropped.AddLambda([this](const Path& file_path)
+    {
+        ImportExternalFile(file_path);
+    });
+
+    // PropertyPanel D&D용 AssetDropResolver 등록
+    DrawerRegistry::Get().SetAssetDropResolver([](const char* dropped_path) -> asset::AssetId
+    {
+        // dropped_path는 AssetsBrowserPanel에서 전달한 물리 경로
+        // VFS 역변환 -> Registry에서 첫 번째 에셋 ID 조회
+        const Optional file_vpath = VFS::Unresolve(Path{ dropped_path });
+        if (!file_vpath)
+        {
+            return {};
+        }
+
+        const asset::AssetRegistry& registry = GetSubsystemChecked<asset::AssetSubsystem>().GetRegistry();
+        const Array<asset::AssetId> assets = registry.GetAssetsInFile(*file_vpath);
+        if (assets.IsEmpty())
+        {
+            return {};
+        }
+        return assets.Front().Value();
+    });
+
     return true;
 }
 
@@ -124,6 +153,18 @@ void EditorAssetSubsystem::Release()
 {
     // 에디터 종료 시 Registry 스냅샷 저장
     SaveRegistrySnapshot();
+
+    // 이벤트 구독 해제
+    if (file_drop_handle.IsValid())
+    {
+        if (EventSubsystem* event_subsystem = GetSubsystem<EventSubsystem>())
+        {
+            event_subsystem->on_file_dropped.Remove(file_drop_handle);
+        }
+    }
+
+    // AssetDropResolver 해제
+    DrawerRegistry::Get().SetAssetDropResolver(nullptr);
 
     if (asset_subsystem)
     {
@@ -630,6 +671,78 @@ bool EditorAssetSubsystem::CookAsset(const VPath& file_vpath)
 
     ConsoleLog(ELogLevel::Debug, "Successfully cooked {} assets from: {}", result.GetCount(), file_path);
     return true;
+}
+
+bool EditorAssetSubsystem::ImportExternalFile(const Path& source_path)
+{
+    ZoneScopedN("EditorAssetSubsystem::ImportExternalFile");
+
+    // Import 가능한 파일인지 확인
+    if (!importer->CanImport(source_path))
+    {
+        ConsoleLog(ELogLevel::Warning, "ImportExternalFile: Unsupported file type: {}", source_path);
+        return false;
+    }
+
+    // 첫 번째 스캔 스킴의 물리 경로를 드롭 대상 디렉토리로 사용
+    Path content_dir;
+    AssetScanSettings scan_settings;
+    if (auto config_result = ConfigFile::Load("Config://EditorConfig.toml"))
+    {
+        scan_settings = config_result->GetSection<AssetScanSettings>("asset_scan");
+    }
+
+    if (!scan_settings.schemes.IsEmpty())
+    {
+        const String& first_scheme = scan_settings.schemes.Front().Value();
+        content_dir = VFS::ToPath(VPath{ String::Format("{}://", first_scheme) });
+    }
+
+    if (content_dir.IsEmpty())
+    {
+        ConsoleLog(ELogLevel::Error, "ImportExternalFile: No content directory configured");
+        return false;
+    }
+
+    // 파일을 Content 디렉토리로 복사
+    const Optional<String> filename = source_path.FileName();
+    if (!filename)
+    {
+        ConsoleLog(ELogLevel::Error, "ImportExternalFile: Cannot extract filename from: {}", source_path);
+        return false;
+    }
+    const Path dest_path = content_dir / *filename;
+    if (dest_path.Exists())
+    {
+        ConsoleLog(ELogLevel::Warning, "ImportExternalFile: File already exists, overwriting: {}", dest_path);
+    }
+
+    if (!FileSystem::Copy(source_path, dest_path))
+    {
+        ConsoleLog(ELogLevel::Error, "ImportExternalFile: Failed to copy {} -> {}", source_path, dest_path);
+        return false;
+    }
+
+    // .meta 생성 + Cook
+    if (!EnsureMetaFile(dest_path))
+    {
+        ConsoleLog(ELogLevel::Error, "ImportExternalFile: Failed to create .meta for: {}", dest_path);
+        return false;
+    }
+
+    const Optional file_vpath = VFS::Unresolve(dest_path);
+    if (!file_vpath)
+    {
+        ConsoleLog(ELogLevel::Error, "ImportExternalFile: Failed to resolve VPath for: {}", dest_path);
+        return false;
+    }
+
+    const bool cook_success = CookAsset(*file_vpath);
+    if (cook_success)
+    {
+        ConsoleLog(ELogLevel::Info, "ImportExternalFile: Successfully imported: {}", *file_vpath);
+    }
+    return cook_success;
 }
 
 void EditorAssetSubsystem::RegisterFromMeta(const VPath& source_vpath, const asset::AssetMetadata& meta)

--- a/Editor/Source/Asset/EditorAssetSubsystem.h
+++ b/Editor/Source/Asset/EditorAssetSubsystem.h
@@ -7,6 +7,7 @@
 #include "SimpleEngine/Asset/AssetSubsystem.h"
 #include "SimpleEngine/Core/Container/ArrayView.h"
 #include "SimpleEngine/Core/Container/HashSet.h"
+#include "SimpleEngine/Core/Functional/MultiDelegate.h"
 #include "SimpleEngine/Core/Subsystem/SubsystemBase.h"
 #include "SimpleEngine/Core/Types/Path.h"
 #include "SimpleEngine/Core/Types/VPath.h"
@@ -69,6 +70,14 @@ public:
     /** DependencyGraph에 대한 읽기 전용 접근자 */
     [[nodiscard]] const DependencyGraph& GetDependencyGraph() const { return dep_graph; }
 
+    /**
+     * 외부 파일을 Content 디렉토리로 복사하고 Import합니다.
+     * OS Drag & Drop으로 받은 파일을 처리하는 데 사용합니다.
+     * @param source_path 드롭된 파일의 물리 경로
+     * @return Import 성공 여부
+     */
+    bool ImportExternalFile(const Path& source_path);
+
 private:
     /**
      * .meta 파일에서 메타데이터를 읽어 AssetRegistry에 등록합니다.
@@ -119,5 +128,7 @@ private:
 
     TracyLockable(std::mutex, cooking_mutex);
     HashSet<VPath> currently_cooking;
+
+    DelegateHandle file_drop_handle;
 };
 }  // namespace se::editor

--- a/EngineCore/Include/SimpleEngine/Core/HAL/EventSubsystem.h
+++ b/EngineCore/Include/SimpleEngine/Core/HAL/EventSubsystem.h
@@ -4,6 +4,7 @@
 #include "SimpleEngine/Core/HAL/PlatformTypes.h"
 #include "SimpleEngine/Core/Reflection/Annotations.h"
 #include "SimpleEngine/Core/Subsystem/SubsystemBase.h"
+#include "SimpleEngine/Core/Types/Path.h"
 
 #include "SDL3/SDL.h"
 
@@ -38,5 +39,11 @@ public:
      * SDL_EVENT_QUIT 이벤트 발생 시 Broadcast됩니다.
      */
     MultiDelegate<void()> on_quit_requested;
+
+    /**
+     * OS에서 파일이 드롭되었을 때 Broadcast됩니다. (탐색기 -> 에디터 창)
+     * 드롭된 파일의 물리 경로가 전달됩니다.
+     */
+    MultiDelegate<void(const Path& file_path)> on_file_dropped;
 };
 } // namespace se

--- a/EngineCore/Source/Core/HAL/EventSubsystem.cpp
+++ b/EngineCore/Source/Core/HAL/EventSubsystem.cpp
@@ -48,6 +48,13 @@ void EventSubsystem::PollEvents() // NOLINT(*-make-member-function-const)
             on_quit_requested.Broadcast();
             break;
 
+        case SDL_EVENT_DROP_FILE:
+            if (event.drop.data)
+            {
+                on_file_dropped.Broadcast(Path{ event.drop.data });
+            }
+            break;
+
         default:
             break;
         }


### PR DESCRIPTION
> 아래 PR 메시지는 Claude Sonnet 4.6을 사용하여 작성되었습니다.

## 개요

탐색기 → 에디터 창 파일 드롭(OS D&D)과 ContentBrowser → PropertyPanel 에셋 드롭(Editor 내부 D&D) 두 가지 Drag & Drop 흐름을 구현합니다.

## 변경 사항

### EngineCore
- **`EventSubsystem`**: `SDL_EVENT_DROP_FILE` 이벤트를 처리하여 `on_file_dropped(Path)` MultiDelegate를 Broadcast
  - `null` guard 적용 (`event.drop.data` 체크)
  - SDL3 drop data는 `const char*` (SDL 내부 소유) → `SDL_free` 불필요

### Editor
- **`EditorAssetSubsystem::Initialize()`**
  - `on_file_dropped` 구독 → `ImportExternalFile()` 호출
  - `DrawerRegistry`에 `AssetDropResolver` 등록: 물리 경로 → VFS `Unresolve` → `AssetRegistry` 조회 → `AssetId` 반환
- **`EditorAssetSubsystem::Release()`**
  - `DelegateHandle` 유효성 검사 후 `on_file_dropped` 구독 해제
  - `AssetDropResolver` `nullptr` 초기화 (graceful: `EventSubsystem` 먼저 해제돼도 안전)
- **`EditorAssetSubsystem::ImportExternalFile(Path)`** (신규)
  - `CanImport` 검증 → EditorConfig 첫 번째 scheme을 대상 디렉토리로 결정 → 파일 복사 → `.meta` 생성 → `CookAsset`

## 플로우

```
[탐색기에서 파일 드롭]
SDL_EVENT_DROP_FILE
  └─ EventSubsystem::on_file_dropped.Broadcast(Path)
       └─ EditorAssetSubsystem::ImportExternalFile()
            ├─ FileSystem::Copy(src → content_dir)
            ├─ EnsureMetaFile(dest)
            └─ CookAsset(vpath)

[ContentBrowser → PropertyPanel 드롭]
ImGui DragDropTarget ("CONTENT_BROWSER_ITEM")
  └─ AssetDropResolver(physical_path)
       ├─ VFS::Unresolve(path) → vpath
       └─ AssetRegistry::GetAssetsInFile(vpath) → AssetId
```

## 체크리스트
- [x] SDL3 drop data 메모리 안전성 확인 (SDL 내부 소유, free 불필요)
- [x] stateless lambda → `AssetDropResolverFunc` (raw function pointer) 변환 가능
- [x] Release 순서 안전성: `GetSubsystem<EventSubsystem>()` nullable 체크
- [x] `Array::Front()` → `Optional<T&>` → `IsEmpty()` 후 `.Value()` 호출

🤖 Generated with [Claude Code](https://claude.com/claude-code)