### PR TITLE
refactor: 렌더링 아키텍처 리팩토링 Phase 2-3 (RenderGraph v2 + SceneDrawData 디커플링)

### DIFF
--- a/Editor/Source/App/EditorApplication.cpp
+++ b/Editor/Source/App/EditorApplication.cpp
@@ -13,6 +13,8 @@
 #include "SimpleEngine/ECS/WorldSubsystem.h"
 #include "SimpleEngine/Graphics/RenderSubsystem.h"
 #include "SimpleEngine/Graphics/RenderPass/ForwardScenePass.h"
+#include "SimpleEngine/Graphics/Scene/CollectDrawData.h"
+#include "SimpleEngine/Graphics/View/RenderView.h"
 #include "SimpleEngine/Utility/SubsystemUtils.h"
 
 
@@ -133,7 +135,10 @@ void EditorApplication::Render()
         const auto [world_subsystem, ui_subsystem, viewport_subsystem] =
             se::GetSubsystemsChecked<const WorldSubsystem, const EditorUISubsystem, const EditorViewportSubsystem>();
 
-        se::ecs::World& world_ref = *world_subsystem.GetWorld();
+        // ECS World 렌더링 데이터 스냅샷 (프레임당 1회)
+        se::graphics::SceneDrawData scene_draw_data = se::graphics::CollectDrawData(*world_subsystem.GetWorld());
+        const se::graphics::GpuResourceManager& gpu_manager = render_subsystem->GetResourceManager();
+
         se::graphics::RenderGraph& graph = render_subsystem->GetRenderGraph();
         for (const auto& [viewport_id, info] : viewport_subsystem.GetActiveViewportInfo())
         {
@@ -142,15 +147,19 @@ void EditorApplication::Render()
                 const StringName color_target_name = viewport_id;
                 graph.ImportTexture(color_target_name, info.color_texture);
 
-                // TODO: 나중에 에디터 카메라나, 월드 카메라 분기 처리
-                const Matrix4x4 vp_matrix_to_render = info.view_matrix * info.projection_matrix;
+                const se::graphics::RenderView render_view = {
+                    .view_matrix = info.view_matrix,
+                    .projection_matrix = info.projection_matrix,
+                    .color_target_name = color_target_name,
+                    .depth_target_name = StringName{ se::String::Format("{}_Depth", viewport_id.ToString()) },
+                    .width = info.width,
+                    .height = info.height,
+                };
 
-                const StringName depth_target_name = se::String::Format("{}_Depth", viewport_id.ToString());
                 graph.AddPass<se::graphics::ForwardScenePass>(
-                    world_ref,
-                    vp_matrix_to_render,
-                    color_target_name, depth_target_name,
-                    info.width, info.height
+                    scene_draw_data,
+                    render_view,
+                    gpu_manager
                 );
             }
         }

