### PR TITLE
refactor: RID/SlotMap/RenderDevice 도입 및 SDL_GPUDevice* 전면 교체 (Phase 1)

### DIFF
--- a/Editor/Include/SimpleEditor/App/EditorApplication.h
+++ b/Editor/Include/SimpleEditor/App/EditorApplication.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include "SimpleEditor/EditorCommon.h"
 #include "SimpleEngine/App/Application.h"
 
@@ -24,6 +25,5 @@ protected:
 
 private:
     SDL_Window* cached_window = nullptr;
-    SDL_GPUDevice* cached_gpu_device = nullptr;
 };
 } // namespace se::editor

--- a/Editor/Include/SimpleEditor/UI/EditorViewportSubsystem.h
+++ b/Editor/Include/SimpleEditor/UI/EditorViewportSubsystem.h
@@ -9,12 +9,15 @@
 
 #include "SDL3/SDL_gpu.h"
 
+// forward declaration
+namespace se
+{
+namespace graphics{ class RenderDevice; }
+namespace editor{ class ViewportPanel; }
+}
 
 namespace se::editor
 {
-class ViewportPanel;
-
-
 /**
  * Viewport Render Data
  */
@@ -48,7 +51,7 @@ public:
     [[nodiscard]] const HashMap<StringName, ViewportRenderInfo>& GetActiveViewportInfo() const { return viewport_data; }
 
 private:
-    SDL_GPUDevice* gpu_device = nullptr;
+    graphics::RenderDevice* render_device = nullptr;
     HashMap<StringName, ViewportRenderInfo> viewport_data;
 };
 }  // namespace se::editor

--- a/Editor/Source/Graphics/Compiler/Compiler.cpp
+++ b/Editor/Source/Graphics/Compiler/Compiler.cpp
@@ -1,12 +1,13 @@
 #include "Graphics/Compiler/Compiler.h"
 
-#include <ranges>
-
 #include "SimpleEngine/Core/FileSystem/FileSystem.h"
 #include "SimpleEngine/Core/Logging/Logging.h"
+#include "SimpleEngine/Graphics/Device/RenderDevice.h"
 #include "SimpleEngine/Graphics/ShaderUtils.h"
 
 #include "SDL3_shadercross/SDL_shadercross.h"
+
+#include <ranges>
 
 
 namespace se::editor