--- a/EngineCore/Include/SimpleEngine/Graphics/RenderGraph/FrameResourcePool.h
+++ b/EngineCore/Include/SimpleEngine/Graphics/RenderGraph/FrameResourcePool.h
@@ -16,16 +16,25 @@ class RenderDevice;
 
 /**
  * 렌더링 파이프라인에서 일시적으로 필요한 텍스처를 재사용하기 위한 Pool
+ * 풀링된 리소스는 idle_frames를 추적하여, 일정 프레임 동안 미사용 시 Trim()을 통해 자동 해제됩니다.
  */
 class SE_CORE_API FrameResourcePool
 {
 private:
-    // Pool 관리용 Entry
+    /** Pool에 보관 중인 개별 리소스와 idle 프레임 수를 추적하기 위한 구조체 */
+    template <typename T>
+    struct PooledResource
+    {
+        T* resource = nullptr;
+        uint32 idle_frames = 0;
+    };
+
+    /** 특정 CreateInfo에 대한 풀 Entry */
     template <typename T>
     struct PoolEntry
     {
-        Array<T*> available_resources;
-        Array<T*> used_resources;
+        Array<PooledResource<T>> available_resources; // 대기 중 (idle 추적)
+        Array<T*> used_resources;                     // 현재 프레임에서 사용 중
     };
 
 public:
@@ -50,8 +59,11 @@ public:
     /** 프레임 종료 후 사용된 버퍼를 반납합니다. */
     void ReleaseBuffer(const SDL_GPUBufferCreateInfo& info, SDL_GPUBuffer* buffer);
 
-    /** 사용되지 않은 리소스를 모두 제거합니다. | TODO: PruneUnusedResources 구현하기 */
-    // void PruneUnusedResources();
+    /** 대기 중인 모든 리소스의 idle 카운터를 1 증가시킵니다. 프레임 경계에서 호출합니다. */
+    void IncrementIdleCounters();
+
+    /** max_idle_frames 이상 미사용된 대기 리소스를 실제 GPU 리소스로부터 해제합니다. */
+    void Trim(uint32 max_idle_frames);
 
 private:
     template <typename T, typename CreateResourceFn>
@@ -60,6 +72,10 @@ private:
 
     template <typename T>
     static void ReleaseResourceInternal(PoolEntry<T>& entry, T* resource);
+
+    template <typename T, typename ReleaseFn>
+        requires std::invocable<ReleaseFn, T*>
+    static void TrimEntry(PoolEntry<T>& entry, uint32 max_idle_frames, ReleaseFn&& release_fn);
 
 private:
     RenderDevice* render_device;
@@ -72,9 +88,9 @@ template <typename T, typename FactoryFn>
     requires std::is_invocable_r_v<T*, FactoryFn>
 T* FrameResourcePool::AcquireResourceInternal(PoolEntry<T>& entry, FactoryFn&& factory_func)
 {
-    if (Optional resource_opt = entry.available_resources.Pop())
+    if (Optional pooled_opt = entry.available_resources.Pop())
     {
-        entry.used_resources.Push(*resource_opt);
+        entry.used_resources.Push(pooled_opt->resource);
     }
     else [[unlikely]]
     {
@@ -87,9 +103,24 @@ template <typename T>
 void FrameResourcePool::ReleaseResourceInternal(PoolEntry<T>& entry, T* resource)
 {
     const Optional<usize> remove_idx_opt = entry.used_resources.Find(resource);
-    SE_ASSERT(remove_idx_opt.HasValue(), "Attempted to deallocate a texture that was not marked as used.");
+    SE_ASSERT(remove_idx_opt.HasValue(), "Attempted to deallocate a resource that was not marked as used.");
 
     entry.used_resources.RemoveAtSwap(*remove_idx_opt);
-    entry.available_resources.Push(resource);
+    entry.available_resources.Push(PooledResource<T>{ .resource = resource, .idle_frames = 0 });
+}
+
+template <typename T, typename ReleaseFn>
+    requires std::invocable<ReleaseFn, T*>
+void FrameResourcePool::TrimEntry(PoolEntry<T>& entry, uint32 max_idle_frames, ReleaseFn&& release_fn)
+{
+    for (isize i = static_cast<isize>(entry.available_resources.Len()) - 1; i >= 0; --i)
+    {
+        auto& pooled = entry.available_resources[static_cast<usize>(i)];
+        if (pooled.idle_frames >= max_idle_frames)
+        {
+            release_fn(pooled.resource);
+            entry.available_resources.RemoveAtSwap(static_cast<usize>(i));
+        }
+    }
 }
 } // namespace se::graphics

--- a/EngineCore/Include/SimpleEngine/Graphics/RenderGraph/RenderGraph.h
+++ b/EngineCore/Include/SimpleEngine/Graphics/RenderGraph/RenderGraph.h
@@ -100,6 +100,12 @@ private:
 
     // 컴파일 후 정렬된 Pass의 순서
     Array<const RGPassNode*> compiled_passes;
+
+    // 패스 실행 전에 Realize할 리소스 인덱스 목록 (pass_idx로 접근)
+    Array<Array<usize>> resources_to_realize;
+
+    // 패스 실행 후에 Unrealize할 리소스 인덱스 목록 (pass_idx로 접근)
+    Array<Array<usize>> resources_to_unrealize;
 };
 
 /**

--- a/EngineCore/Include/SimpleEngine/Graphics/RenderPass/ForwardScenePass.h
+++ b/EngineCore/Include/SimpleEngine/Graphics/RenderPass/ForwardScenePass.h
@@ -4,19 +4,18 @@
 #include "SimpleEngine/Core/Container/Array.h"
 #include "SimpleEngine/Core/HAL/PlatformTypes.h"
 #include "SimpleEngine/Core/Math/Math.h"
-#include "SimpleEngine/Core/Types/StringName.h"
 #include "SimpleEngine/Graphics/RenderGraph/RGResourceHandle.h"
 #include "SimpleEngine/Graphics/RenderPass/RenderPassBase.h"
 
 
-namespace se::ecs
-{
-class World;
-}
-
 namespace se::graphics
 {
-/** 개별 객체의 렌더링 정보 */
+// forward declaration
+struct SceneDrawData;
+struct RenderView;
+class GpuResourceManager;
+
+/** 개별 오브젝트의 프레임 내 렌더링 정보 */
 struct EntityDrawInfo
 {
     Matrix4x4 mvp_matrix;
@@ -25,7 +24,7 @@ struct EntityDrawInfo
 };
 
 /**
- * World에 있는 Entity를 그리는 Pass
+ * SceneDrawData의 오브젝트를 Forward 렌더링하는 패스
  */
 class SE_CORE_API SE_ANNOTATION(=meta::Internal) ForwardScenePass : public RenderPassBase
 {
@@ -33,26 +32,21 @@ class SE_CORE_API SE_ANNOTATION(=meta::Internal) ForwardScenePass : public Rende
 
 public:
     explicit ForwardScenePass(
-        ecs::World& in_world_ref,
-        const Matrix4x4& in_vp_matrix,
-        const StringName& in_color_target_name,
-        const StringName& in_depth_target_name,
-        uint32 in_width, uint32 in_height
+        const SceneDrawData& in_draw_data,
+        const RenderView& in_render_view,
+        const GpuResourceManager& in_gpu_manager
     );
 
     virtual void Setup(RenderGraphBuilder& builder) override;
     virtual void Execute(RGExecutionContext& context) override;
 
 private:
-    const Matrix4x4 vp_matrix;
-    ecs::World& world_ref; // TODO: 추후 QueryEntities가 const로 바뀌면 const&로 수정
-    const StringName color_target_name;
-    const StringName depth_target_name;
-    const uint32 width;
-    const uint32 height;
+    const SceneDrawData& draw_data;
+    const RenderView& render_view;
+    const GpuResourceManager& gpu_manager;
 
     Array<EntityDrawInfo> draw_infos;
     RGResourceHandle color_target_handle;
     RGResourceHandle depth_target_handle;
 };
-}  // namespace se::graphics
+} // namespace se::graphics

--- a/EngineCore/Include/SimpleEngine/Graphics/Scene/CollectDrawData.h
+++ b/EngineCore/Include/SimpleEngine/Graphics/Scene/CollectDrawData.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "SimpleEngine/Graphics/Scene/SceneDrawData.h"
+
+// forward declaration
+namespace se::ecs{ class World; }
+
+
+namespace se::graphics
+{
+/**
+ * ECS World에서 렌더링 가능한 엔티티를 수집하여 SceneDrawData를 생성합니다.
+ */
+[[nodiscard]] SE_CORE_API SceneDrawData CollectDrawData(ecs::World& world);
+} // namespace se::graphics

--- a/EngineCore/Include/SimpleEngine/Graphics/Scene/DrawCommand.h
+++ b/EngineCore/Include/SimpleEngine/Graphics/Scene/DrawCommand.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "SimpleEngine/Asset/AssetId.h"
+#include "SimpleEngine/Core/HAL/PlatformTypes.h"
+#include "SimpleEngine/Core/Math/Math.h"
+
+
+namespace se::graphics
+{
+/**
+ * 개별 오브젝트의 Draw Command를 나타내는 구조체
+ */
+struct DrawCommand
+{
+    Matrix4x4 model_matrix;
+    asset::AssetId mesh_id;
+    asset::AssetId material_id;
+    uint64 sort_key = 0;
+};
+} // namespace se::graphics

--- a/EngineCore/Include/SimpleEngine/Graphics/Scene/SceneDrawData.h
+++ b/EngineCore/Include/SimpleEngine/Graphics/Scene/SceneDrawData.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "SimpleEngine/Core/Container/Array.h"
+#include "SimpleEngine/Graphics/Scene/DrawCommand.h"
+
+
+namespace se::graphics
+{
+/**
+ * 한 프레임에서 렌더링할 드로우 커맨드의 스냅샷
+ */
+struct SceneDrawData
+{
+    Array<DrawCommand> opaque_commands;
+    // Array<DrawCommand> transparent_commands; // 추후 투명 오브젝트 분류 시 추가
+};
+} // namespace se::graphics

--- a/EngineCore/Include/SimpleEngine/Graphics/View/FramePacket.h
+++ b/EngineCore/Include/SimpleEngine/Graphics/View/FramePacket.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "SimpleEngine/Core/Container/Array.h"
+#include "SimpleEngine/Graphics/Scene/SceneDrawData.h"
+#include "SimpleEngine/Graphics/View/RenderView.h"
+
+
+namespace se::graphics
+{
+/**
+ * 한 프레임의 렌더링에 필요한 모든 데이터를 묶는 최상위 구조체
+ * @note Application 레이어에서 생성되어, RenderSubsystem에 전달됩니다.
+ */
+struct FramePacket
+{
+    Array<RenderView> render_views;
+    SceneDrawData scene_draw_data;
+    uint64 frame_number = 0;
+};
+} // namespace se::graphics