@@ -14,7 +15,7 @@ namespace se::editor
 using namespace se;
 
 SDL_GPUShader* CompileFromHLSL(
-    SDL_GPUDevice* device,
+    const graphics::RenderDevice& render_device,
     const Path& shader_path,
     Optional<const Path&> include_dir_opt,
     Optional<ArrayView<const HLSL_Define>> defines_opt
@@ -90,7 +91,7 @@ SDL_GPUShader* CompileFromHLSL(
 
     SDL_ShaderCross_GraphicsShaderMetadata* refl_metadata = nullptr;
 
-    const SDL_GPUShaderFormat backend_formats = SDL_GetGPUShaderFormats(device);
+    const SDL_GPUShaderFormat backend_formats = SDL_GetGPUShaderFormats(render_device.GetRawDevice());
     if (backend_formats & SDL_GPU_SHADERFORMAT_DXIL)
     {
         bytecode = SDL_ShaderCross_CompileDXILFromHLSL(&hlsl_info, &bytecode_size);
@@ -121,7 +122,7 @@ SDL_GPUShader* CompileFromHLSL(
             .num_storage_buffers = refl_metadata->resource_info.num_storage_buffers,
             .num_uniform_buffers = refl_metadata->resource_info.num_uniform_buffers,
         };
-        SDL_GPUShader* shader = SDL_CreateGPUShader(device, &create_info);
+        SDL_GPUShader* shader = SDL_CreateGPUShader(render_device.GetRawDevice(), &create_info);
         SDL_free(refl_metadata);
         SDL_free(bytecode);
         return shader;

--- a/Editor/Source/Graphics/Compiler/Compiler.h
+++ b/Editor/Source/Graphics/Compiler/Compiler.h
@@ -7,6 +7,9 @@
 #include "SDL3/SDL_gpu.h"
 
 
+// forward declaration
+namespace se::graphics{ class RenderDevice; }
+
 namespace se::editor
 {
 struct HLSL_Define
@@ -17,7 +20,7 @@ struct HLSL_Define
 
 /** HLSL을 컴파일하여 SDL_GPUShader로 변환합니다. */
 [[nodiscard]] SDL_GPUShader* CompileFromHLSL(
-    SDL_GPUDevice* device,
+    const se::graphics::RenderDevice& render_device,
     const Path& shader_path,
     Optional<const Path&> include_dir_opt = NullOpt,
     Optional<ArrayView<const HLSL_Define>> defines_opt = NullOpt

--- a/Editor/Source/Graphics/Compiler/Provider.cpp
+++ b/Editor/Source/Graphics/Compiler/Provider.cpp
@@ -1,6 +1,6 @@
 #include "Graphics/Compiler/Provider.h"
-
 #include "Graphics/Compiler/Compiler.h"
+
 #include "SimpleEngine/Core/Container/Array.h"
 #include "SimpleEngine/Core/Container/Optional.h"
 #include "SimpleEngine/Core/Logging/Logging.h"
@@ -12,7 +12,7 @@ using namespace se::graphics;
 
 namespace se::editor
 {
-SDL_GPUShader* CompilingShaderProvider::Provide(SDL_GPUDevice* device, const ShaderRequest& request)
+SDL_GPUShader* CompilingShaderProvider::Provide(graphics::RenderDevice& render_device, const ShaderRequest& request)
 {
     const Optional ext_opt = request.source_path.Extension();
     if (!ext_opt.HasValue())
@@ -41,7 +41,7 @@ SDL_GPUShader* CompilingShaderProvider::Provide(SDL_GPUDevice* device, const Sha
         }
 
         return CompileFromHLSL(
-            device,
+            render_device,
             request.source_path,
             request.hlsl_include_dir_opt,
             defines_opt
@@ -55,7 +55,7 @@ SDL_GPUShader* CompilingShaderProvider::Provide(SDL_GPUDevice* device, const Sha
         || ext.Contains(".spvt")
     )
     {
-        return graphics::CompileFromSPIRV(device, request.source_path);
+        return graphics::CompileFromSPIRV(render_device, request.source_path);
     }
 
     return nullptr;

--- a/Editor/Source/Graphics/Compiler/Provider.h
+++ b/Editor/Source/Graphics/Compiler/Provider.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include "SimpleEngine/Graphics/ShaderProvider/IShaderProvider.h"
 #include "SDL3/SDL_gpu.h"
 
@@ -12,6 +13,6 @@ class CompilingShaderProvider : public se::graphics::IShaderProvider
 {
 public:
     /** HLSL 컴파일 및, SPIR-V을 가져옵니다. */
-    virtual SDL_GPUShader* Provide(SDL_GPUDevice* device, const se::graphics::ShaderRequest& request) override;
+    virtual SDL_GPUShader* Provide(se::graphics::RenderDevice& render_device, const se::graphics::ShaderRequest& request) override;
 };
 }  // namespace se::editor

--- a/Editor/Source/UI/EditorUISubsystem.cpp
+++ b/Editor/Source/UI/EditorUISubsystem.cpp
@@ -48,7 +48,7 @@ bool EditorUISubsystem::Initialize()
     const auto [window_subsystem, render_subsystem] = GetSubsystems<WindowSubsystem, const RenderSubsystem>();
 
     SDL_Window* main_window = window_subsystem->GetMainWindow();
-    SDL_GPUDevice* gpu_device = render_subsystem->GetGpuDevice();
+    SDL_GPUDevice* raw_device = render_subsystem->GetRenderDevice().GetRawDevice();
 
     // ImGui 초기화
     IMGUI_CHECKVERSION();
@@ -90,8 +90,8 @@ bool EditorUISubsystem::Initialize()
 
     ImGui_ImplSDL3_InitForSDLGPU(main_window);
     ImGui_ImplSDLGPU3_InitInfo init_info = {
-        .Device = gpu_device,
-        .ColorTargetFormat = SDL_GetGPUSwapchainTextureFormat(gpu_device, main_window),
+        .Device = raw_device,
+        .ColorTargetFormat = SDL_GetGPUSwapchainTextureFormat(raw_device, main_window),
         .MSAASamples = SDL_GPU_SAMPLECOUNT_1,
     };
     ImGui_ImplSDLGPU3_Init(&init_info);

--- a/Editor/Source/UI/EditorViewportSubsystem.cpp
+++ b/Editor/Source/UI/EditorViewportSubsystem.cpp
@@ -1,6 +1,7 @@
 #include "SimpleEditor/UI/EditorViewportSubsystem.h"
 
 #include "SimpleEngine/Core/Subsystem/SubsystemRegistration.h"
+#include "SimpleEngine/Graphics/Device/RenderDevice.h"
 #include "SimpleEngine/Utility/SubsystemUtils.h"
 
 
@@ -14,24 +15,24 @@ SE_END_REFLECT(EditorViewportSubsystem)
 
 bool EditorViewportSubsystem::Initialize()
 {
-    gpu_device = GetSubsystemChecked<RenderSubsystem>().GetGpuDevice();
-    return gpu_device != nullptr;
+    render_device = &GetSubsystemChecked<RenderSubsystem>().GetRenderDevice();
+    return true;
 }
 
 void EditorViewportSubsystem::Release()
 {
-    if (gpu_device)
+    if (render_device)
     {
         for (const ViewportRenderInfo& info : viewport_data | std::views::values)
         {
             if (info.color_texture)
             {
-                SDL_ReleaseGPUTexture(gpu_device, info.color_texture);
+                SDL_ReleaseGPUTexture(render_device->GetRawDevice(), info.color_texture);
             }
         }
     }
     viewport_data.Clear();
-    gpu_device = nullptr;
+    render_device = nullptr;
 }
 
 SDL_GPUTexture* EditorViewportSubsystem::UpdateAndGetViewportTexture(const StringName& viewport_id, uint32 new_width, uint32 new_height)
@@ -43,7 +44,7 @@ SDL_GPUTexture* EditorViewportSubsystem::UpdateAndGetViewportTexture(const Strin
             ViewportRenderInfo& info = data_opt.Value();
             if (info.color_texture)
             {
-                SDL_ReleaseGPUTexture(gpu_device, info.color_texture);
+                SDL_ReleaseGPUTexture(render_device->GetRawDevice(), info.color_texture);
                 info.color_texture = nullptr;
             }
             return nullptr;
@@ -56,7 +57,7 @@ SDL_GPUTexture* EditorViewportSubsystem::UpdateAndGetViewportTexture(const Strin
     {
         if (info.color_texture)
         {
-            SDL_ReleaseGPUTexture(gpu_device, info.color_texture);
+            SDL_ReleaseGPUTexture(render_device->GetRawDevice(), info.color_texture);
         }
 
         const SDL_GPUTextureCreateInfo color_create_info = {
@@ -72,7 +73,7 @@ SDL_GPUTexture* EditorViewportSubsystem::UpdateAndGetViewportTexture(const Strin
             .num_levels = 1,
             .sample_count = SDL_GPU_SAMPLECOUNT_1,
         };
-        info.color_texture = SDL_CreateGPUTexture(gpu_device, &color_create_info);
+        info.color_texture = SDL_CreateGPUTexture(render_device->GetRawDevice(), &color_create_info);
         info.width = new_width;
         info.height = new_height;
     }

--- a/EngineCore/Include/SimpleEngine/Graphics/Device/RID.h
+++ b/EngineCore/Include/SimpleEngine/Graphics/Device/RID.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "SimpleEngine/Core/HAL/PlatformTypes.h"
+
+#include <functional>
+#include <limits>
+
+
+namespace se::graphics
+{
+/**
+ * GPU 리소스를 가리키는 불투명 핸들 (Render resource ID)
+ *
+ * 32-bit index + 32-bit generation 으로 구성된 generational handle
+ * SlotMap<T>과 함께 사용하여 use-after-free를 방지합니다.
+ */
+struct RID
+{
+    static constexpr uint32 INVALID_INDEX = std::numeric_limits<uint32>::max();
+    static constexpr uint32 INVALID_GENERATION = std::numeric_limits<uint32>::max();
+
+    uint32 index = INVALID_INDEX;
+    uint32 generation = INVALID_GENERATION;
+
+    [[nodiscard]] constexpr bool IsValid() const noexcept
+    {
+        return index != INVALID_INDEX && generation != INVALID_GENERATION;
+    }
+
+    [[nodiscard]] explicit constexpr operator bool() const noexcept { return IsValid(); }
+
+    [[nodiscard]] constexpr bool operator==(const RID&) const noexcept = default;
+    [[nodiscard]] constexpr auto operator<=>(const RID&) const noexcept = default;
+
+    /** 64비트 패킹 값 반환 (주로 디버그 출력용) */
+    [[nodiscard]] constexpr uint64 ToU64() const noexcept
+    {
+        return (static_cast<uint64>(generation) << 32) | static_cast<uint64>(index);
+    }
+};
+} // namespace se::graphics
+
+
+template<>
+struct std::hash<se::graphics::RID>
+{
+    [[nodiscard]] size_t operator()(const se::graphics::RID& rid) const noexcept
+    {
+        return std::hash<uint64>{}(rid.ToU64());
+    }
+};

--- a/EngineCore/Include/SimpleEngine/Graphics/Device/RenderDevice.h
+++ b/EngineCore/Include/SimpleEngine/Graphics/Device/RenderDevice.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#include "SimpleEngine/Core/Container/Array.h"
+#include "SimpleEngine/Graphics/Device/RID.h"
+#include "SimpleEngine/Graphics/Device/SlotMap.h"
+
+#include "SDL3/SDL_gpu.h"
+
+
+namespace se::graphics
+{
+/** RenderDevice가 관리하는 텍스처 리소스의 메타데이터입니다. */
+struct TextureResource
+{
+    SDL_GPUTexture* handle = nullptr;
+    uint32 width = 0;
+    uint32 height = 0;
+    SDL_GPUTextureFormat format = SDL_GPU_TEXTUREFORMAT_INVALID;
+};
+
+/** RenderDevice가 관리하는 버퍼 리소스의 메타데이터입니다. */
+struct BufferResource
+{
+    SDL_GPUBuffer* handle = nullptr;
+    uint32 size = 0;
+    SDL_GPUBufferUsageFlags usage = 0;
+};
+
+
+/**
+ * SDL_GPUDevice를 래핑하여 GPU 리소스를 RID 기반으로 관리하는 클래스
+ *
+ * 모든 GPU 리소스(텍스처, 버퍼)는 SlotMap에 저장되며, RID를 통해 O(1) 접근합니다.
+ * 리소스 삭제는 지연 파괴(deferred destruction) 큐를 통해 프레임 경계에서 일괄 처리됩니다.
+ */
+class SE_CORE_API RenderDevice
+{
+public:
+    /** @param raw_device SDL_GPUDevice 포인터입니다. */
+    explicit RenderDevice(SDL_GPUDevice* raw_device);
+    ~RenderDevice();
+
+    RenderDevice(const RenderDevice&) = delete;
+    RenderDevice& operator=(const RenderDevice&) = delete;
+    RenderDevice(RenderDevice&&) = delete;
+    RenderDevice& operator=(RenderDevice&&) = delete;
+
+public:
+    /** GPU 텍스처를 생성하고 RID를 반환합니다. 실패 시 유효하지 않은 RID를 반환합니다. */
+    [[nodiscard]] RID CreateTexture(const SDL_GPUTextureCreateInfo& desc);
+
+    /** GPU 버퍼를 생성하고 RID를 반환합니다. 실패 시 유효하지 않은 RID를 반환합니다. */
+    [[nodiscard]] RID CreateBuffer(const SDL_GPUBufferCreateInfo& desc);
+
+    /** RID에 해당하는 텍스처 리소스를 반환합니다. 유효하지 않은 RID이면 NullOpt를 반환합니다. */
+    [[nodiscard]] Optional<const TextureResource&> GetTexture(RID rid) const;
+
+    /** RID에 해당하는 버퍼 리소스를 반환합니다. 유효하지 않은 RID이면 NullOpt를 반환합니다. */
+    [[nodiscard]] Optional<const BufferResource&> GetBuffer(RID rid) const;
+
+    /** RID가 유효한 텍스처를 가리키는지 확인합니다. */
+    [[nodiscard]] bool IsValidTexture(RID rid) const;
+
+    /** RID가 유효한 버퍼를 가리키는지 확인합니다. */
+    [[nodiscard]] bool IsValidBuffer(RID rid) const;
+
+    /**
+     * 텍스처를 지연 파괴 큐에 등록합니다.
+     * RID는 즉시 무효화되지만, 실제 GPU 리소스 해제는 ProcessDeferredDestructions() 호출 시 수행됩니다.
+     */
+    void DestroyTexture(RID rid);
+
+    /**
+     * 버퍼를 지연 파괴 큐에 등록합니다.
+     * RID는 즉시 무효화되지만, 실제 GPU 리소스 해제는 ProcessDeferredDestructions() 호출 시 수행됩니다.
+     */
+    void DestroyBuffer(RID rid);
+
+    /**
+     * 지연 파괴 큐에 등록된 모든 GPU 리소스를 실제로 해제합니다.
+     * 프레임 경계에서 호출해야 합니다.
+     */
+    void ProcessDeferredDestructions();
+
+    /** 내부 SDL_GPUDevice 포인터를 반환합니다. */
+    [[nodiscard]] SDL_GPUDevice* GetRawDevice() const noexcept { return raw_device; }
+
+    /** 현재 관리 중인 텍스처 수를 반환합니다. */
+    [[nodiscard]] uint32 TextureCount() const noexcept { return textures.Count(); }
+
+    /** 현재 관리 중인 버퍼 수를 반환합니다. */
+    [[nodiscard]] uint32 BufferCount() const noexcept { return buffers.Count(); }
+
+private:
+    SDL_GPUDevice* raw_device;
+
+    SlotMap<TextureResource> textures;
+    SlotMap<BufferResource> buffers;
+
+    Array<SDL_GPUTexture*> deferred_texture_destroys;
+    Array<SDL_GPUBuffer*> deferred_buffer_destroys;
+};
+} // namespace se::graphics

--- a/EngineCore/Include/SimpleEngine/Graphics/Device/SlotMap.h
+++ b/EngineCore/Include/SimpleEngine/Graphics/Device/SlotMap.h
@@ -1,0 +1,177 @@
+#pragma once
+
+#include "SimpleEngine/Core/Container/Array.h"
+#include "SimpleEngine/Core/Container/Optional.h"
+#include "SimpleEngine/Graphics/Device/RID.h"
+
+#include <concepts>
+#include <limits>
+#include <ranges>
+#include <utility>
+
+
+namespace se::graphics
+{
+/** SlotMap에 저장 가능한 타입 */
+template <typename T>
+concept SlotMapStorable = std::move_constructible<T> && std::default_initializable<T>;
+
+
+/**
+ * Generational Arena 기반의 SlotMap 컨테이너
+ *
+ * RID(index + generation)를 키로 사용하여 O(1) 접근을 제공합니다.
+ * 삭제된 슬롯은 free list를 통해 재사용되며, generation이 증가하므로
+ * 오래된 RID로의 접근은 자동으로 실패합니다.
+ *
+ * @tparam T 저장할 요소 타입
+ */
+template<SlotMapStorable T>
+class SlotMap
+{
+    static constexpr uint32 FREE_SENTINEL = std::numeric_limits<uint32>::max();
+
+    struct Slot
+    {
+        T data{};
+        uint32 generation = 0;
+
+        // free list 연결: 사용 중이면 FREE_SENTINEL, 아니면 다음 free 슬롯 인덱스
+        uint32 next_free = FREE_SENTINEL;
+        bool occupied = false;
+    };
+
+public:
+    SlotMap() = default;
+
+    /**
+     * 새 요소를 삽입하고 해당 요소를 가리키는 RID를 반환합니다.
+     * free list에 빈 슬롯이 있으면 재사용하고, 없으면 새 슬롯을 할당합니다.
+     */
+    template <typename U = T>
+        requires std::convertible_to<U&&, T>
+    RID Insert(U&& value)
+    {
+        usize slot_index;
+
+        if (free_head != FREE_SENTINEL)
+        {
+            // 기존 free_list 재사용
+            slot_index = free_head;
+            Slot& slot = slots[slot_index];
+            free_head = slot.next_free;
+
+            slot.data = std::forward<U>(value);
+            slot.next_free = FREE_SENTINEL;
+            slot.occupied = true;
+        }
+        else
+        {
+            // 빈 공간이 없을 경우, 새로 추가
+            slot_index = slots.Len();
+            slots.Push(Slot{
+                .data = std::forward<U>(value),
+                .generation = 1,
+                .next_free = FREE_SENTINEL,
+                .occupied = true,
+            });
+        }
+
+        ++count;
+        return {
+            .index = static_cast<uint32>(slot_index),
+            .generation = slots[slot_index].generation
+        };
+    }
+
+    /**
+     * RID에 해당하는 요소의 참조를 반환합니다.
+     * RID가 무효하거나 세대가 불일치하면 NullOpt를 반환합니다.
+     */
+    template <typename Self>
+    [[nodiscard]] auto Get(this Self& self, RID rid)
+    {
+        using OptRef = std::conditional_t<std::is_const_v<Self>, Optional<const T&>, Optional<T&>>;
+        if (!self.IsValidRID(rid))
+        {
+            return OptRef{ NullOpt };
+        }
+        return OptRef{ self.slots[rid.index].data };
+    }
+
+    /**
+     * RID에 해당하는 요소를 제거합니다.
+     * 세대를 증가시켜 기존 RID를 무효화하고, 슬롯을 free list에 반환합니다.
+     * @return 제거 성공 시 true, RID가 무효하면 false를 반환합니다.
+     */
+    bool Remove(RID rid)
+    {
+        if (!IsValidRID(rid))
+        {
+            return false;
+        }
+
+        Slot& slot = slots[rid.index];
+        slot.data = T{};
+        slot.occupied = false;
+        ++slot.generation;
+        slot.next_free = free_head;
+        free_head = rid.index;
+        --count;
+
+        return true;
+    }
+
+    /**
+     * RID가 유효한지(슬롯이 존재하고, 세대가 일치하고, 사용 중인지) 검사합니다.
+     */
+    [[nodiscard]] bool IsValidRID(RID rid) const
+    {
+        if (std::cmp_greater_equal(rid.index, slots.Len()))  // rid.index >= slots.Len()
+        {
+            return false;
+        }
+        const Slot& slot = slots[rid.index];
+        return slot.occupied && slot.generation == rid.generation;
+    }
+
+    /**
+     * 모든 사용 중인 요소에 대해 콜백을 호출합니다.
+     * @param fn void(RID, T&) 또는 void(RID, const T&) 시그니처의 callable입니다.
+     */
+    template <typename Self, typename Fn>
+        requires std::invocable<Fn&, RID, std::conditional_t<std::is_const_v<Self>, const T&, T&>>
+    void ForEach(this Self& self, Fn&& fn)
+    {
+        for (const auto [idx, slot] : self.slots | std::views::enumerate)
+        {
+            if (slot.occupied)
+            {
+                fn(RID{
+                    .index = static_cast<uint32>(idx),
+                    .generation = slot.generation,
+                }, slot.data);
+            }
+        }
+    }
+
+    /** 현재 사용 중인 요소 수를 반환합니다. */
+    [[nodiscard]] uint32 Count() const noexcept { return count; }
+
+    /** SlotMap이 비어 있는지 확인합니다. */
+    [[nodiscard]] bool IsEmpty() const noexcept { return count == 0; }
+
+    /** 모든 요소를 제거하고 내부 상태를 초기화합니다. */
+    void Clear()
+    {
+        slots.Clear();
+        free_head = FREE_SENTINEL;
+        count = 0;
+    }
+
+private:
+    Array<Slot> slots;
+    uint32 free_head = FREE_SENTINEL;
+    uint32 count = 0;
+};
+} // namespace se::graphics

--- a/EngineCore/Include/SimpleEngine/Graphics/Manager/PSOManager.h
+++ b/EngineCore/Include/SimpleEngine/Graphics/Manager/PSOManager.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <concepts>
 
 #include "SimpleEngine/Core/Container/HashMap.h"
 #include "SimpleEngine/Graphics/Manager/PipelineCreateInfo.h"
@@ -7,6 +6,8 @@
 #include "SimpleEngine/Graphics/Traits/CreateInfoHash.h"
 
 #include "SDL3/SDL_gpu.h"
+
+#include <concepts>
 
 
 namespace se::graphics
@@ -17,7 +18,7 @@ namespace se::graphics
 class SE_CORE_API PSOManager
 {
 public:
-    explicit PSOManager(SDL_GPUDevice* in_device);
+    explicit PSOManager(RenderDevice& in_render_device);
     ~PSOManager();
 
     /** 캐싱된 SDL_GPUGraphicsPipeline* 를 가져오거나, 새로 생성합니다. */
@@ -35,7 +36,7 @@ public:
     void EndFrame();
 
 private:
-    SDL_GPUDevice* device;
+    RenderDevice* render_device;
     ShaderCache shader_cache;
 
     HashMap<GraphicsPipelineCreateInfo, SDL_GPUGraphicsPipeline*> cached_graphics_pipelines;

--- a/EngineCore/Include/SimpleEngine/Graphics/Manager/ShaderCache.h
+++ b/EngineCore/Include/SimpleEngine/Graphics/Manager/ShaderCache.h
@@ -15,7 +15,7 @@ class SE_CORE_API ShaderCache
 {
 public:
     explicit ShaderCache(
-        SDL_GPUDevice* in_device,
+        RenderDevice& in_render_device,
         std::unique_ptr<IShaderProvider> init_provider = std::make_unique<PrecompiledShaderProvider>()
     );
     ~ShaderCache();
@@ -37,7 +37,7 @@ public:
     void ClearCache();
 
 private:
-    SDL_GPUDevice* device;
+    RenderDevice* render_device;
     std::unique_ptr<IShaderProvider> provider;
 
     HashMap<ShaderRequest, SDL_GPUShader*> shader_cache;

--- a/EngineCore/Include/SimpleEngine/Graphics/Memory/GpuMemoryBlock.h
+++ b/EngineCore/Include/SimpleEngine/Graphics/Memory/GpuMemoryBlock.h
@@ -9,6 +9,9 @@
 
 namespace se::graphics
 {
+// forward declaration
+class RenderDevice;
+
 /**
  * GPU VRAM의 거대한 단일 할당 블록을 관리하는 클래스
  * 하나의 SDL_GPUBuffer를 소유하며, 이를 작은 Slice로 나누어 제공합니다.
@@ -16,7 +19,7 @@ namespace se::graphics
 class SE_CORE_API GpuMemoryBlock
 {
 public:
-    GpuMemoryBlock(SDL_GPUDevice* in_device, uint32 in_size, SDL_GPUBufferUsageFlags in_usage);
+    GpuMemoryBlock(RenderDevice* in_render_device, uint32 in_size, SDL_GPUBufferUsageFlags in_usage);
     ~GpuMemoryBlock();
 
     // 복사 방지
@@ -37,7 +40,7 @@ public:
     [[nodiscard]] SDL_GPUBuffer* GetNativeBuffer() const { return buffer; }
 
 private:
-    SDL_GPUDevice* device = nullptr;
+    RenderDevice* render_device = nullptr;
     SDL_GPUBuffer* buffer = nullptr; // GPU Buffer 리소스
 
     SDL_GPUBufferUsageFlags usage_flags = 0; // Buffer의 사용 용도

--- a/EngineCore/Include/SimpleEngine/Graphics/Memory/GpuResourceManager.h
+++ b/EngineCore/Include/SimpleEngine/Graphics/Memory/GpuResourceManager.h
@@ -11,6 +11,9 @@
 
 namespace se::graphics
 {
+// forward declaration
+class RenderDevice;
+
 /** 텍스처 업로드 시 적용할 옵션 */
 struct TextureUploadSettings
 {
@@ -40,7 +43,7 @@ struct TextureUploadSettings
 class SE_CORE_API GpuResourceManager
 {
 public:
-    explicit GpuResourceManager(SDL_GPUDevice* in_device);
+    explicit GpuResourceManager(RenderDevice& in_render_device);
     ~GpuResourceManager();
 
     // 이동 & 복사 생성자 제거
@@ -126,7 +129,7 @@ private:
     // TODO: 추후 Unload한 Mesh에 대해서 Defragmentation을 적용 후 VRAM 최적화
 
 private:
-    SDL_GPUDevice* device = nullptr;
+    RenderDevice* render_device;
 
     // Geometry(Vertex+Index)용 메모리 블록 목록
     Array<GpuMemoryBlock> geometry_blocks;

--- a/EngineCore/Include/SimpleEngine/Graphics/RenderGraph/FrameResourcePool.h
+++ b/EngineCore/Include/SimpleEngine/Graphics/RenderGraph/FrameResourcePool.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <memory>
 
 #include "SimpleEngine/Core/Container/Array.h"
 #include "SimpleEngine/Core/Container/HashMap.h"
@@ -12,6 +11,9 @@
 
 namespace se::graphics
 {
+// forward declaration
+class RenderDevice;
+
 /**
  * 렌더링 파이프라인에서 일시적으로 필요한 텍스처를 재사용하기 위한 Pool
  */
@@ -27,7 +29,7 @@ private:
     };
 
 public:
-    explicit FrameResourcePool(SDL_GPUDevice* in_device);
+    explicit FrameResourcePool(RenderDevice& in_render_device);
     ~FrameResourcePool();
 
     FrameResourcePool(const FrameResourcePool&) = delete;
@@ -60,7 +62,7 @@ private:
     static void ReleaseResourceInternal(PoolEntry<T>& entry, T* resource);
 
 private:
-    SDL_GPUDevice* device;
+    RenderDevice* render_device;
 
     HashMap<SDL_GPUTextureCreateInfo, PoolEntry<SDL_GPUTexture>> texture_pool;
     HashMap<SDL_GPUBufferCreateInfo, PoolEntry<SDL_GPUBuffer>> buffer_pool;
@@ -90,4 +92,4 @@ void FrameResourcePool::ReleaseResourceInternal(PoolEntry<T>& entry, T* resource
     entry.used_resources.RemoveAtSwap(*remove_idx_opt);
     entry.available_resources.Push(resource);
 }
-}  // namespace se::graphics
+} // namespace se::graphics

--- a/EngineCore/Include/SimpleEngine/Graphics/RenderGraph/RenderGraph.h
+++ b/EngineCore/Include/SimpleEngine/Graphics/RenderGraph/RenderGraph.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <memory>
 
 #include "SimpleEngine/Core/Container/HashSet.h"
 #include "SimpleEngine/Core/Types/StringName.h"
@@ -8,15 +7,18 @@
 #include "SimpleEngine/Graphics/RenderGraph/RGResources.h"
 #include "SimpleEngine/Graphics/RenderPass/RenderPassBase.h"
 
+#include <memory>
+
 
 namespace se::graphics
 {
 // forward declaration
-struct GraphicsPipelineCreateInfo;
 struct ComputePipelineCreateInfo;
+struct GraphicsPipelineCreateInfo;
 class PSOManager;
-class RenderGraphBuilder;
 class RGExecutionContext;
+class RenderDevice;
+class RenderGraphBuilder;
 
 
 /** 그래프 내의 렌더 패스를 표현하는 내부 구조체 */
@@ -55,10 +57,10 @@ class SE_CORE_API RenderGraph
     friend class RGExecutionContext;
 
 public:
-    explicit RenderGraph(SDL_GPUDevice* in_device);
+    explicit RenderGraph(RenderDevice& in_render_device);
     ~RenderGraph();
 
-    // 복사 생성자는 제거
+    // 복사만 불가
     RenderGraph(const RenderGraph&) = delete;
     RenderGraph& operator=(const RenderGraph&) = delete;
     RenderGraph(RenderGraph&&) noexcept = default;
@@ -87,7 +89,7 @@ private:
     RGResourceHandle RegisterResource(RGResourceNode&& node);
 
 private:
-    SDL_GPUDevice* device;
+    RenderDevice* render_device;
     FrameResourcePool resource_pool;
 
     // StringName으로 리소스 핸들을 찾기 위한 Map

--- a/EngineCore/Include/SimpleEngine/Graphics/RenderSubsystem.h
+++ b/EngineCore/Include/SimpleEngine/Graphics/RenderSubsystem.h
@@ -3,6 +3,7 @@
 #include "SimpleEngine/Core/Functional/MultiDelegate.h"
 #include "SimpleEngine/Core/HAL/WindowSubsystem.h"
 #include "SimpleEngine/Core/Subsystem/SubsystemBase.h"
+#include "SimpleEngine/Graphics/Device/RenderDevice.h"
 #include "SimpleEngine/Graphics/Manager/PSOManager.h"
 #include "SimpleEngine/Graphics/Memory/GpuResourceManager.h"
 #include "SimpleEngine/Graphics/RenderGraph/RenderGraph.h"
@@ -33,7 +34,7 @@ public:
     void SubmitCommands() const;
 
 public:
-    [[nodiscard]] SDL_GPUDevice* GetGpuDevice() const { return gpu_device; }
+    [[nodiscard]] graphics::RenderDevice& GetRenderDevice() const { return *render_device; }
     [[nodiscard]] graphics::PSOManager& GetPSOManager() const { return *pso_manager; }
     [[nodiscard]] graphics::RenderGraph& GetRenderGraph() const { return *render_graph; }
     [[nodiscard]] graphics::GpuResourceManager& GetResourceManager() const { return *resource_manager; }
@@ -50,8 +51,7 @@ private:
     void OnWindowDestroyed(SDL_WindowID window_id, SDL_Window* window);
 
 private:
-    SDL_GPUDevice* gpu_device = nullptr;
-
+    std::unique_ptr<graphics::RenderDevice> render_device;
     std::unique_ptr<graphics::RenderGraph> render_graph;
     std::unique_ptr<graphics::PSOManager> pso_manager;
     std::unique_ptr<graphics::GpuResourceManager> resource_manager;

--- a/EngineCore/Include/SimpleEngine/Graphics/ShaderProvider/IShaderProvider.h
+++ b/EngineCore/Include/SimpleEngine/Graphics/ShaderProvider/IShaderProvider.h
@@ -12,6 +12,9 @@
 
 namespace se::graphics
 {
+// forward declaration
+class RenderDevice;
+
 /**
  * Shader 요청에 필요한 정보
  */
@@ -35,7 +38,7 @@ public:
     virtual ~IShaderProvider() = default;
 
     /** 주어진 Request에 따라 Shader를 가져옵니다. */
-    virtual SDL_GPUShader* Provide(SDL_GPUDevice* device, const ShaderRequest& request) = 0;
+    virtual SDL_GPUShader* Provide(RenderDevice& render_device, const ShaderRequest& request) = 0;
 };
 }  // namespace se::graphics
 

--- a/EngineCore/Include/SimpleEngine/Graphics/ShaderProvider/PrecompiledShaderProvider.h
+++ b/EngineCore/Include/SimpleEngine/Graphics/ShaderProvider/PrecompiledShaderProvider.h
@@ -10,6 +10,6 @@ class PrecompiledShaderProvider : public IShaderProvider
 {
 public:
     /** SPIR-V 파일을 SDL_GPUShader*로 변환합니다. */
-    virtual SDL_GPUShader* Provide(SDL_GPUDevice* device, const ShaderRequest& request) override;
+    virtual SDL_GPUShader* Provide(RenderDevice& render_device, const ShaderRequest& request) override;
 };
 }

--- a/EngineCore/Include/SimpleEngine/Graphics/ShaderUtils.h
+++ b/EngineCore/Include/SimpleEngine/Graphics/ShaderUtils.h
@@ -8,12 +8,15 @@
 
 namespace se::graphics
 {
+// forward declaration
+class RenderDevice;
+
 /** 파일명으로 ShaderStage를 자동으로 탐지합니다. */
 [[nodiscard]] SE_CORE_API Optional<SDL_ShaderCross_ShaderStage> DetermineShaderStage(const Path& shader_path);
 
 /** SPIRV를 컴파일하여 SDL_GPUShader로 변환합니다. */
 [[nodiscard]] SE_CORE_API SDL_GPUShader* CompileFromSPIRV(
-    SDL_GPUDevice* device,
+    const RenderDevice& render_device,
     const Path& shader_path
 );
 }  // namespace se::graphics

--- a/EngineCore/Source/Core/Engine/Engine.cpp
+++ b/EngineCore/Source/Core/Engine/Engine.cpp
@@ -1,7 +1,5 @@
 #include "SimpleEngine/Core/Engine/Engine.h"
 
-#include <ranges>
-
 #include "SimpleEngine/Core/Concurrency/AsyncFileIO.h"
 #include "SimpleEngine/Core/Concurrency/JobSystem.h"
 #include "SimpleEngine/Core/Config/ConfigFile.h"
@@ -20,6 +18,8 @@
 
 #include "SDL3/SDL_gpu.h"
 #include "tracy/Tracy.hpp"
+
+#include <ranges>
 
 
 namespace se
@@ -235,7 +235,7 @@ void Engine::ReleaseAllSubsystems()
     // RenderSubsystem이 있다면, 해제하기전에 GPU 대기
     if (const RenderSubsystem* render_subsystem = GetSubsystem<const RenderSubsystem>())
     {
-        SDL_WaitForGPUIdle(render_subsystem->GetGpuDevice());
+        SDL_WaitForGPUIdle(render_subsystem->GetRenderDevice().GetRawDevice());
     }
 
     for (SubsystemBase* sub_system : sorted_subsystems | std::views::reverse)

--- a/EngineCore/Source/Graphics/Device/RenderDevice.cpp
+++ b/EngineCore/Source/Graphics/Device/RenderDevice.cpp
@@ -1,0 +1,118 @@
+#include "SimpleEngine/Graphics/Device/RenderDevice.h"
+#include "SimpleEngine/Core/Logging/Logging.h"
+
+#include "SDL3/SDL_gpu.h"
+
+
+namespace se::graphics
+{
+RenderDevice::RenderDevice(SDL_GPUDevice* raw_device)
+    : raw_device(raw_device)
+{
+}
+
+RenderDevice::~RenderDevice()
+{
+    // 지연 파괴 큐를 먼저 처리
+    ProcessDeferredDestructions();
+
+    // 남아 있는 모든 라이브 리소스를 해제
+    textures.ForEach([this](RID, const TextureResource& resource)
+    {
+        SDL_ReleaseGPUTexture(raw_device, resource.handle);
+    });
+    textures.Clear();
+
+    buffers.ForEach([this](RID, const BufferResource& resource)
+    {
+        SDL_ReleaseGPUBuffer(raw_device, resource.handle);
+    });
+    buffers.Clear();
+}
+
+RID RenderDevice::CreateTexture(const SDL_GPUTextureCreateInfo& desc)
+{
+    SDL_GPUTexture* raw = SDL_CreateGPUTexture(raw_device, &desc);
+    if (!raw)
+    {
+        ConsoleLog(ELogLevel::Error, "SDL_CreateGPUTexture failed: {}", SDL_GetError());
+        return {};
+    }
+
+    return textures.Insert({
+        .handle = raw,
+        .width = desc.width,
+        .height = desc.height,
+        .format = desc.format,
+    });
+}
+
+RID RenderDevice::CreateBuffer(const SDL_GPUBufferCreateInfo& desc)
+{
+    SDL_GPUBuffer* raw = SDL_CreateGPUBuffer(raw_device, &desc);
+    if (!raw)
+    {
+        ConsoleLog(ELogLevel::Error, "SDL_CreateGPUBuffer failed: {}", SDL_GetError());
+        return {};
+    }
+
+    return buffers.Insert({
+        .handle = raw,
+        .size = desc.size,
+        .usage = desc.usage,
+    });
+}
+
+Optional<const TextureResource&> RenderDevice::GetTexture(RID rid) const
+{
+    return textures.Get(rid);
+}
+
+Optional<const BufferResource&> RenderDevice::GetBuffer(RID rid) const
+{
+    return buffers.Get(rid);
+}
+
+bool RenderDevice::IsValidTexture(RID rid) const
+{
+    return textures.IsValidRID(rid);
+}
+
+bool RenderDevice::IsValidBuffer(RID rid) const
+{
+    return buffers.IsValidRID(rid);
+}
+
+void RenderDevice::DestroyTexture(RID rid)
+{
+    if (auto resource = textures.Get(rid))
+    {
+        deferred_texture_destroys.Push(resource->handle);
+        textures.Remove(rid);
+    }
+}
+
+void RenderDevice::DestroyBuffer(RID rid)
+{
+    if (auto resource = buffers.Get(rid))
+    {
+        deferred_buffer_destroys.Push(resource->handle);
+        buffers.Remove(rid);
+    }
+}
+
+void RenderDevice::ProcessDeferredDestructions()
+{
+    for (SDL_GPUTexture* texture : deferred_texture_destroys)
+    {
+        SDL_ReleaseGPUTexture(raw_device, texture);
+    }
+    deferred_texture_destroys.Clear();
+
+    for (SDL_GPUBuffer* buffer : deferred_buffer_destroys)
+    {
+        SDL_ReleaseGPUBuffer(raw_device, buffer);
+    }
+    deferred_buffer_destroys.Clear();
+}
+} // namespace se::graphics

--- a/EngineCore/Source/Graphics/Device/RenderDevice.cpp
+++ b/EngineCore/Source/Graphics/Device/RenderDevice.cpp
@@ -28,6 +28,9 @@ RenderDevice::~RenderDevice()
         SDL_ReleaseGPUBuffer(raw_device, resource.handle);
     });
     buffers.Clear();
+
+    // SDL_GPUDevice 정리
+    SDL_DestroyGPUDevice(raw_device);
 }
 
 RID RenderDevice::CreateTexture(const SDL_GPUTextureCreateInfo& desc)

--- a/EngineCore/Source/Graphics/Manager/PSOManager.cpp
+++ b/EngineCore/Source/Graphics/Manager/PSOManager.cpp
@@ -1,14 +1,16 @@
 #include "SimpleEngine/Graphics/Manager/PSOManager.h"
 
-#include <ranges>
 #include "SimpleEngine/Core/Logging/Logging.h"
+#include "SimpleEngine/Graphics/Device/RenderDevice.h"
+
+#include <ranges>
 
 
 namespace se::graphics
 {
-PSOManager::PSOManager(SDL_GPUDevice* in_device)
-    : device(in_device)
-    , shader_cache(in_device)
+PSOManager::PSOManager(RenderDevice& in_render_device)
+    : render_device(&in_render_device)
+    , shader_cache(in_render_device)
 {
 }
 
@@ -16,13 +18,13 @@ PSOManager::~PSOManager()
 {
     for (SDL_GPUGraphicsPipeline* pipeline : cached_graphics_pipelines | std::views::values)
     {
-        SDL_ReleaseGPUGraphicsPipeline(device, pipeline);
+        SDL_ReleaseGPUGraphicsPipeline(render_device->GetRawDevice(), pipeline);
     }
     cached_graphics_pipelines.Clear();
 
     for (SDL_GPUComputePipeline* pipeline : cached_compute_pipelines | std::views::values)
     {
-        SDL_ReleaseGPUComputePipeline(device, pipeline);
+        SDL_ReleaseGPUComputePipeline(render_device->GetRawDevice(), pipeline);
     }
     cached_compute_pipelines.Clear();
 }
@@ -60,7 +62,7 @@ SDL_GPUGraphicsPipeline* PSOManager::GetOrCreateGraphicsPipeline(const GraphicsP
         .props = create_info.props
     };
 
-    SDL_GPUGraphicsPipeline* pipeline = SDL_CreateGPUGraphicsPipeline(device, &info);
+    SDL_GPUGraphicsPipeline* pipeline = SDL_CreateGPUGraphicsPipeline(render_device->GetRawDevice(), &info);
     if (!pipeline)
     {
         ConsoleLog(ELogLevel::Error, "Failed to create graphics pipeline!, Err: {}", SDL_GetError());
@@ -73,7 +75,7 @@ SDL_GPUGraphicsPipeline* PSOManager::GetOrCreateGraphicsPipeline(const GraphicsP
 
 SDL_GPUComputePipeline* PSOManager::GetOrCreateComputePipeline(const ComputePipelineCreateInfo& create_info)
 {
-    return SDL_CreateGPUComputePipeline(device, &create_info.compute_pipeline_create_info);
+    return SDL_CreateGPUComputePipeline(render_device->GetRawDevice(), &create_info.compute_pipeline_create_info);
 }
 
 void PSOManager::EndFrame()

--- a/EngineCore/Source/Graphics/Manager/ShaderCache.cpp
+++ b/EngineCore/Source/Graphics/Manager/ShaderCache.cpp
@@ -1,13 +1,15 @@
 #include "SimpleEngine/Graphics/Manager/ShaderCache.h"
 
-#include <ranges>
 #include "SimpleEngine/Core/Logging/Logging.h"
+#include "SimpleEngine/Graphics/Device/RenderDevice.h"
+
+#include <ranges>
 
 
 namespace se::graphics
 {
-ShaderCache::ShaderCache(SDL_GPUDevice* in_device, std::unique_ptr<IShaderProvider> init_provider)
-    : device(in_device)
+ShaderCache::ShaderCache(RenderDevice& in_render_device, std::unique_ptr<IShaderProvider> init_provider)
+    : render_device(&in_render_device)
     , provider(std::move(init_provider))
 {
 }
@@ -24,7 +26,7 @@ SDL_GPUShader* ShaderCache::GetOrCreate(const ShaderRequest& request)
         return *cache_opt;
     }
 
-    if (SDL_GPUShader* shader = provider->Provide(device, request))
+    if (SDL_GPUShader* shader = provider->Provide(*render_device, request))
     {
         shader_cache[request] = shader;
         return shader;
@@ -38,7 +40,7 @@ void ShaderCache::ClearCache()
 {
     for (SDL_GPUShader* cache : shader_cache | std::views::values)
     {
-        SDL_ReleaseGPUShader(device, cache);
+        SDL_ReleaseGPUShader(render_device->GetRawDevice(), cache);
     }
     shader_cache.Clear();
 }

--- a/EngineCore/Source/Graphics/Memory/GpuMemoryBlock.cpp
+++ b/EngineCore/Source/Graphics/Memory/GpuMemoryBlock.cpp
@@ -1,11 +1,13 @@
 #include "SimpleEngine/Graphics/Memory/GpuMemoryBlock.h"
+
+#include "SimpleEngine/Graphics/Device/RenderDevice.h"
 #include "SimpleEngine/Utility/Common.h"
 
 
 namespace se::graphics
 {
-GpuMemoryBlock::GpuMemoryBlock(SDL_GPUDevice* in_device, uint32 in_size, SDL_GPUBufferUsageFlags in_usage)
-    : device(in_device)
+GpuMemoryBlock::GpuMemoryBlock(RenderDevice* in_render_device, uint32 in_size, SDL_GPUBufferUsageFlags in_usage)
+    : render_device(in_render_device)
     , usage_flags(in_usage)
     , total_size(in_size)
 {
@@ -13,15 +15,14 @@ GpuMemoryBlock::GpuMemoryBlock(SDL_GPUDevice* in_device, uint32 in_size, SDL_GPU
         .usage = in_usage,
         .size = in_size,
     };
-    buffer = SDL_CreateGPUBuffer(device, &buffer_info);
-    // SDL_SetGPUBufferName(device, buffer, 이름 설정);
+    buffer = SDL_CreateGPUBuffer(render_device->GetRawDevice(), &buffer_info);
 }
 
 GpuMemoryBlock::~GpuMemoryBlock()
 {
-    if (buffer)
+    if (buffer && render_device)
     {
-        SDL_ReleaseGPUBuffer(device, buffer);
+        SDL_ReleaseGPUBuffer(render_device->GetRawDevice(), buffer);
     }
 }
 
@@ -36,13 +37,13 @@ GpuMemoryBlock& GpuMemoryBlock::operator=(GpuMemoryBlock&& other) noexcept
     {
          if (buffer)
         {
-            SDL_ReleaseGPUBuffer(device, buffer);
+            SDL_ReleaseGPUBuffer(render_device->GetRawDevice(), buffer);
         }
 
         static_assert(
             AlignedSize<alignof(GpuMemoryBlock)>(
-                sizeof(device)   // NOLINT(*-sizeof-expression)
-                + sizeof(buffer) // NOLINT(*-sizeof-expression)
+                sizeof(render_device) // NOLINT(*-sizeof-expression)
+                + sizeof(buffer)      // NOLINT(*-sizeof-expression)
                 + sizeof(usage_flags)
                 + sizeof(total_size)
                 + sizeof(used_offset)
@@ -50,7 +51,7 @@ GpuMemoryBlock& GpuMemoryBlock::operator=(GpuMemoryBlock&& other) noexcept
             "GpuMemoryBlock size mismatch"
         );
 
-        device = std::exchange(other.device, nullptr);
+        render_device = std::exchange(other.render_device, nullptr);
         buffer = std::exchange(other.buffer, nullptr);
         usage_flags = std::exchange(other.usage_flags, 0);
         total_size = std::exchange(other.total_size, 0);

--- a/EngineCore/Source/Graphics/Memory/GpuResourceManager.cpp
+++ b/EngineCore/Source/Graphics/Memory/GpuResourceManager.cpp
@@ -1,17 +1,17 @@
 #include "SimpleEngine/Graphics/Memory/GpuResourceManager.h"
 
-#include <cmath>
-
 #include "SimpleEngine/Core/Logging/Logging.h"
+#include "SimpleEngine/Graphics/Device/RenderDevice.h"
 #include "SimpleEngine/Utility/Debug.h"
+
+#include <cmath>
 
 
 namespace se::graphics
 {
-GpuResourceManager::GpuResourceManager(SDL_GPUDevice* in_device)
-    : device(in_device)
+GpuResourceManager::GpuResourceManager(RenderDevice& in_render_device)
+    : render_device(&in_render_device)
 {
-    SE_ASSERT(device, "GPU device is null!");
 }
 
 GpuResourceManager::~GpuResourceManager()
@@ -21,7 +21,7 @@ GpuResourceManager::~GpuResourceManager()
     {
         if (gpu_texture.IsValid())
         {
-            SDL_ReleaseGPUTexture(device, gpu_texture.texture);
+            SDL_ReleaseGPUTexture(render_device->GetRawDevice(), gpu_texture.texture);
         }
     }
     texture_map.Clear();
@@ -62,7 +62,7 @@ bool GpuResourceManager::UploadMesh(
     };
 
     // TODO: transfer_buffer를 매번 할당하는 대신, 추후 Ring Buffer 방식으로 개선
-    SDL_GPUTransferBuffer* transfer_buffer = SDL_CreateGPUTransferBuffer(device, &transfer_info);
+    SDL_GPUTransferBuffer* transfer_buffer = SDL_CreateGPUTransferBuffer(render_device->GetRawDevice(), &transfer_info);
     if (!transfer_buffer)
     {
         ConsoleLog(ELogLevel::Error, "Failed to create Transfer Buffer: {}", SDL_GetError());
@@ -70,7 +70,7 @@ bool GpuResourceManager::UploadMesh(
     }
 
     // 메모리 맵핑 및 복사 (CPU -> Transfer Buffer)
-    if (void* mapped_ptr = SDL_MapGPUTransferBuffer(device, transfer_buffer, false))
+    if (void* mapped_ptr = SDL_MapGPUTransferBuffer(render_device->GetRawDevice(), transfer_buffer, false))
     {
         uint8* cursor = static_cast<uint8*>(mapped_ptr);
 
@@ -83,12 +83,12 @@ bool GpuResourceManager::UploadMesh(
             std::memcpy(cursor + in_vertex_size, in_index_data, in_index_size);
         }
 
-        SDL_UnmapGPUTransferBuffer(device, transfer_buffer);
+        SDL_UnmapGPUTransferBuffer(render_device->GetRawDevice(), transfer_buffer);
     }
     else
     {
         ConsoleLog(ELogLevel::Error, "Failed to map Transfer Buffer: {}", SDL_GetError());
-        SDL_ReleaseGPUTransferBuffer(device, transfer_buffer);
+        SDL_ReleaseGPUTransferBuffer(render_device->GetRawDevice(), transfer_buffer);
         return false;
     }
 
@@ -109,7 +109,7 @@ bool GpuResourceManager::UploadMesh(
         SDL_UploadToGPUBuffer(copy_pass, &src_loc, &dst_loc, false);
     }
     SDL_EndGPUCopyPass(copy_pass);
-    SDL_ReleaseGPUTransferBuffer(device, transfer_buffer);
+    SDL_ReleaseGPUTransferBuffer(render_device->GetRawDevice(), transfer_buffer);
 
     slice_map.Insert(in_id, slice);
     return true;
@@ -184,7 +184,7 @@ bool GpuResourceManager::UploadTexture(
         .sample_count = SDL_GPU_SAMPLECOUNT_1
     };
 
-    SDL_GPUTexture* texture = SDL_CreateGPUTexture(device, &create_info);
+    SDL_GPUTexture* texture = SDL_CreateGPUTexture(render_device->GetRawDevice(), &create_info);
     if (!texture)
     {
         ConsoleLog(ELogLevel::Error, "Failed to create GPU texture: {}", SDL_GetError());
@@ -198,24 +198,24 @@ bool GpuResourceManager::UploadTexture(
         .size = buffer_size
     };
 
-    SDL_GPUTransferBuffer* transfer_buffer = SDL_CreateGPUTransferBuffer(device, &transfer_info);
+    SDL_GPUTransferBuffer* transfer_buffer = SDL_CreateGPUTransferBuffer(render_device->GetRawDevice(), &transfer_info);
     if (!transfer_buffer)
     {
-        SDL_ReleaseGPUTexture(device, texture);
+        SDL_ReleaseGPUTexture(render_device->GetRawDevice(), texture);
         SDL_DestroySurface(converted_surface);
         return false;
     }
 
     // 메모리 맵핑 및 복사 (CPU -> Transfer Buffer)
-    if (void* mapped_ptr = SDL_MapGPUTransferBuffer(device, transfer_buffer, false))
+    if (void* mapped_ptr = SDL_MapGPUTransferBuffer(render_device->GetRawDevice(), transfer_buffer, false))
     {
         std::memcpy(mapped_ptr, converted_surface->pixels, buffer_size);
-        SDL_UnmapGPUTransferBuffer(device, transfer_buffer);
+        SDL_UnmapGPUTransferBuffer(render_device->GetRawDevice(), transfer_buffer);
     }
     else
     {
-        SDL_ReleaseGPUTexture(device, texture);
-        SDL_ReleaseGPUTransferBuffer(device, transfer_buffer);
+        SDL_ReleaseGPUTexture(render_device->GetRawDevice(), texture);
+        SDL_ReleaseGPUTransferBuffer(render_device->GetRawDevice(), transfer_buffer);
         SDL_DestroySurface(converted_surface);
         return false;
     }
@@ -248,7 +248,7 @@ bool GpuResourceManager::UploadTexture(
         SDL_GenerateMipmapsForGPUTexture(in_cmd, texture);
     }
 
-    SDL_ReleaseGPUTransferBuffer(device, transfer_buffer);
+    SDL_ReleaseGPUTransferBuffer(render_device->GetRawDevice(), transfer_buffer);
     SDL_DestroySurface(converted_surface); // 변환된 임시 Surface 해제
 
     texture_map.Insert(in_id, {
@@ -271,7 +271,7 @@ void GpuResourceManager::UnloadTexture(const asset::AssetId& in_id)
     {
         if (texture_opt->IsValid())
         {
-            SDL_ReleaseGPUTexture(device, texture_opt->texture);
+            SDL_ReleaseGPUTexture(render_device->GetRawDevice(), texture_opt->texture);
         }
         texture_map.Remove(in_id);
     }
@@ -297,7 +297,7 @@ GpuBufferSlice GpuResourceManager::AllocateInGeometryBlock(uint32 in_size)
     // Geometry용 Usage: Vertex + Index (Unified)
     // 필요하다면 Storage Buffer Read 플래그도 추가 가능 (SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ)
     constexpr SDL_GPUBufferUsageFlags usage = SDL_GPU_BUFFERUSAGE_VERTEX | SDL_GPU_BUFFERUSAGE_INDEX;
-    geometry_blocks.Emplace(device, new_block_size, usage);
+    geometry_blocks.Emplace(render_device, new_block_size, usage);
     GpuMemoryBlock& new_block = geometry_blocks.Back().Value();
 
     GpuBufferSlice slice;

--- a/EngineCore/Source/Graphics/RenderGraph/FrameResourcePool.cpp
+++ b/EngineCore/Source/Graphics/RenderGraph/FrameResourcePool.cpp
@@ -1,12 +1,13 @@
 #include "SimpleEngine/Graphics/RenderGraph/FrameResourcePool.h"
+#include "SimpleEngine/Graphics/Device/RenderDevice.h"
 
 #include <ranges>
 
 
 namespace se::graphics
 {
-FrameResourcePool::FrameResourcePool(SDL_GPUDevice* in_device)
-    : device(in_device)
+FrameResourcePool::FrameResourcePool(RenderDevice& in_render_device)
+    : render_device(&in_render_device)
 {
 }
 
@@ -16,11 +17,11 @@ FrameResourcePool::~FrameResourcePool()
     {
         for (SDL_GPUTexture* texture : entry.available_resources)
         {
-            SDL_ReleaseGPUTexture(device, texture);
+            SDL_ReleaseGPUTexture(render_device->GetRawDevice(), texture);
         }
         for (SDL_GPUTexture* texture : entry.used_resources)
         {
-            SDL_ReleaseGPUTexture(device, texture);
+            SDL_ReleaseGPUTexture(render_device->GetRawDevice(), texture);
         }
     }
 
@@ -28,11 +29,11 @@ FrameResourcePool::~FrameResourcePool()
     {
         for (SDL_GPUBuffer* buffer : entry.available_resources)
         {
-            SDL_ReleaseGPUBuffer(device, buffer);
+            SDL_ReleaseGPUBuffer(render_device->GetRawDevice(), buffer);
         }
         for (SDL_GPUBuffer* buffer : entry.used_resources)
         {
-            SDL_ReleaseGPUBuffer(device, buffer);
+            SDL_ReleaseGPUBuffer(render_device->GetRawDevice(), buffer);
         }
     }
 }
@@ -41,7 +42,7 @@ SDL_GPUTexture* FrameResourcePool::AcquireTexture(const SDL_GPUTextureCreateInfo
 {
     return AcquireResourceInternal(texture_pool[info], [this, &info = std::as_const(info)]
     {
-        return SDL_CreateGPUTexture(device, &info);
+        return SDL_CreateGPUTexture(render_device->GetRawDevice(), &info);
     });
 }
 
@@ -54,7 +55,7 @@ SDL_GPUBuffer* FrameResourcePool::AcquireBuffer(const SDL_GPUBufferCreateInfo& i
 {
     return AcquireResourceInternal(buffer_pool[info], [this, &info = std::as_const(info)]
     {
-        return SDL_CreateGPUBuffer(device, &info);
+        return SDL_CreateGPUBuffer(render_device->GetRawDevice(), &info);
     });
 }
 

--- a/EngineCore/Source/Graphics/RenderGraph/RenderGraph.cpp
+++ b/EngineCore/Source/Graphics/RenderGraph/RenderGraph.cpp
@@ -1,25 +1,27 @@
 // ReSharper disable CppMemberFunctionMayBeConst
 #include "SimpleEngine/Graphics/RenderGraph/RenderGraph.h"
 
-#include <algorithm>
-#include <memory>
-#include <ranges>
-#include <utility>
-
 #include "SimpleEngine/Core/Container/HashMap.h"
 #include "SimpleEngine/Core/Container/Queue.h"
 #include "SimpleEngine/Core/Logging/Logging.h"
 #include "SimpleEngine/Core/Reflection/Cast.h"
+#include "SimpleEngine/Graphics/Device/RenderDevice.h"
 #include "SimpleEngine/Graphics/Manager/PSOManager.h"
 #include "SimpleEngine/Utility/Debug.h"
 
 #include "tracy/Tracy.hpp"
 
+#include <algorithm>
+#include <memory>
+#include <ranges>
+#include <utility>
+
+
 namespace se::graphics
 {
-RenderGraph::RenderGraph(SDL_GPUDevice* in_device)
-    : device(in_device)
-    , resource_pool(in_device)
+RenderGraph::RenderGraph(RenderDevice& in_render_device)
+    : render_device(&in_render_device)
+    , resource_pool(in_render_device)
 {
 }
 

--- a/EngineCore/Source/Graphics/RenderSubsystem.cpp
+++ b/EngineCore/Source/Graphics/RenderSubsystem.cpp
@@ -56,21 +56,22 @@ bool RenderSubsystem::Initialize()
     SDL_SetHint(SDL_HINT_GPU_DRIVER, "metal");
 #endif
 
-    gpu_device = SDL_CreateGPUDeviceWithProperties(props);
+    SDL_GPUDevice* raw_device = SDL_CreateGPUDeviceWithProperties(props);
     SDL_DestroyProperties(props);
 
-    if (!gpu_device)
+    if (!raw_device)
     {
         ConsoleLog(ELogLevel::Error, "SDL_CreateGPUDeviceWithProperties failed: {}", SDL_GetError());
         return false;
     }
 
+    render_device = std::make_unique<RenderDevice>(raw_device);
+
     // Main Window를 GPU Device에 연결
-    if (!SDL_ClaimWindowForGPUDevice(gpu_device, main_window))
+    if (!SDL_ClaimWindowForGPUDevice(render_device->GetRawDevice(), main_window))
     {
         ConsoleLog(ELogLevel::Error, "SDL_ClaimWindowForGPUDevice failed: {}", SDL_GetError());
-        SDL_DestroyGPUDevice(gpu_device);
-        gpu_device = nullptr;
+        render_device.reset();
         return false;
     }
 
@@ -80,14 +81,14 @@ bool RenderSubsystem::Initialize()
     const SDL_GPUPresentMode present_mode = window_desc_opt->present_mode
         .ValueOr(DetermineBestPresentMode(main_window));
 
-    if (!SDL_SetGPUSwapchainParameters(gpu_device, main_window, swapchain_composition, present_mode))
+    if (!SDL_SetGPUSwapchainParameters(render_device->GetRawDevice(), main_window, swapchain_composition, present_mode))
     {
         ConsoleLog(ELogLevel::Warning, "SDL_SetGPUSwapchainParameters failed: {}", SDL_GetError());
     }
 
-    resource_manager = std::make_unique<GpuResourceManager>(gpu_device);
-    render_graph = std::make_unique<RenderGraph>(gpu_device);
-    pso_manager = std::make_unique<PSOManager>(gpu_device);
+    resource_manager = std::make_unique<GpuResourceManager>(*render_device);
+    render_graph = std::make_unique<RenderGraph>(*render_device);
+    pso_manager = std::make_unique<PSOManager>(*render_device);
 
     // 동적 윈도우 생성/파괴에 대응하기 위해 Delegate 구독
     WindowSubsystem& window_subsystem_mut = se::GetSubsystemChecked<WindowSubsystem>();
@@ -108,7 +109,7 @@ bool RenderSubsystem::Initialize()
 
 void RenderSubsystem::Release()
 {
-    if (!gpu_device)
+    if (!render_device)
     {
         return;
     }
@@ -133,17 +134,17 @@ void RenderSubsystem::Release()
     pso_manager.reset();
     resource_manager.reset();
 
-    // 모든 윈도우에서 GPU 디바이스 릴리스
+    // 모든 윈도우에서 GPU 디바이스 릴리스 (RenderDevice 소멸 전에 수행)
     if (window_subsystem)
     {
         window_subsystem->ForEachWindow([this](SDL_WindowID, SDL_Window* window, const WindowDesc&)
         {
-            SDL_ReleaseWindowFromGPUDevice(gpu_device, window);
+            SDL_ReleaseWindowFromGPUDevice(render_device->GetRawDevice(), window);
         });
     }
 
-    SDL_DestroyGPUDevice(gpu_device);
-    gpu_device = nullptr;
+    // RenderDevice 소멸자에서 SDL_DestroyGPUDevice를 호출
+    render_device.reset();
 }
 
 void RenderSubsystem::RenderFrame() const
@@ -160,7 +161,7 @@ void RenderSubsystem::RenderFrame() const
         }
 
         // Command Buffer 가져오기
-        SDL_GPUCommandBuffer* command_buffer = SDL_AcquireGPUCommandBuffer(gpu_device);
+        SDL_GPUCommandBuffer* command_buffer = SDL_AcquireGPUCommandBuffer(render_device->GetRawDevice());
         if (!command_buffer)
         {
             render_graph->Clear();
@@ -221,12 +222,12 @@ void RenderSubsystem::SubmitCommands() const
 // ReSharper disable once CppMemberFunctionMayBeConst
 void RenderSubsystem::OnWindowCreated(SDL_WindowID window_id, SDL_Window* window, const WindowDesc& desc)
 {
-    if (!gpu_device)
+    if (!render_device)
     {
         return;
     }
 
-    if (!SDL_ClaimWindowForGPUDevice(gpu_device, window))
+    if (!SDL_ClaimWindowForGPUDevice(render_device->GetRawDevice(), window))
     {
         ConsoleLog(ELogLevel::Warning, "SDL_ClaimWindowForGPUDevice failed for window {}: {}", window_id, SDL_GetError());
         return;
@@ -237,7 +238,7 @@ void RenderSubsystem::OnWindowCreated(SDL_WindowID window_id, SDL_Window* window
     );
     const SDL_GPUPresentMode present_mode = desc.present_mode.ValueOr(DetermineBestPresentMode(window));
 
-    if (!SDL_SetGPUSwapchainParameters(gpu_device, window, composition, present_mode))
+    if (!SDL_SetGPUSwapchainParameters(render_device->GetRawDevice(), window, composition, present_mode))
     {
         ConsoleLog(ELogLevel::Warning, "SDL_SetGPUSwapchainParameters failed for window {}: {}", window_id, SDL_GetError());
     }
@@ -246,12 +247,12 @@ void RenderSubsystem::OnWindowCreated(SDL_WindowID window_id, SDL_Window* window
 // ReSharper disable once CppMemberFunctionMayBeConst
 void RenderSubsystem::OnWindowDestroyed([[maybe_unused]] SDL_WindowID window_id, SDL_Window* window)
 {
-    if (!gpu_device)
+    if (!render_device)
     {
         return;
     }
 
-    SDL_ReleaseWindowFromGPUDevice(gpu_device, window);
+    SDL_ReleaseWindowFromGPUDevice(render_device->GetRawDevice(), window);
 }
 
 SDL_GPUSwapchainComposition RenderSubsystem::DetermineBestSwapchainComposition(SDL_Window* window, const WindowDesc& desc) const
@@ -259,7 +260,7 @@ SDL_GPUSwapchainComposition RenderSubsystem::DetermineBestSwapchainComposition(S
     // HDR이 요청되고 지원되는 경우
     if (
         desc.enable_hdr
-        && SDL_WindowSupportsGPUSwapchainComposition(gpu_device, window, SDL_GPU_SWAPCHAINCOMPOSITION_HDR_EXTENDED_LINEAR)
+        && SDL_WindowSupportsGPUSwapchainComposition(render_device->GetRawDevice(), window, SDL_GPU_SWAPCHAINCOMPOSITION_HDR_EXTENDED_LINEAR)
     )
     {
         return SDL_GPU_SWAPCHAINCOMPOSITION_HDR_EXTENDED_LINEAR;
@@ -268,7 +269,7 @@ SDL_GPUSwapchainComposition RenderSubsystem::DetermineBestSwapchainComposition(S
     // 선형 색공간이 선호되고 지원되는 경우
     if (
         desc.prefer_linear_color_space
-        && SDL_WindowSupportsGPUSwapchainComposition(gpu_device, window, SDL_GPU_SWAPCHAINCOMPOSITION_SDR_LINEAR)
+        && SDL_WindowSupportsGPUSwapchainComposition(render_device->GetRawDevice(), window, SDL_GPU_SWAPCHAINCOMPOSITION_SDR_LINEAR)
     )
     {
         return SDL_GPU_SWAPCHAINCOMPOSITION_SDR_LINEAR;
@@ -281,13 +282,13 @@ SDL_GPUSwapchainComposition RenderSubsystem::DetermineBestSwapchainComposition(S
 SDL_GPUPresentMode RenderSubsystem::DetermineBestPresentMode(SDL_Window* window) const
 {
     // MAILBOX가 지원되면 우선 선택 (낮은 지연시간)
-    if (SDL_WindowSupportsGPUPresentMode(gpu_device, window, SDL_GPU_PRESENTMODE_MAILBOX))
+    if (SDL_WindowSupportsGPUPresentMode(render_device->GetRawDevice(), window, SDL_GPU_PRESENTMODE_MAILBOX))
     {
         return SDL_GPU_PRESENTMODE_MAILBOX;
     }
 
     // IMMEDIATE가 지원되면 다음 선택
-    if (SDL_WindowSupportsGPUPresentMode(gpu_device, window, SDL_GPU_PRESENTMODE_IMMEDIATE))
+    if (SDL_WindowSupportsGPUPresentMode(render_device->GetRawDevice(), window, SDL_GPU_PRESENTMODE_IMMEDIATE))
     {
         return SDL_GPU_PRESENTMODE_IMMEDIATE;
     }

--- a/EngineCore/Source/Graphics/ShaderProvider/PrecompiledShaderProvider.cpp
+++ b/EngineCore/Source/Graphics/ShaderProvider/PrecompiledShaderProvider.cpp
@@ -6,7 +6,7 @@
 
 namespace se::graphics
 {
-SDL_GPUShader* PrecompiledShaderProvider::Provide(SDL_GPUDevice* device, const ShaderRequest& request)
+SDL_GPUShader* PrecompiledShaderProvider::Provide(RenderDevice& render_device, const ShaderRequest& request)
 {
     if constexpr (SE_BUILD_DEBUG)
     {
@@ -29,6 +29,6 @@ SDL_GPUShader* PrecompiledShaderProvider::Provide(SDL_GPUDevice* device, const S
         }
     }
 
-    return graphics::CompileFromSPIRV(device, request.source_path);
+    return CompileFromSPIRV(render_device, request.source_path);
 }
 }  // namespace se::graphics

--- a/EngineCore/Source/Graphics/ShaderUtils.cpp
+++ b/EngineCore/Source/Graphics/ShaderUtils.cpp
@@ -3,6 +3,7 @@
 #include "SimpleEngine/Core/FileSystem/FileSystem.h"
 #include "SimpleEngine/Core/HAL/PlatformTypes.h"
 #include "SimpleEngine/Core/Logging/Logging.h"
+#include "SimpleEngine/Graphics/Device/RenderDevice.h"
 
 
 namespace se::graphics
@@ -43,7 +44,7 @@ Optional<SDL_ShaderCross_ShaderStage> DetermineShaderStage(const Path& shader_pa
     return NullOpt;
 }
 
-SDL_GPUShader* CompileFromSPIRV(SDL_GPUDevice* device, const Path& shader_path)
+SDL_GPUShader* CompileFromSPIRV(const RenderDevice& render_device, const Path& shader_path)
 {
     // read shader file
     Array<uint8> source;
@@ -101,7 +102,7 @@ SDL_GPUShader* CompileFromSPIRV(SDL_GPUDevice* device, const Path& shader_path)
     }
 
     // create gpu shader
-    const SDL_GPUShaderFormat backend_formats = SDL_GetGPUShaderFormats(device);
+    const SDL_GPUShaderFormat backend_formats = SDL_GetGPUShaderFormats(render_device.GetRawDevice());
     if (backend_formats & SDL_GPU_SHADERFORMAT_DXIL)
     {
         usize bytecode_size;
@@ -118,7 +119,7 @@ SDL_GPUShader* CompileFromSPIRV(SDL_GPUDevice* device, const Path& shader_path)
             .num_storage_buffers = refl_metadata->resource_info.num_storage_buffers,
             .num_uniform_buffers = refl_metadata->resource_info.num_uniform_buffers,
         };
-        SDL_GPUShader* shader = SDL_CreateGPUShader(device, &create_info);
+        SDL_GPUShader* shader = SDL_CreateGPUShader(render_device.GetRawDevice(), &create_info);
         SDL_free(bytecode);
         return shader;
     }
@@ -131,7 +132,7 @@ SDL_GPUShader* CompileFromSPIRV(SDL_GPUDevice* device, const Path& shader_path)
             .num_storage_buffers = refl_metadata->resource_info.num_storage_buffers,
             .num_uniform_buffers = refl_metadata->resource_info.num_uniform_buffers,
         };
-        return SDL_ShaderCross_CompileGraphicsShaderFromSPIRV(device, &spirv_info, &resource_info, 0);
+        return SDL_ShaderCross_CompileGraphicsShaderFromSPIRV(render_device.GetRawDevice(), &spirv_info, &resource_info, 0);
     }
 
     ConsoleLog(ELogLevel::Error, "Unknown shader backend format: {}", shader_path);

--- a/EngineTest/Source/UnitTests/SlotMapTest.cpp
+++ b/EngineTest/Source/UnitTests/SlotMapTest.cpp
@@ -1,0 +1,305 @@
+#include "gtest/gtest.h"
+
+#include "SimpleEngine/Graphics/Device/RID.h"
+#include "SimpleEngine/Graphics/Device/SlotMap.h"
+
+using namespace se;
+using namespace se::graphics;
+
+
+class RIDTest : public ::testing::Test {};
+class SlotMapTest : public ::testing::Test {};
+
+
+// ============================================================================
+// RID Tests
+// ============================================================================
+
+TEST_F(RIDTest, DefaultConstructedIsInvalid)
+{
+    const RID rid{};
+    EXPECT_FALSE(rid.IsValid());
+    EXPECT_FALSE(static_cast<bool>(rid));
+}
+
+TEST_F(RIDTest, ValidRID)
+{
+    const RID rid{ .index = 0, .generation = 1 };
+    EXPECT_TRUE(rid.IsValid());
+    EXPECT_TRUE(static_cast<bool>(rid));
+}
+
+TEST_F(RIDTest, Equality)
+{
+    const RID a{ .index = 1, .generation = 2 };
+    const RID b{ .index = 1, .generation = 2 };
+    const RID c{ .index = 1, .generation = 3 };
+
+    EXPECT_EQ(a, b);
+    EXPECT_NE(a, c);
+}
+
+TEST_F(RIDTest, ToU64Packing)
+{
+    const RID rid{ .index = 0xDEAD, .generation = 0xBEEF };
+    const uint64 packed = rid.ToU64();
+
+    EXPECT_EQ(packed, (static_cast<uint64>(0xBEEF) << 32) | 0xDEAD);
+}
+
+TEST_F(RIDTest, HashConsistency)
+{
+    const RID a{ .index = 42, .generation = 7 };
+    const RID b{ .index = 42, .generation = 7 };
+
+    EXPECT_EQ(std::hash<RID>{}(a), std::hash<RID>{}(b));
+}
+
+
+// ============================================================================
+// SlotMap Tests
+// ============================================================================
+
+TEST_F(SlotMapTest, EmptyOnConstruction)
+{
+    const SlotMap<int> map;
+    EXPECT_TRUE(map.IsEmpty());
+    EXPECT_EQ(map.Count(), 0u);
+}
+
+TEST_F(SlotMapTest, InsertAndGet)
+{
+    SlotMap<int> map;
+    const RID rid = map.Insert(42);
+
+    EXPECT_TRUE(rid.IsValid());
+    EXPECT_EQ(map.Count(), 1u);
+
+    auto value = map.Get(rid);
+    EXPECT_TRUE(value.HasValue());
+    EXPECT_EQ(*value, 42);
+}
+
+TEST_F(SlotMapTest, InsertLvalue)
+{
+    SlotMap<int> map;
+    const int value = 100;
+    const RID rid = map.Insert(value);
+
+    auto result = map.Get(rid);
+    EXPECT_TRUE(result.HasValue());
+    EXPECT_EQ(*result, 100);
+}
+
+TEST_F(SlotMapTest, GetInvalidRID)
+{
+    const SlotMap<int> map;
+    const RID invalid{};
+
+    EXPECT_FALSE(map.Get(invalid).HasValue());
+}
+
+TEST_F(SlotMapTest, GetOutOfBoundsIndex)
+{
+    const SlotMap<int> map;
+    const RID out_of_bounds{ .index = 999, .generation = 1 };
+
+    EXPECT_FALSE(map.Get(out_of_bounds).HasValue());
+}
+
+TEST_F(SlotMapTest, Remove)
+{
+    SlotMap<int> map;
+    const RID rid = map.Insert(42);
+
+    EXPECT_TRUE(map.Remove(rid));
+    EXPECT_EQ(map.Count(), 0u);
+    EXPECT_FALSE(map.Get(rid).HasValue());
+}
+
+TEST_F(SlotMapTest, RemoveInvalidRID)
+{
+    SlotMap<int> map;
+    const RID invalid{};
+
+    EXPECT_FALSE(map.Remove(invalid));
+}
+
+TEST_F(SlotMapTest, GenerationInvalidatesOldRID)
+{
+    SlotMap<int> map;
+    const RID old_rid = map.Insert(42);
+
+    map.Remove(old_rid);
+
+    // 같은 슬롯을 재사용하지만 세대가 증가합니다.
+    const RID new_rid = map.Insert(99);
+
+    // 이전 RID로 접근하면 실패해야 합니다.
+    EXPECT_FALSE(map.Get(old_rid).HasValue());
+    EXPECT_FALSE(map.IsValidRID(old_rid));
+
+    // 새 RID로 접근하면 성공해야 합니다.
+    auto value = map.Get(new_rid);
+    EXPECT_TRUE(value.HasValue());
+    EXPECT_EQ(*value, 99);
+}
+
+TEST_F(SlotMapTest, SlotReuse)
+{
+    SlotMap<int> map;
+    const RID rid1 = map.Insert(1);
+    const uint32 first_index = rid1.index;
+
+    map.Remove(rid1);
+
+    const RID rid2 = map.Insert(2);
+
+    // 삭제된 슬롯이 재사용되어야 합니다.
+    EXPECT_EQ(rid2.index, first_index);
+    // 세대는 증가해야 합니다.
+    EXPECT_GT(rid2.generation, rid1.generation);
+}
+
+TEST_F(SlotMapTest, MultipleInsertRemove)
+{
+    SlotMap<int> map;
+
+    Array<RID> rids;
+    for (int i = 0; i < 100; ++i)
+    {
+        rids.Push(map.Insert(i));
+    }
+    EXPECT_EQ(map.Count(), 100u);
+
+    // 짝수 인덱스 제거
+    for (usize i = 0; i < rids.Len(); i += 2)
+    {
+        map.Remove(rids[i]);
+    }
+    EXPECT_EQ(map.Count(), 50u);
+
+    // 홀수 인덱스 값 확인
+    for (usize i = 1; i < rids.Len(); i += 2)
+    {
+        auto value = map.Get(rids[i]);
+        EXPECT_TRUE(value.HasValue());
+        EXPECT_EQ(*value, static_cast<int>(i));
+    }
+
+    // 짝수 인덱스는 무효화 확인
+    for (usize i = 0; i < rids.Len(); i += 2)
+    {
+        EXPECT_FALSE(map.Get(rids[i]).HasValue());
+    }
+}
+
+TEST_F(SlotMapTest, ForEachMutable)
+{
+    SlotMap<int> map;
+    map.Insert(1);
+    map.Insert(2);
+    map.Insert(3);
+
+    int sum = 0;
+    map.ForEach([&sum](RID, int& value)
+    {
+        sum += value;
+        value *= 2;  // 값 수정
+    });
+    EXPECT_EQ(sum, 6);
+
+    // 수정 확인
+    int doubled_sum = 0;
+    map.ForEach([&doubled_sum](RID, int& value)
+    {
+        doubled_sum += value;
+    });
+    EXPECT_EQ(doubled_sum, 12);
+}
+
+TEST_F(SlotMapTest, ForEachConst)
+{
+    SlotMap<int> map;
+    map.Insert(10);
+    map.Insert(20);
+
+    const auto& const_map = map;
+
+    int sum = 0;
+    const_map.ForEach([&sum](RID, const int& value)
+    {
+        sum += value;
+    });
+    EXPECT_EQ(sum, 30);
+}
+
+TEST_F(SlotMapTest, ForEachSkipsRemovedSlots)
+{
+    SlotMap<int> map;
+    const RID rid1 = map.Insert(1);
+    map.Insert(2);
+    map.Insert(3);
+
+    map.Remove(rid1);
+
+    int count = 0;
+    map.ForEach([&count](RID, const int&)
+    {
+        ++count;
+    });
+    EXPECT_EQ(count, 2);
+}
+
+TEST_F(SlotMapTest, GetMutableModifiesValue)
+{
+    SlotMap<int> map;
+    const RID rid = map.Insert(42);
+
+    auto value = map.Get(rid);
+    EXPECT_TRUE(value.HasValue());
+    *value = 100;
+
+    auto check = map.Get(rid);
+    EXPECT_TRUE(check.HasValue());
+    EXPECT_EQ(*check, 100);
+}
+
+TEST_F(SlotMapTest, ConstGetReturnsConstOptional)
+{
+    SlotMap<int> map;
+    const RID rid = map.Insert(42);
+
+    const auto& const_map = map;
+    auto value = const_map.Get(rid);
+
+    EXPECT_TRUE(value.HasValue());
+    EXPECT_EQ(*value, 42);
+
+    // const_map.Get(rid) 반환 타입이 Optional<const int&>인지 컴파일 타임 확인
+    static_assert(std::is_same_v<decltype(const_map.Get(rid)), Optional<const int&>>);
+}
+
+TEST_F(SlotMapTest, Clear)
+{
+    SlotMap<int> map;
+    const RID rid = map.Insert(1);
+    map.Insert(2);
+
+    map.Clear();
+
+    EXPECT_TRUE(map.IsEmpty());
+    EXPECT_EQ(map.Count(), 0u);
+    EXPECT_FALSE(map.Get(rid).HasValue());
+}
+
+TEST_F(SlotMapTest, MoveOnlyType)
+{
+    SlotMap<std::unique_ptr<int>> map;
+    const RID rid = map.Insert(std::make_unique<int>(42));
+
+    auto value = map.Get(rid);
+    EXPECT_TRUE(value.HasValue());
+    EXPECT_NE(*value, nullptr);
+    EXPECT_EQ(**value, 42);
+}


### PR DESCRIPTION
> 아래 PR 메시지는 Claude Sonnet 4.6을 사용하여 작성되었습니다.

## Summary

- **RID + SlotMap + RenderDevice** 세 가지 인프라 클래스 신규 구현
- 코드베이스 전체에서 `SDL_GPUDevice*` raw pointer를 `RenderDevice*`로 교체
- `RenderDevice`가 `SDL_GPUDevice*` 소유권을 가지며 소멸자에서 `SDL_DestroyGPUDevice` 호출
- 모든 그래픽스 매니저의 멤버 저장 방식을 **포인터로 통일** (레퍼런스 멤버 제거)

## 신규 파일

| 파일 | 설명 |
|------|------|
| `Graphics/Device/RID.h` | 32-bit index + 32-bit generation의 GPU 리소스 핸들. `IsValid()`, `operator==`, `std::hash` 특수화 포함 |
| `Graphics/Device/SlotMap.h` | Generational Arena 기반 컨테이너. `Insert → RID`, `Get(RID) → Optional<T&>`, `Remove`, `ForEach`. 22개 단위 테스트 통과 |
| `Graphics/Device/RenderDevice.h/.cpp` | `SDL_GPUDevice*` 래퍼. `CreateTexture/Buffer → RID`, 지연 파괴(deferred destruction) 큐, `GetRawDevice()` SDL interop |

## 변경 내용

### 아키텍처 변경

- `RenderSubsystem`: `SDL_GPUDevice* gpu_device` → `std::unique_ptr<RenderDevice> render_device`
  - `GetGpuDevice()` 제거 → `GetRenderDevice()` 추가
  - `RenderDevice` 소멸 시 `SDL_DestroyGPUDevice` 자동 호출
- `FrameResourcePool`, `RenderGraph`: 레퍼런스 멤버 제거로 이동 연산 복원 (`= default`)

### 교체된 파일 목록

- `IShaderProvider`, `ShaderUtils`, `PrecompiledShaderProvider`
- `ShaderCache`, `PSOManager`
- `GpuMemoryBlock`, `GpuResourceManager`
- `FrameResourcePool`, `RenderGraph`
- `Engine.cpp`, `EditorViewportSubsystem`, `EditorUISubsystem`, `EditorApplication`

### 컨벤션 통일

```
생성자 파라미터 : RenderDevice&   (null 불가 의도 표현)
멤버 저장       : RenderDevice*   (이동 가능, 일관성)
사용부          : render_device->GetRawDevice()
```

## Test plan

- [x] `SlotMapTest` 22개 테스트 통과 (Insert/Get/Remove, generational validation, const correctness)
- [x] 전체 843 테스트 통과 (`UnitTests.exe`)
- [x] Debug 빌드 성공 (EngineCore.dll, Editor.dll, EditorApp.exe, UnitTests.exe)
- [x] `GetGpuDevice()` 호출부 코드베이스 전체 0건 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)