--- a/EngineCore/Include/SimpleEngine/Graphics/View/RenderView.h
+++ b/EngineCore/Include/SimpleEngine/Graphics/View/RenderView.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "SimpleEngine/Core/HAL/PlatformTypes.h"
+#include "SimpleEngine/Core/Math/Math.h"
+#include "SimpleEngine/Core/Types/StringName.h"
+
+
+namespace se::graphics
+{
+/**
+ * 단일 뷰포트의 렌더링에 필요한 카메라/타겟 정보를 담는 구조체
+ */
+struct RenderView
+{
+    Matrix4x4 view_matrix = Matrix4x4::Identity();
+    Matrix4x4 projection_matrix = Matrix4x4::Identity();
+
+    StringName color_target_name;
+    StringName depth_target_name;
+
+    uint32 width = 0;
+    uint32 height = 0;
+};
+} // namespace se::graphics

--- a/EngineCore/Source/Graphics/RenderGraph/FrameResourcePool.cpp
+++ b/EngineCore/Source/Graphics/RenderGraph/FrameResourcePool.cpp
@@ -66,20 +66,19 @@ void FrameResourcePool::ReleaseBuffer(const SDL_GPUBufferCreateInfo& info, SDL_G
 
 void FrameResourcePool::IncrementIdleCounters()
 {
-    for (auto& entry : texture_pool | std::views::values)
+    auto increment_pool_counters = []<typename K, typename T>(HashMap<K, PoolEntry<T>>& pool)
     {
-        for (auto& pooled : entry.available_resources)
+        for (auto& entry : pool | std::views::values)
         {
-            ++pooled.idle_frames;
+            for (auto& pooled : entry.available_resources)
+            {
+                ++pooled.idle_frames;
+            }
         }
-    }
-    for (auto& entry : buffer_pool | std::views::values)
-    {
-        for (auto& pooled : entry.available_resources)
-        {
-            ++pooled.idle_frames;
-        }
-    }
+    };
+
+    increment_pool_counters(texture_pool);
+    increment_pool_counters(buffer_pool);
 }
 
 void FrameResourcePool::Trim(uint32 max_idle_frames)

--- a/EngineCore/Source/Graphics/RenderGraph/FrameResourcePool.cpp
+++ b/EngineCore/Source/Graphics/RenderGraph/FrameResourcePool.cpp
@@ -15,9 +15,9 @@ FrameResourcePool::~FrameResourcePool()
 {
     for (const PoolEntry<SDL_GPUTexture>& entry : texture_pool | std::views::values)
     {
-        for (SDL_GPUTexture* texture : entry.available_resources)
+        for (const auto& pooled : entry.available_resources)
         {
-            SDL_ReleaseGPUTexture(render_device->GetRawDevice(), texture);
+            SDL_ReleaseGPUTexture(render_device->GetRawDevice(), pooled.resource);
         }
         for (SDL_GPUTexture* texture : entry.used_resources)
         {
@@ -27,9 +27,9 @@ FrameResourcePool::~FrameResourcePool()
 
     for (const PoolEntry<SDL_GPUBuffer>& entry : buffer_pool | std::views::values)
     {
-        for (SDL_GPUBuffer* buffer : entry.available_resources)
+        for (const auto& pooled : entry.available_resources)
         {
-            SDL_ReleaseGPUBuffer(render_device->GetRawDevice(), buffer);
+            SDL_ReleaseGPUBuffer(render_device->GetRawDevice(), pooled.resource);
         }
         for (SDL_GPUBuffer* buffer : entry.used_resources)
         {
@@ -62,5 +62,44 @@ SDL_GPUBuffer* FrameResourcePool::AcquireBuffer(const SDL_GPUBufferCreateInfo& i
 void FrameResourcePool::ReleaseBuffer(const SDL_GPUBufferCreateInfo& info, SDL_GPUBuffer* buffer)
 {
     ReleaseResourceInternal(buffer_pool[info], buffer);
+}
+
+void FrameResourcePool::IncrementIdleCounters()
+{
+    for (auto& entry : texture_pool | std::views::values)
+    {
+        for (auto& pooled : entry.available_resources)
+        {
+            ++pooled.idle_frames;
+        }
+    }
+    for (auto& entry : buffer_pool | std::views::values)
+    {
+        for (auto& pooled : entry.available_resources)
+        {
+            ++pooled.idle_frames;
+        }
+    }
+}
+
+void FrameResourcePool::Trim(uint32 max_idle_frames)
+{
+    SDL_GPUDevice* raw_device = render_device->GetRawDevice();
+
+    for (auto& entry : texture_pool | std::views::values)
+    {
+        TrimEntry(entry, max_idle_frames, [raw_device](SDL_GPUTexture* texture)
+        {
+            SDL_ReleaseGPUTexture(raw_device, texture);
+        });
+    }
+
+    for (auto& entry : buffer_pool | std::views::values)
+    {
+        TrimEntry(entry, max_idle_frames, [raw_device](SDL_GPUBuffer* buffer)
+        {
+            SDL_ReleaseGPUBuffer(raw_device, buffer);
+        });
+    }
 }
 }  // namespace se::graphics

--- a/EngineCore/Source/Graphics/RenderGraph/RenderGraph.cpp
+++ b/EngineCore/Source/Graphics/RenderGraph/RenderGraph.cpp
@@ -240,40 +240,85 @@ void RenderGraph::Compile()
         return;
     }
 
-    // TODO: 리소스 생명주기 계산
+    // 4. 리소스 생명주기 분석
+    // compiled_passes 순서를 기준으로 각 리소스의 첫 사용/마지막 사용 패스 인덱스를 계산합니다.
+    for (const auto [pass_index, pass_node] : compiled_passes | std::views::enumerate)
+    {
+        const uint32 idx = static_cast<uint32>(pass_index);
+
+        for (const auto [handle_idx] : pass_node->reads)
+        {
+            RGResourceNode& node = resource_nodes[handle_idx];
+            node.first_user_pass_index = std::min(node.first_user_pass_index, idx);
+            node.last_user_pass_index = std::max(node.last_user_pass_index, idx);
+        }
+        for (const auto [handle_idx] : pass_node->writes)
+        {
+            RGResourceNode& node = resource_nodes[handle_idx];
+            node.first_user_pass_index = std::min(node.first_user_pass_index, idx);
+            node.last_user_pass_index = std::max(node.last_user_pass_index, idx);
+        }
+    }
+
+    // 5. 리소스 할당/해제 스케줄 구축
+    resources_to_realize.Clear();
+    resources_to_unrealize.Clear();
+    for (usize i = 0; i < compiled_passes.Len(); ++i)
+    {
+        resources_to_realize.Emplace();
+        resources_to_unrealize.Emplace();
+    }
+
+    for (const auto [idx, node] : resource_nodes | std::views::enumerate)
+    {
+        // first <= last인 리소스만 스케줄에 포함 (미사용 리소스는 first=max, last=0이므로 제외)
+        if (node.first_user_pass_index <= node.last_user_pass_index)
+        {
+            resources_to_realize[node.first_user_pass_index].Push(static_cast<usize>(idx));
+            resources_to_unrealize[node.last_user_pass_index].Push(static_cast<usize>(idx));
+        }
+    }
 }
 
 void RenderGraph::Execute(SDL_GPUCommandBuffer* cmd, PSOManager& pso_manager)
 {
     ZoneScoped;
 
-    // TODO: 컴파일 단계에서 리소스 lifecycle 체크해서 필요한 시점에만 리소스를 할당하고 재사용하게끔 수정
-
-    for (const RGPassNode* pass_node : compiled_passes)
+    for (uint32 pass_index = 0; pass_index < compiled_passes.Len(); ++pass_index)
     {
+        const RGPassNode* pass_node = compiled_passes[pass_index];
+
         ZoneScoped;
         SE_DEBUG_EXPRESSION({
             String zone_name = String::Format("RenderGraph::Execute - {}::Execute", pass_node->name);
             ZoneName(zone_name.CStr(), zone_name.ByteLen());
         })
 
-        for (const auto [write_handle_idx] : pass_node->writes)
+        // 이 패스에서 생명주기가 시작되는 리소스를 할당합니다.
+        for (const usize resource_idx : resources_to_realize[pass_index])
         {
-            resource_nodes[write_handle_idx].resource->Realize(resource_pool);
+            resource_nodes[resource_idx].resource->Realize(resource_pool);
         }
 
         RGExecutionContext context{ cmd, pso_manager, *this };
         pass_node->pass_object->Execute(context);
+
+        // 이 패스에서 생명주기가 끝나는 리소스를 해제합니다.
+        for (const usize resource_idx : resources_to_unrealize[pass_index])
+        {
+            resource_nodes[resource_idx].resource->Unrealize(resource_pool);
+        }
     }
 }
 
 void RenderGraph::Clear()
 {
-    for (const RGPassNode* pass_node : compiled_passes)
+    // Execute()에서 Unrealize되지 못한 리소스가 있을 경우를 대비
+    for (RGResourceNode& node : resource_nodes)
     {
-        for (const auto& [write_handle_idx] : pass_node->writes)
+        if (node.resource)
         {
-            resource_nodes[write_handle_idx].resource->Unrealize(resource_pool);
+            node.resource->Unrealize(resource_pool);
         }
     }
 
@@ -281,6 +326,13 @@ void RenderGraph::Clear()
     resource_nodes.Clear();
     resource_name_map.Clear();
     compiled_passes.Clear();
+    resources_to_realize.Clear();
+    resources_to_unrealize.Clear();
+
+    // 풀 리소스 idle 카운터 증가 + 장기 미사용 리소스 정리
+    static constexpr uint32 MAX_IDLE_FRAMES = 3;
+    resource_pool.IncrementIdleCounters();
+    resource_pool.Trim(MAX_IDLE_FRAMES);
 }
 
 RGResourceHandle RenderGraph::ImportTexture(const StringName& name, SDL_GPUTexture* texture)

--- a/EngineCore/Source/Graphics/RenderPass/ForwardScenePass.cpp
+++ b/EngineCore/Source/Graphics/RenderPass/ForwardScenePass.cpp
@@ -1,76 +1,61 @@
 #include "SimpleEngine/Graphics/RenderPass/ForwardScenePass.h"
 
-#include "SimpleEngine/Core/Logging/Logging.h"
 #include "SimpleEngine/Core/FileSystem/VFS.h"
+#include "SimpleEngine/Core/Logging/Logging.h"
 #include "SimpleEngine/Core/Types/VPath.h"
-#include "SimpleEngine/ECS/Query.h"
-#include "SimpleEngine/ECS/World.h"
-#include "SimpleEngine/ECS/Components/Camera3dComponent.h"
-#include "SimpleEngine/ECS/Components/MaterialComponent.h"
-#include "SimpleEngine/ECS/Components/StaticMeshComponent.h"
-#include "SimpleEngine/ECS/Components/TransformComponent.h"
 #include "SimpleEngine/Graphics/MeshPrimitives.h"
-#include "SimpleEngine/Graphics/RenderSubsystem.h"
+#include "SimpleEngine/Graphics/Memory/GpuResourceManager.h"
 #include "SimpleEngine/Graphics/RenderGraph/RenderGraph.h"
-#include "SimpleEngine/Utility/SubsystemUtils.h"
+#include "SimpleEngine/Graphics/Scene/SceneDrawData.h"
+#include "SimpleEngine/Graphics/View/RenderView.h"
 
 #include "SDL3/SDL_gpu.h"
-
-using namespace se::math;
-using namespace se::ecs;
 
 
 namespace se::graphics
 {
+using namespace se::math;
+
 SE_BEGIN_REFLECT(ForwardScenePass, meta::Internal)
 SE_END_REFLECT(ForwardScenePass)
 
 ForwardScenePass::ForwardScenePass(
-    World& in_world_ref,
-    const Matrix4x4& in_vp_matrix,
-    const StringName& in_color_target_name,
-    const StringName& in_depth_target_name,
-    uint32 in_width, uint32 in_height
+    const SceneDrawData& in_draw_data,
+    const RenderView& in_render_view,
+    const GpuResourceManager& in_gpu_manager
 )
-    : vp_matrix(in_vp_matrix)
-    , world_ref(in_world_ref)
-    , color_target_name(in_color_target_name)
-    , depth_target_name(in_depth_target_name)
-    , width(in_width)
-    , height(in_height)
+    : draw_data(in_draw_data)
+    , render_view(in_render_view)
+    , gpu_manager(in_gpu_manager)
 {
 }
 
 void ForwardScenePass::Setup(RenderGraphBuilder& builder)
 {
-    // 1. 월드에서 렌더링에 필요한 Entity목록을 가져옴
-    // 엔티티의 렌더 정보 생성
-    draw_infos.Clear();
+    // VP 행렬 계산 (per-view)
+    const Matrix4x4 vp_matrix = render_view.view_matrix * render_view.projection_matrix;
 
-    Query entity_query = world_ref.QueryEntities<const TransformComponent&, const StaticMeshComponent&, const MaterialHandleComponent&>();
-    for (const auto [transform, mesh, material] : entity_query)
+    // DrawCommand -> EntityDrawInfo 변환 (MVP 사전 계산)
+    draw_infos.Clear();
+    for (const DrawCommand& cmd : draw_data.opaque_commands)
     {
         draw_infos.Push({
-            .mvp_matrix = TransformUtility::MakeModelMatrix(
-                transform.position,
-                transform.rotation,
-                transform.scale
-            ) * vp_matrix,
-            .mesh_id = mesh.mesh_id,
-            .material_id = material.material_id,
+            .mvp_matrix = cmd.model_matrix * vp_matrix,
+            .mesh_id = cmd.mesh_id,
+            .material_id = cmd.material_id,
         });
     }
 
-    // 2. Pass에서 사용할 Texture를 생성
-    color_target_handle = builder.GetResourceHandleByName(color_target_name);
+    // 렌더 타겟 설정
+    color_target_handle = builder.GetResourceHandleByName(render_view.color_target_name);
     builder.Write(color_target_handle);
 
-    depth_target_handle = builder.CreateTexture(depth_target_name, {
+    depth_target_handle = builder.CreateTexture(render_view.depth_target_name, {
         .type = SDL_GPU_TEXTURETYPE_2D,
         .format = SDL_GPU_TEXTUREFORMAT_D24_UNORM_S8_UINT,  // 24비트 깊이버퍼 + 8비트 스텐실버퍼
         .usage = SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET, // 이 텍스처는 깊이/스텐실 버퍼로만 사용될 것임을 의미
-        .width = width,
-        .height = height,
+        .width = render_view.width,
+        .height = render_view.height,
         .layer_count_or_depth = 1,
         .num_levels = 1,
         .sample_count = SDL_GPU_SAMPLECOUNT_1,
@@ -80,15 +65,15 @@ void ForwardScenePass::Setup(RenderGraphBuilder& builder)
 
 void ForwardScenePass::Execute(RGExecutionContext& context)
 {
-    const RenderSubsystem& render_subsystem = GetSubsystemChecked<RenderSubsystem>();
-    const GpuResourceManager& gpu_manager = render_subsystem.GetResourceManager();
-
     SDL_GPUCommandBuffer* cmd = context.GetCommandBuffer();
 
     SDL_GPUTexture* color_target = context.GetActualTexture(color_target_handle);
     SDL_GPUTexture* depth_target = context.GetActualTexture(depth_target_handle);
 
-    if (!(color_target && depth_target)) { return; }
+    if (!(color_target && depth_target))
+    {
+        return;
+    }
 
     const SDL_GPUColorTargetInfo color_target_info[] = {
         {
@@ -100,7 +85,7 @@ void ForwardScenePass::Execute(RGExecutionContext& context)
             .store_op = SDL_GPU_STOREOP_STORE,
         }
     };
-    const SDL_GPUDepthStencilTargetInfo depth_stencil_target_info{
+    const SDL_GPUDepthStencilTargetInfo depth_stencil_target_info = {
         .texture = depth_target,
         .clear_depth = 1.0f,
         .load_op = SDL_GPU_LOADOP_CLEAR,
@@ -110,7 +95,7 @@ void ForwardScenePass::Execute(RGExecutionContext& context)
         .clear_stencil = 0,
     };
 
-    SDL_GPUGraphicsPipeline* pipeline;
+    SDL_GPUGraphicsPipeline* pipeline = [&context]
     {
         // TODO: 여기서 셰이더 컴파일하면 프레임 드랍이 생길 수 있음, 개선필요
         static const Path VSPath = VFS::ToPath(VPath("CoreShader://Default.vert.hlsl"));
@@ -123,7 +108,7 @@ void ForwardScenePass::Execute(RGExecutionContext& context)
         SDL_GPUVertexBufferDescription vertex_buffer_desc[] = {
             {
                 .slot = 0,                                    // 이 버퍼가 바인딩될 슬롯 번호 (셰이더에서 참조)
-                .pitch = sizeof(Vertex),                 // 정점 하나가 차지하는 총 메모리 크기 (stride)
+                .pitch = sizeof(Vertex),                      // 정점 하나가 차지하는 총 메모리 크기 (stride)
                 .input_rate = SDL_GPU_VERTEXINPUTRATE_VERTEX, // 버퍼 데이터가 정점마다 바뀌는지(VERTEX) 또는 인스턴스마다 바뀌는지(INSTANCE)
             },
         };
@@ -137,7 +122,7 @@ void ForwardScenePass::Execute(RGExecutionContext& context)
                 .location = 0,                                // 셰이더 내에서의 위치(location). HLSL의 :POSITION에 해당
                 .buffer_slot = 0,                             // 이 속성이 어느 버퍼(vertex_buffer_desc)에 속하는지
                 .format = SDL_GPU_VERTEXELEMENTFORMAT_FLOAT3, // 데이터 타입 (float 3개)
-                .offset = offsetof(Vertex, position)     // Vertex 구조체 내에서 이 속성이 시작되는 위치(offset)
+                .offset = offsetof(Vertex, position)          // Vertex 구조체 내에서 이 속성이 시작되는 위치(offset)
             },
             {
                 .location = 1,
@@ -160,7 +145,7 @@ void ForwardScenePass::Execute(RGExecutionContext& context)
         };
 
         /**
-         * 컬러 렌더 타겟에 대한 Description
+         * 렌더 타겟에 대한 Description
          * 파이프라인이 어떤 포맷의 텍스처에 렌더링될 것인지, 그리고 어떻게 색상을 혼합(블렌딩)할지 정의
          */
         SDL_GPUColorTargetDescription color_target_desc[] = {
@@ -189,7 +174,7 @@ void ForwardScenePass::Execute(RGExecutionContext& context)
             }
         };
 
-        pipeline = context.GetOrCreateGraphicsPipeline({
+        return context.GetOrCreateGraphicsPipeline({
             // 사용할 셰이더 지정
             .vertex_shader_request = { .source_path = VSPath, },
             .fragment_shader_request = { .source_path = FSPath, },
@@ -231,25 +216,25 @@ void ForwardScenePass::Execute(RGExecutionContext& context)
                 .has_depth_stencil_target = true,
             },
         });
-    }
+    }();
 
     SDL_GPURenderPass* pass = SDL_BeginGPURenderPass(cmd, color_target_info, std::size(color_target_info), &depth_stencil_target_info);
     {
-        // Pipeline 설정
+        // PSO 설정
         SDL_BindGPUGraphicsPipeline(pass, pipeline);
 
         // Viewport/Scissor 설정
         const SDL_GPUViewport viewport = {
             .x = 0.0f, .y = 0.0f,
-            .w = static_cast<float>(width),
-            .h = static_cast<float>(height),
+            .w = static_cast<float>(render_view.width),
+            .h = static_cast<float>(render_view.height),
             .min_depth = 0.0f, .max_depth = 1.0f,
         };
 
         const SDL_Rect scissor = {
             .x = 0, .y = 0,
-            .w = static_cast<int32>(width),
-            .h = static_cast<int32>(height),
+            .w = static_cast<int32>(render_view.width),
+            .h = static_cast<int32>(render_view.height),
         };
 
         SDL_SetGPUViewport(pass, &viewport);

--- a/EngineCore/Source/Graphics/Scene/CollectDrawData.cpp
+++ b/EngineCore/Source/Graphics/Scene/CollectDrawData.cpp
@@ -1,0 +1,55 @@
+#include "SimpleEngine/Graphics/Scene/CollectDrawData.h"
+
+#include "SimpleEngine/Core/Math/TransformUtility.h"
+#include "SimpleEngine/ECS/Query.h"
+#include "SimpleEngine/ECS/World.h"
+#include "SimpleEngine/ECS/Components/MaterialComponent.h"
+#include "SimpleEngine/ECS/Components/StaticMeshComponent.h"
+#include "SimpleEngine/ECS/Components/TransformComponent.h"
+
+#include <algorithm>
+
+
+namespace se::graphics
+{
+using namespace se::math;
+
+namespace
+{
+/** DrawCommand의 정렬 키를 계산합니다. */
+[[nodiscard]] uint64 ComputeSortKey(const asset::AssetId& mesh_id, const asset::AssetId& material_id)
+{
+    const uint64 mesh_hash = std::hash<asset::AssetId>{}(mesh_id);
+    const uint64 material_hash = std::hash<asset::AssetId>{}(material_id);
+
+    // 상위 32비트: material (PSO/셰이더 변경 최소화)
+    // 하위 32비트: mesh     (VB/IB 바인딩 변경 최소화)
+    return (material_hash << 32) | (mesh_hash & 0xFFFF'FFFF);
+}
+} // namespace
+
+
+SceneDrawData CollectDrawData(ecs::World& world)
+{
+    SceneDrawData result;
+
+    auto query = world.QueryEntities<const TransformComponent&, const StaticMeshComponent&, const MaterialHandleComponent&>();
+    for (const auto [transform, mesh, material] : query)
+    {
+        result.opaque_commands.Push({
+            .model_matrix = TransformUtility::MakeModelMatrix(
+                transform.position,
+                transform.rotation,
+                transform.scale
+            ),
+            .mesh_id = mesh.mesh_id,
+            .material_id = material.material_id,
+            .sort_key = ComputeSortKey(mesh.mesh_id, material.material_id),
+        });
+    }
+
+    std::ranges::sort(result.opaque_commands, {}, &DrawCommand::sort_key);
+
+    return result;
+}
+} // namespace se::graphics


### PR DESCRIPTION
> 아래 PR 메시지는 Claude Sonnet 4.6을 사용하여 작성되었습니다.

## Summary

- **RenderGraph v2**: Lifetime Analysis로 리소스 수명 추적, Lazy Alloc + Early Reclaim으로 피크 GPU 메모리 감소
- **FrameResourcePool Trim**: idle_frames 기반 미사용 리소스 자동 해제 (3프레임 기준)
- **SceneDrawData 디커플링**: `ForwardScenePass`에서 `World&` / `GetSubsystemChecked` 완전 제거, 불변 데이터 스냅샷으로 대체
- **CollectDrawData**: ECS↔렌더링 경계의 단일 브릿지 함수
- **sort_key 정렬**: material 1차(PSO 변경 최소화), mesh 2차(VB/IB 변경 최소화)

## Test plan

- [x] 전체 빌드 성공 (Debug)
- [x] 845개 단위 테스트 전부 통과
- [x] `ForwardScenePass` 내 `World` / `ECS` / `GetSubsystem` 참조 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)