### PR TITLE
[Refactor] ECS World 구조 및 네이밍 개선

### DIFF
--- a/Editor/Include/SimpleEditor/Core/EditorActionSubsystem.h
+++ b/Editor/Include/SimpleEditor/Core/EditorActionSubsystem.h
@@ -10,7 +10,7 @@
 namespace se
 {
 class InputSubsystem;
-class WorldSubsystem;
+class EntitySubsystem;
 class World;
 }
 
@@ -50,7 +50,7 @@ private:
 
 private:
     InputSubsystem* input_subsystem = nullptr;
-    WorldSubsystem* world_subsystem = nullptr;
+    EntitySubsystem* world_subsystem = nullptr;
     EditorSubsystem* editor_subsystem = nullptr;
     EditorUISubsystem* ui_subsystem = nullptr;
     EditorViewportSubsystem* viewport_subsystem = nullptr;

--- a/Editor/Include/SimpleEditor/Core/EditorActionSubsystem.h
+++ b/Editor/Include/SimpleEditor/Core/EditorActionSubsystem.h
@@ -46,7 +46,7 @@ public:
     void DeleteSelectedEntities();
 
 private:
-    static void DeleteEntityRecursive(World* world, EditorSelection& selection, Entity entity);
+    static void DeleteEntityRecursive(World& world, EditorSelection& selection, Entity entity);
 
 private:
     InputSubsystem* input_subsystem = nullptr;

--- a/Editor/Include/SimpleEditor/Core/EditorActionSubsystem.h
+++ b/Editor/Include/SimpleEditor/Core/EditorActionSubsystem.h
@@ -50,7 +50,7 @@ private:
 
 private:
     InputSubsystem* input_subsystem = nullptr;
-    EntitySubsystem* world_subsystem = nullptr;
+    EntitySubsystem* entity_subsystem = nullptr;
     EditorSubsystem* editor_subsystem = nullptr;
     EditorUISubsystem* ui_subsystem = nullptr;
     EditorViewportSubsystem* viewport_subsystem = nullptr;

--- a/Editor/Source/App/EditorApplication.cpp
+++ b/Editor/Source/App/EditorApplication.cpp
@@ -138,12 +138,13 @@ void EditorApplication::Render()
         return;
     }
 
-    const auto [world_subsystem, ui_subsystem, viewport_subsystem] =
+    const auto [entity_subsystem, ui_subsystem, viewport_subsystem] =
         se::GetSubsystemsChecked<const EntitySubsystem, const EditorUISubsystem, const EditorViewportSubsystem>();
 
     // FramePacket 조립 (SceneDrawData 수집)
     se::graphics::FramePacket frame_packet;
-    frame_packet.scene_draw_data = se::graphics::CollectDrawData(*world_subsystem.GetWorld());
+    // TODO: const Query 사용할 수 있게 만든 뒤, const_cast 제거 및 CollectDrawData를 const World& 로 변경할 것
+    frame_packet.scene_draw_data = se::graphics::CollectDrawData(const_cast<World&>(entity_subsystem.GetMainWorld().GetWorld()));
 
     // TODO: GPU 리소스 해제 로직
     // - 현재 Bump Pointer 할당이라 개별 VRAM 회수 불가 (UnloadMesh는 매핑만 제거)

--- a/Editor/Source/App/EditorApplication.cpp
+++ b/Editor/Source/App/EditorApplication.cpp
@@ -14,7 +14,7 @@
 #include "SimpleEngine/Core/Config/ConfigFile.h"
 #include "SimpleEngine/Core/HAL/WindowSubsystem.h"
 #include "SimpleEngine/Core/Types/VPath.h"
-#include "SimpleEngine/ECS/WorldSubsystem.h"
+#include "SimpleEngine/ECS/EntitySubsystem.h"
 #include "SimpleEngine/Graphics/MeshPrimitives.h"
 #include "SimpleEngine/Graphics/RenderSubsystem.h"
 #include "SimpleEngine/Debug/DebugDrawSubsystem.h"
@@ -139,7 +139,7 @@ void EditorApplication::Render()
     }
 
     const auto [world_subsystem, ui_subsystem, viewport_subsystem] =
-        se::GetSubsystemsChecked<const WorldSubsystem, const EditorUISubsystem, const EditorViewportSubsystem>();
+        se::GetSubsystemsChecked<const EntitySubsystem, const EditorUISubsystem, const EditorViewportSubsystem>();
 
     // FramePacket 조립 (SceneDrawData 수집)
     se::graphics::FramePacket frame_packet;

--- a/Editor/Source/Core/EditorActionSubsystem.cpp
+++ b/Editor/Source/Core/EditorActionSubsystem.cpp
@@ -98,31 +98,31 @@ void EditorActionSubsystem::Update([[maybe_unused]] float delta_time)
 
 void EditorActionSubsystem::DeleteEntity(Entity entity)
 {
-    World* world = &entity_subsystem->GetMainWorld().GetWorld();
+    World& world = entity_subsystem->GetMainWorld().GetWorld();
     EditorSelection& selection = editor_subsystem->GetSelection();
     DeleteEntityRecursive(world, selection, entity);
 }
 
 void EditorActionSubsystem::DeleteSelectedEntities()
 {
-    World* world = &entity_subsystem->GetMainWorld().GetWorld();
+    World& world = entity_subsystem->GetMainWorld().GetWorld();
     EditorSelection& selection = editor_subsystem->GetSelection();
 
     // 삭제 도중 selection이 변경되므로 먼저 복사
     const Array<Entity> to_delete = Array<Entity>::FromRange(selection.GetSelectedEntities());
     for (const Entity& entity : to_delete)
     {
-        if (world->IsEntityAlive(entity))
+        if (world.IsEntityAlive(entity))
         {
             DeleteEntityRecursive(world, selection, entity);
         }
     }
 }
 
-void EditorActionSubsystem::DeleteEntityRecursive(World* world, EditorSelection& selection, Entity entity)
+void EditorActionSubsystem::DeleteEntityRecursive(World& world, EditorSelection& selection, Entity entity)
 {
     // 자식들을 먼저 재귀적으로 삭제
-    if (const Optional children_opt = world->TryGetComponent<ChildrenComponent>(entity))
+    if (const Optional children_opt = world.TryGetComponent<ChildrenComponent>(entity))
     {
         const Array<Entity> children_copy = children_opt->children;
         for (const Entity& child : children_copy)
@@ -132,15 +132,15 @@ void EditorActionSubsystem::DeleteEntityRecursive(World* world, EditorSelection&
     }
 
     // 부모의 ChildrenComponent에서 자신을 제거
-    if (const Optional parent_opt = world->TryGetComponent<ParentComponent>(entity))
+    if (const Optional parent_opt = world.TryGetComponent<ParentComponent>(entity))
     {
-        if (const Optional parent_children_opt = world->TryGetComponent<ChildrenComponent>(parent_opt->parent))
+        if (const Optional parent_children_opt = world.TryGetComponent<ChildrenComponent>(parent_opt->parent))
         {
             parent_children_opt->children.Remove(entity);
         }
     }
 
     selection.DeselectEntity(entity);
-    world->DestroyEntity(entity);
+    world.DestroyEntity(entity);
 }
 } // namespace se::editor

--- a/Editor/Source/Core/EditorActionSubsystem.cpp
+++ b/Editor/Source/Core/EditorActionSubsystem.cpp
@@ -10,7 +10,7 @@
 #include "SimpleEngine/ECS/Components/ChildrenComponent.h"
 #include "SimpleEngine/ECS/Components/ParentComponent.h"
 #include "SimpleEngine/ECS/World.h"
-#include "SimpleEngine/ECS/WorldSubsystem.h"
+#include "SimpleEngine/ECS/EntitySubsystem.h"
 #include "SimpleEngine/Utility/SubsystemUtils.h"
 
 #include "imgui.h"
@@ -21,7 +21,7 @@ namespace se::editor
 SE_REGISTER_SUBSYSTEM(EditorActionSubsystem)
     .DependsOn<
         InputSubsystem,
-        WorldSubsystem,
+        EntitySubsystem,
         EditorSubsystem,
         EditorUISubsystem,
         EditorViewportSubsystem
@@ -34,7 +34,7 @@ SE_END_REFLECT(EditorActionSubsystem)
 bool EditorActionSubsystem::Initialize()
 {
     input_subsystem = &GetSubsystemChecked<InputSubsystem>();
-    world_subsystem = &GetSubsystemChecked<WorldSubsystem>();
+    world_subsystem = &GetSubsystemChecked<EntitySubsystem>();
     editor_subsystem = &GetSubsystemChecked<EditorSubsystem>();
     ui_subsystem = &GetSubsystemChecked<EditorUISubsystem>();
     viewport_subsystem = &GetSubsystemChecked<EditorViewportSubsystem>();

--- a/Editor/Source/Core/EditorActionSubsystem.cpp
+++ b/Editor/Source/Core/EditorActionSubsystem.cpp
@@ -34,7 +34,7 @@ SE_END_REFLECT(EditorActionSubsystem)
 bool EditorActionSubsystem::Initialize()
 {
     input_subsystem = &GetSubsystemChecked<InputSubsystem>();
-    world_subsystem = &GetSubsystemChecked<EntitySubsystem>();
+    entity_subsystem = &GetSubsystemChecked<EntitySubsystem>();
     editor_subsystem = &GetSubsystemChecked<EditorSubsystem>();
     ui_subsystem = &GetSubsystemChecked<EditorUISubsystem>();
     viewport_subsystem = &GetSubsystemChecked<EditorViewportSubsystem>();
@@ -44,7 +44,7 @@ bool EditorActionSubsystem::Initialize()
 void EditorActionSubsystem::Release()
 {
     input_subsystem = nullptr;
-    world_subsystem = nullptr;
+    entity_subsystem = nullptr;
     editor_subsystem = nullptr;
     ui_subsystem = nullptr;
     viewport_subsystem = nullptr;
@@ -98,14 +98,14 @@ void EditorActionSubsystem::Update([[maybe_unused]] float delta_time)
 
 void EditorActionSubsystem::DeleteEntity(Entity entity)
 {
-    World* world = world_subsystem->GetWorld();
+    World* world = &entity_subsystem->GetMainWorld().GetWorld();
     EditorSelection& selection = editor_subsystem->GetSelection();
     DeleteEntityRecursive(world, selection, entity);
 }
 
 void EditorActionSubsystem::DeleteSelectedEntities()
 {
-    World* world = world_subsystem->GetWorld();
+    World* world = &entity_subsystem->GetMainWorld().GetWorld();
     EditorSelection& selection = editor_subsystem->GetSelection();
 
     // 삭제 도중 selection이 변경되므로 먼저 복사

--- a/Editor/Source/UI/EditorUISubsystem.cpp
+++ b/Editor/Source/UI/EditorUISubsystem.cpp
@@ -22,7 +22,7 @@
 #include "SimpleEngine/Core/Subsystem/SubsystemRegistration.h"
 #include "SimpleEngine/Core/FileSystem/VFS.h"
 #include "SimpleEngine/Core/Types/VPath.h"
-#include "SimpleEngine/ECS/WorldSubsystem.h"
+#include "SimpleEngine/ECS/EntitySubsystem.h"
 #include "SimpleEngine/Utility/SubsystemUtils.h"
 
 #include "imgui.h"
@@ -224,7 +224,7 @@ void EditorUISubsystem::DrawMainMenu()
         {
             if (ImGui::MenuItem("Spawn Entity"))
             {
-                if (const WorldSubsystem* world_subsystem = GetSubsystem<WorldSubsystem>())
+                if (const EntitySubsystem* world_subsystem = GetSubsystem<EntitySubsystem>())
                 {
                     World* world = world_subsystem->GetWorld();
                     world->SpawnEntity();

--- a/Editor/Source/UI/EditorUISubsystem.cpp
+++ b/Editor/Source/UI/EditorUISubsystem.cpp
@@ -224,10 +224,9 @@ void EditorUISubsystem::DrawMainMenu()
         {
             if (ImGui::MenuItem("Spawn Entity"))
             {
-                if (const EntitySubsystem* world_subsystem = GetSubsystem<EntitySubsystem>())
+                if (EntitySubsystem* entity_subsystem = GetSubsystem<EntitySubsystem>())
                 {
-                    World* world = world_subsystem->GetWorld();
-                    world->SpawnEntity();
+                    entity_subsystem->GetMainWorld().GetWorld().SpawnEntity();
                 }
             }
             ImGui::EndMenu();

--- a/Editor/Source/UI/Panels/AssetsBrowserPanel.cpp
+++ b/Editor/Source/UI/Panels/AssetsBrowserPanel.cpp
@@ -413,7 +413,7 @@ void AssetsBrowserPanel::SpawnMeshEntitiesFromFile(const Path& file_path)
         return;
     }
 
-    World* world = &entity_subsystem->GetMainWorld().GetWorld();
+    World& world = entity_subsystem->GetMainWorld().GetWorld();
 
     // 파일에 등록된 에셋 중 StaticMesh 타입만 수집
     const asset::AssetRegistry& registry = asset_subsystem->GetRegistry();
@@ -436,7 +436,7 @@ void AssetsBrowserPanel::SpawnMeshEntitiesFromFile(const Path& file_path)
 
     if (mesh_ids.Len() == 1)
     {
-        world->SpawnEntity(
+        world.SpawnEntity(
             TransformComponent{},
             StaticMeshComponent{ .mesh_id = mesh_ids[0] },
             MaterialHandleComponent{}
@@ -445,13 +445,13 @@ void AssetsBrowserPanel::SpawnMeshEntitiesFromFile(const Path& file_path)
     else
     {
         // root entity (Transform + ChildrenComponent)
-        const Entity root = world->SpawnEntity(TransformComponent{});
+        const Entity root = world.SpawnEntity(TransformComponent{});
 
         // N child entities
         ChildrenComponent children_comp;
         for (const asset::AssetId& mesh_id : mesh_ids)
         {
-            const Entity child = world->SpawnEntity(
+            const Entity child = world.SpawnEntity(
                 TransformComponent{},
                 StaticMeshComponent{ .mesh_id = mesh_id },
                 MaterialHandleComponent{},
@@ -459,7 +459,7 @@ void AssetsBrowserPanel::SpawnMeshEntitiesFromFile(const Path& file_path)
             );
             children_comp.children.Push(child);
         }
-        world->AddComponent(root, std::move(children_comp));
+        world.AddComponent(root, std::move(children_comp));
     }
 
     ConsoleLog(ELogLevel::Info, "Spawned {} mesh entities from: {}", mesh_ids.Len(), *vpath);

--- a/Editor/Source/UI/Panels/AssetsBrowserPanel.cpp
+++ b/Editor/Source/UI/Panels/AssetsBrowserPanel.cpp
@@ -407,17 +407,13 @@ void AssetsBrowserPanel::SpawnMeshEntitiesFromFile(const Path& file_path)
         return;
     }
 
-    const auto [asset_subsystem, world_subsystem] = GetSubsystems<const asset::AssetSubsystem, EntitySubsystem>();
-    if (!asset_subsystem || !world_subsystem)
+    const auto [asset_subsystem, entity_subsystem] = GetSubsystems<const asset::AssetSubsystem, EntitySubsystem>();
+    if (!asset_subsystem || !entity_subsystem)
     {
         return;
     }
 
-    World* world = world_subsystem->GetWorld();
-    if (!world)
-    {
-        return;
-    }
+    World* world = &entity_subsystem->GetMainWorld().GetWorld();
 
     // 파일에 등록된 에셋 중 StaticMesh 타입만 수집
     const asset::AssetRegistry& registry = asset_subsystem->GetRegistry();

--- a/Editor/Source/UI/Panels/AssetsBrowserPanel.cpp
+++ b/Editor/Source/UI/Panels/AssetsBrowserPanel.cpp
@@ -16,7 +16,7 @@
 #include "SimpleEngine/Core/Logging/Logging.h"
 #include "SimpleEngine/Core/Reflection/TypeRegistry.h"
 #include "SimpleEngine/Core/Types/Path.h"
-#include "SimpleEngine/ECS/WorldSubsystem.h"
+#include "SimpleEngine/ECS/EntitySubsystem.h"
 #include "SimpleEngine/ECS/Components/ChildrenComponent.h"
 #include "SimpleEngine/ECS/Components/MaterialComponent.h"
 #include "SimpleEngine/ECS/Components/ParentComponent.h"
@@ -407,7 +407,7 @@ void AssetsBrowserPanel::SpawnMeshEntitiesFromFile(const Path& file_path)
         return;
     }
 
-    const auto [asset_subsystem, world_subsystem] = GetSubsystems<const asset::AssetSubsystem, WorldSubsystem>();
+    const auto [asset_subsystem, world_subsystem] = GetSubsystems<const asset::AssetSubsystem, EntitySubsystem>();
     if (!asset_subsystem || !world_subsystem)
     {
         return;

--- a/Editor/Source/UI/Panels/DetailPanel.cpp
+++ b/Editor/Source/UI/Panels/DetailPanel.cpp
@@ -29,8 +29,8 @@ const char* DetailPanel::GetName() const
 
 void DetailPanel::DrawContent()
 {
-    const auto [world_subsystem, editor_subsystem] = GetSubsystems<const EntitySubsystem, EditorSubsystem>();
-    if (!(world_subsystem && editor_subsystem))
+    const auto [entity_subsystem, editor_subsystem] = GetSubsystems<EntitySubsystem, EditorSubsystem>();
+    if (!(entity_subsystem && editor_subsystem))
     {
         return;
     }
@@ -51,7 +51,7 @@ void DetailPanel::DrawContent()
     }
 
     const Entity entity = selection.GetPrimarySelectedEntity().Value();
-    World* world = world_subsystem->GetWorld();
+    World* world = &entity_subsystem->GetMainWorld().GetWorld();
 
     // 선택된 Entity가 바뀌면 Rotation 캐시 초기화
     if (last_selected_entity != entity)

--- a/Editor/Source/UI/Panels/DetailPanel.cpp
+++ b/Editor/Source/UI/Panels/DetailPanel.cpp
@@ -9,7 +9,7 @@
 #include "SimpleEngine/ECS/ComponentRegistry.h"
 #include "SimpleEngine/ECS/Components/TransformComponent.h"
 #include "SimpleEngine/ECS/Query.h"
-#include "SimpleEngine/ECS/WorldSubsystem.h"
+#include "SimpleEngine/ECS/EntitySubsystem.h"
 #include "SimpleEngine/Utility/StringUtils.h"
 #include "SimpleEngine/Utility/SubsystemUtils.h"
 
@@ -29,7 +29,7 @@ const char* DetailPanel::GetName() const
 
 void DetailPanel::DrawContent()
 {
-    const auto [world_subsystem, editor_subsystem] = GetSubsystems<const WorldSubsystem, EditorSubsystem>();
+    const auto [world_subsystem, editor_subsystem] = GetSubsystems<const EntitySubsystem, EditorSubsystem>();
     if (!(world_subsystem && editor_subsystem))
     {
         return;

--- a/Editor/Source/UI/Panels/DetailPanel.cpp
+++ b/Editor/Source/UI/Panels/DetailPanel.cpp
@@ -51,7 +51,7 @@ void DetailPanel::DrawContent()
     }
 
     const Entity entity = selection.GetPrimarySelectedEntity().Value();
-    World* world = &entity_subsystem->GetMainWorld().GetWorld();
+    World& world = entity_subsystem->GetMainWorld().GetWorld();
 
     // 선택된 Entity가 바뀌면 Rotation 캐시 초기화
     if (last_selected_entity != entity)
@@ -86,12 +86,6 @@ void DetailPanel::DrawContent()
         usize found_count = 0;
         for (const TypeId& type_id : ComponentRegistry::Get().GetOperators() | std::views::keys)
         {
-            IStorage* storage = world->GetStorage(type_id);
-            if (!storage)
-            {
-                continue;
-            }
-
             const Optional type_info_opt = TypeRegistry::Get().Find(type_id);
             if (!type_info_opt)
             {
@@ -106,6 +100,7 @@ void DetailPanel::DrawContent()
                 ++found_count;
                 if (ImGui::Selectable(add_label.CStr(), false))
                 {
+                    IStorage* storage = world.GetOrCreateRawStorage(type_id);
                     if (!storage->Contains(entity))
                     {
                         storage->EmplaceDefault(entity);
@@ -128,7 +123,7 @@ void DetailPanel::DrawContent()
     TypeId component_to_remove;
     for (const auto& [component_type, component_ops] : ComponentRegistry::Get().GetOperators())
     {
-        const IStorage* storage = world->GetStorage(component_type);
+        const IStorage* storage = world.FindRawStorage(component_type);
 
         // Entity가 가지고 있지 않은 Component는 건너뜀
         if (!(storage && storage->Contains(entity)))
@@ -156,7 +151,7 @@ void DetailPanel::DrawContent()
 
         if (header_is_open)
         {
-            void* component_data = component_ops.get_component_mutable(*world, entity);
+            void* component_data = component_ops.get_component_mutable(world, entity);
             if (!component_data)
             {
                 continue;
@@ -210,7 +205,7 @@ void DetailPanel::DrawContent()
     {
         if (const Optional ops = ComponentRegistry::Get().GetOps(component_to_remove))
         {
-            ops->remove_component(*world, entity);
+            ops->remove_component(world, entity);
         }
     }
 }

--- a/Editor/Source/UI/Panels/OutlinerPanel.cpp
+++ b/Editor/Source/UI/Panels/OutlinerPanel.cpp
@@ -9,7 +9,7 @@
 #include "SimpleEngine/ECS/Components/NameComponent.h"
 #include "SimpleEngine/ECS/Components/ParentComponent.h"
 #include "SimpleEngine/ECS/Query.h"
-#include "SimpleEngine/ECS/WorldSubsystem.h"
+#include "SimpleEngine/ECS/EntitySubsystem.h"
 #include "SimpleEngine/Utility/SubsystemUtils.h"
 
 #include "imgui.h"
@@ -25,10 +25,10 @@ const char* OutlinerPanel::GetName() const
 void OutlinerPanel::DrawContent()
 {
 
-    const auto [world_subsystem, editor_subsystem] = GetSubsystems<const WorldSubsystem, EditorSubsystem>();
+    const auto [world_subsystem, editor_subsystem] = GetSubsystems<const EntitySubsystem, EditorSubsystem>();
     if (!(world_subsystem && editor_subsystem))
     {
-        ConsoleLogOnce(ELogLevel::Error, "EditorSubsystem or WorldSubsystem is not initialized!");
+        ConsoleLogOnce(ELogLevel::Error, "EditorSubsystem or EntitySubsystem is not initialized!");
         return;
     }
 

--- a/Editor/Source/UI/Panels/OutlinerPanel.cpp
+++ b/Editor/Source/UI/Panels/OutlinerPanel.cpp
@@ -32,22 +32,22 @@ void OutlinerPanel::DrawContent()
         return;
     }
 
-    World* world = &entity_subsystem->GetMainWorld().GetWorld();
+    World& world = entity_subsystem->GetMainWorld().GetWorld();
     EditorSelection& selection = editor_subsystem->GetSelection();
 
     Entity entity_to_delete;
 
 
     // ParentComponent가 없는 루트 엔티티를 최상위에서 렌더링
-    for (const auto& [entity] : world->QueryEntities<Entity, Without<ParentComponent>>())
+    for (const auto& [entity] : world.CreateQuery<Entity, Without<ParentComponent>>())
     {
         DrawEntityNode(world, selection, entity, entity_to_delete);
     }
 
     // ParentComponent가 있으나 부모가 이미 소멸된 고아 엔티티를 루트로 렌더링
-    for (const auto& [entity, parent_comp] : world->QueryEntities<Entity, ParentComponent&>())
+    for (const auto& [entity, parent_comp] : world.CreateQuery<Entity, ParentComponent&>())
     {
-        if (!world->IsEntityAlive(parent_comp.parent))
+        if (!world.IsEntityAlive(parent_comp.parent))
         {
             DrawEntityNode(world, selection, entity, entity_to_delete);
         }
@@ -68,10 +68,10 @@ void OutlinerPanel::DrawContent()
     }
 }
 
-void OutlinerPanel::DrawEntityNode(World* world, EditorSelection& selection, Entity entity, Entity& entity_to_delete)
+void OutlinerPanel::DrawEntityNode(World& world, EditorSelection& selection, Entity entity, Entity& entity_to_delete)
 {
-    const Optional name_opt = world->TryGetComponent<NameComponent>(entity);
-    const Optional children_opt = world->TryGetComponent<ChildrenComponent>(entity);
+    const Optional name_opt = world.TryGetComponent<NameComponent>(entity);
+    const Optional children_opt = world.TryGetComponent<ChildrenComponent>(entity);
     const bool has_children = children_opt && !children_opt->children.IsEmpty();
 
     const String display_name = (name_opt && !name_opt->name.IsEmpty())
@@ -98,7 +98,7 @@ void OutlinerPanel::DrawEntityNode(World* world, EditorSelection& selection, Ent
             }
             else
             {
-                world->AddComponent(entity, NameComponent{ .name = rename_name });
+                world.AddComponent(entity, NameComponent{ .name = rename_name });
             }
             renaming_entity = Entity{};
         }
@@ -167,7 +167,7 @@ void OutlinerPanel::DrawEntityNode(World* world, EditorSelection& selection, Ent
         {
             for (const Entity& child : children_opt->children)
             {
-                if (world->IsEntityAlive(child))
+                if (world.IsEntityAlive(child))
                 {
                     DrawEntityNode(world, selection, child, entity_to_delete);
                 }

--- a/Editor/Source/UI/Panels/OutlinerPanel.cpp
+++ b/Editor/Source/UI/Panels/OutlinerPanel.cpp
@@ -25,14 +25,14 @@ const char* OutlinerPanel::GetName() const
 void OutlinerPanel::DrawContent()
 {
 
-    const auto [world_subsystem, editor_subsystem] = GetSubsystems<const EntitySubsystem, EditorSubsystem>();
-    if (!(world_subsystem && editor_subsystem))
+    const auto [entity_subsystem, editor_subsystem] = GetSubsystems<EntitySubsystem, EditorSubsystem>();
+    if (!(entity_subsystem && editor_subsystem))
     {
         ConsoleLogOnce(ELogLevel::Error, "EditorSubsystem or EntitySubsystem is not initialized!");
         return;
     }
 
-    World* world = world_subsystem->GetWorld();
+    World* world = &entity_subsystem->GetMainWorld().GetWorld();
     EditorSelection& selection = editor_subsystem->GetSelection();
 
     Entity entity_to_delete;

--- a/Editor/Source/UI/Panels/OutlinerPanel.h
+++ b/Editor/Source/UI/Panels/OutlinerPanel.h
@@ -21,7 +21,7 @@ protected:
 
 private:
     /** Entity를 트리 노드로 재귀적으로 그립니다. */
-    void DrawEntityNode(World* world, EditorSelection& selection, Entity entity, Entity& entity_to_delete);
+    void DrawEntityNode(World& world, EditorSelection& selection, Entity entity, Entity& entity_to_delete);
 
     /** 이름을 바꾸려는 Entity */
     Entity renaming_entity;

--- a/EngineCore/Include/SimpleEngine/ECS/ComponentRegistry.h
+++ b/EngineCore/Include/SimpleEngine/ECS/ComponentRegistry.h
@@ -89,7 +89,7 @@ public:
         operators.Insert(type_id, ComponentOps{
             .ensure_storage = [](World& world) static -> IStorage*
             {
-                return &world.GetOrCreateStorageImpl<T>();
+                return world.GetOrCreateRawStorage<T>();
             },
             .add_component = [](World& world, Entity entity) static
             {

--- a/EngineCore/Include/SimpleEngine/ECS/EntitySubsystem.h
+++ b/EngineCore/Include/SimpleEngine/ECS/EntitySubsystem.h
@@ -9,9 +9,9 @@ namespace se
 /**
  * ECS World의 생명주기를 관리하고 엔진 업데이트 루프와 연결하는 Subsystem
  */
-class SE_CORE_API SE_ANNOTATION(=meta::Internal) WorldSubsystem : public SubsystemBase, public IUpdatable
+class SE_CORE_API SE_ANNOTATION(=meta::Internal) EntitySubsystem : public SubsystemBase, public IUpdatable
 {
-    SE_CLASS(WorldSubsystem, SubsystemBase)
+    SE_CLASS(EntitySubsystem, SubsystemBase)
 
 public:
     //~ Begin SubsystemBase

--- a/EngineCore/Include/SimpleEngine/ECS/EntitySubsystem.h
+++ b/EngineCore/Include/SimpleEngine/ECS/EntitySubsystem.h
@@ -1,17 +1,30 @@
 #pragma once
-#include "SimpleEngine/Core/Subsystem/SubsystemBase.h"
+
+#include "SimpleEngine/Core/Container/HashMap.h"
+#include "SimpleEngine/Core/Container/Optional.h"
 #include "SimpleEngine/Core/Subsystem/IUpdatable.h"
-#include "SimpleEngine/ECS/World.h"
+#include "SimpleEngine/Core/Subsystem/SubsystemBase.h"
+#include "SimpleEngine/Core/Types/StringName.h"
+#include "SimpleEngine/ECS/WorldContext.h"
 
 
 namespace se
 {
 /**
- * ECS World의 생명주기를 관리하고 엔진 업데이트 루프와 연결하는 Subsystem
+ * ECS WorldContext 컬렉션을 관리하고 엔진 업데이트 루프와 연결하는 Subsystem
  */
 class SE_CORE_API SE_ANNOTATION(=meta::Internal) EntitySubsystem : public SubsystemBase, public IUpdatable
 {
     SE_CLASS(EntitySubsystem, SubsystemBase)
+
+public:
+    EntitySubsystem() = default;
+    virtual ~EntitySubsystem() override = default;
+
+    EntitySubsystem(const EntitySubsystem&) = delete;
+    EntitySubsystem& operator=(const EntitySubsystem&) = delete;
+    EntitySubsystem(EntitySubsystem&&) = default;
+    EntitySubsystem& operator=(EntitySubsystem&&) = default;
 
 public:
     //~ Begin SubsystemBase
@@ -25,10 +38,24 @@ public:
     virtual void PostUpdate() override;
     //~ End IUpdatable
 
-    [[nodiscard]] World* GetWorld() const noexcept { return world.get(); }
+public:
+    /** World를 가져옵니다. 존재하지 않으면 새로 생성합니다. */
+    WorldContext& GetOrCreateWorld(const StringName& name);
+
+    /** 이름으로 WorldContext를 찾습니다. 존재하지 않으면 NullOpt를 반환합니다. */
+    [[nodiscard]] Optional<WorldContext&> FindWorld(const StringName& name);
+
+    /** Main World를 반환합니다. */
+    [[nodiscard]] WorldContext& GetMainWorld();
+    [[nodiscard]] const WorldContext& GetMainWorld() const;
+
+    /** World를 제거합니다. */
+    void DestroyWorld(const StringName& name);
 
 private:
-    // TODO: 나중에 다중 월드로 관리
-    std::unique_ptr<World> world;
+    static const StringName& GetMainWorldName();
+
+private:
+    HashMap<StringName, WorldContext> worlds;
 };
 } // namespace se

--- a/EngineCore/Include/SimpleEngine/ECS/Query.h
+++ b/EngineCore/Include/SimpleEngine/ECS/Query.h
@@ -27,7 +27,6 @@ class Query
     using FetchTypes = QueryDataType::FetchTypes;
 
     static constexpr bool HasBasePool = std::tuple_size_v<typename QueryDataType::PredicateTypes> > 0;
-
     using IterationSourceType = std::conditional_t<HasBasePool, IStorage*, const Array<Entity>*>;
 
 public:

--- a/EngineCore/Include/SimpleEngine/ECS/QueryConcepts.h
+++ b/EngineCore/Include/SimpleEngine/ECS/QueryConcepts.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "SimpleEngine/Core/Container/Optional.h"
 #include "SimpleEngine/ECS/Entity.h"
+#include "SimpleEngine/Traits/ContainerTraits.h"
 #include "SimpleEngine/Traits/TupleTraits.h"
 #include "SimpleEngine/Traits/TypeTraits.h"
 
@@ -39,7 +39,7 @@ concept IsFetchType = !(traits::IsSpecializationOf<T, With> || traits::IsSpecial
 
 /** Optional이나 Entity가 아닌 필수 컴포넌트인지 확인합니다. */
 template <typename T>
-concept IsRequiredComponent = IsFetchType<T> && !(traits::IsSpecializationOf<T, Optional> || std::same_as<T, Entity>);
+concept IsRequiredComponent = IsFetchType<T> && !(traits::OptionalLike<T> || std::same_as<T, Entity>);
 
 template <typename... Ts>
 struct QueryValidator;

--- a/EngineCore/Include/SimpleEngine/ECS/QueryConcepts.h
+++ b/EngineCore/Include/SimpleEngine/ECS/QueryConcepts.h
@@ -59,8 +59,11 @@ struct QueryValidator<TupleLike<ProcessedTs...>>
     // 포인터 타입이 없는지
     static constexpr bool NoPointers = !(std::is_pointer_v<ProcessedTs> || ...);
 
+    // 모든 타입이 유효한 컴포넌트(class/struct)인지
+    static constexpr bool AllValidComponents = (std::is_class_v<ProcessedTs> && ...);
+
     // 최종 결과
-    static constexpr bool IsValidPack = HasElements && IsUnique && NoPointers;
+    static constexpr bool IsValidPack = HasElements && IsUnique && NoPointers && AllValidComponents;
 };
 
 template <typename... Ts>

--- a/EngineCore/Include/SimpleEngine/ECS/QueryConcepts.h
+++ b/EngineCore/Include/SimpleEngine/ECS/QueryConcepts.h
@@ -67,16 +67,15 @@ struct QueryValidator<TupleLike<ProcessedTs...>>
 };
 
 template <typename... Ts>
-consteval bool ValidateQueryPack()
-{
-    using RawTuple = std::tuple<Ts...>;
-    using FlattenedTuple = traits::FlattenTuple<RawTuple>;
-    using ProcessedTuple = traits::TupleMap<FlattenedTuple, std::decay_t>;
+using ProcessedQueryTuple = traits::TupleMap<
+    traits::FlattenTuple<std::tuple<Ts...>>,
+    std::decay_t
+>;
 
-    return QueryValidator<ProcessedTuple>::IsValidPack;
-}
+template <typename... Ts>
+constexpr bool IsValidQueryPack = QueryValidator<ProcessedQueryTuple<Ts...>>::IsValidPack;
 } // namespace detail
 
 template <typename... Ts>
-concept QueryParameterPack = detail::ValidateQueryPack();
+concept QueryParameterPack = detail::IsValidQueryPack<Ts...>;
 } // namespace se

--- a/EngineCore/Include/SimpleEngine/ECS/QueryConcepts.h
+++ b/EngineCore/Include/SimpleEngine/ECS/QueryConcepts.h
@@ -69,7 +69,7 @@ struct QueryValidator<TupleLike<ProcessedTs...>>
 template <typename... Ts>
 using ProcessedQueryTuple = traits::TupleMap<
     traits::FlattenTuple<std::tuple<Ts...>>,
-    std::decay_t
+    std::remove_cvref_t
 >;
 
 template <typename... Ts>

--- a/EngineCore/Include/SimpleEngine/ECS/QueryConcepts.h
+++ b/EngineCore/Include/SimpleEngine/ECS/QueryConcepts.h
@@ -41,25 +41,39 @@ concept IsFetchTag = !(traits::IsSpecializationOf<T, With> || traits::IsSpeciali
 template <typename T>
 concept IsRequiredComponent = IsFetchTag<T> && !(traits::IsSpecializationOf<T, Optional> || std::same_as<T, Entity>);
 
-template <typename TupleType>
-struct TupleContainsPointersImpl;
+template <typename... Ts>
+struct QueryValidator;
 
 template <
     template <typename...> typename TupleLike,
-    typename... Ts
+    typename... ProcessedTs
 >
-struct TupleContainsPointersImpl<TupleLike<Ts...>>
+struct QueryValidator<TupleLike<ProcessedTs...>>
 {
-    static constexpr bool Value = (std::is_pointer_v<Ts> || ...);
+    // 최소 1개 이상의 파라미터가 있는지
+    static constexpr bool HasElements = sizeof...(ProcessedTs) > 0;
+
+    // 모든 타입이 고유한지
+    static constexpr bool IsUnique = traits::TupleUniqueTypes<TupleLike<ProcessedTs...>>;
+
+    // 포인터 타입이 없는지
+    static constexpr bool NoPointers = !(std::is_pointer_v<ProcessedTs> || ...);
+
+    // 최종 결과
+    static constexpr bool IsValidPack = HasElements && IsUnique && NoPointers;
 };
 
-template <typename TupleType>
-concept TupleContainsPointers = TupleContainsPointersImpl<TupleType>::Value;
+template <typename... Ts>
+consteval bool ValidateQueryPack()
+{
+    using RawTuple = std::tuple<Ts...>;
+    using FlattenedTuple = traits::FlattenTuple<RawTuple>;
+    using ProcessedTuple = traits::TupleMap<FlattenedTuple, std::decay_t>;
+
+    return QueryValidator<ProcessedTuple>::IsValidPack;
+}
 } // namespace detail
 
 template <typename... Ts>
-concept QueryParameterPack =
-    sizeof...(Ts) > 0                                                                                           // Ts...의 개수는 1개 이상
-    && traits::TupleUniqueTypes<traits::FlattenTuple<std::tuple<Ts...>>>                                        // Ts...는 Unique 해야 함
-    && !detail::TupleContainsPointers<traits::TupleMap<traits::FlattenTuple<std::tuple<Ts...>>, std::decay_t>>; // Ts...에 포인터 타입이 들어오면 안됨
+concept QueryParameterPack = detail::ValidateQueryPack();
 } // namespace se

--- a/EngineCore/Include/SimpleEngine/ECS/QueryConcepts.h
+++ b/EngineCore/Include/SimpleEngine/ECS/QueryConcepts.h
@@ -35,11 +35,11 @@ namespace detail
 {
 /** 타입 T가 FilterTag(With/Without)가 아닌 Fetch 대상인지 확인합니다. */
 template <typename T>
-concept IsFetchTag = !(traits::IsSpecializationOf<T, With> || traits::IsSpecializationOf<T, Without>);
+concept IsFetchType = !(traits::IsSpecializationOf<T, With> || traits::IsSpecializationOf<T, Without>);
 
 /** Optional이나 Entity가 아닌 필수 컴포넌트인지 확인합니다. */
 template <typename T>
-concept IsRequiredComponent = IsFetchTag<T> && !(traits::IsSpecializationOf<T, Optional> || std::same_as<T, Entity>);
+concept IsRequiredComponent = IsFetchType<T> && !(traits::IsSpecializationOf<T, Optional> || std::same_as<T, Entity>);
 
 template <typename... Ts>
 struct QueryValidator;

--- a/EngineCore/Include/SimpleEngine/ECS/QueryData.h
+++ b/EngineCore/Include/SimpleEngine/ECS/QueryData.h
@@ -124,7 +124,7 @@ IStorage* QueryData<Ts...>::FindSmallestPool()
         traits::ApplyTypes<PredicateTypes>([this]<typename... PredComps> -> FixedArray<IStorage*, pool_size>
         {
             return {
-                world->GetIStorage<std::decay_t<PredComps>>()...
+                world->FindRawStorage<std::decay_t<PredComps>>()...
             };
         });
 

--- a/EngineCore/Include/SimpleEngine/ECS/QueryData.h
+++ b/EngineCore/Include/SimpleEngine/ECS/QueryData.h
@@ -32,7 +32,7 @@ using FlatFilterTypes = traits::FlattenTuple<FilterTypes<ConditionTag, Ts...>>;
 
 // 가져올 컴포넌트인지 확인 (FilterTag가 아닌 것)
 template <typename T>
-struct FetchTypePred { static constexpr bool Value = IsFetchTag<T>; };
+struct FetchTypePred { static constexpr bool Value = IsFetchType<T>; };
 
 // 검사할 컴포넌트인지 확인 (필수 컴포넌트)
 template <typename T>

--- a/EngineCore/Include/SimpleEngine/ECS/Schedule.h
+++ b/EngineCore/Include/SimpleEngine/ECS/Schedule.h
@@ -17,7 +17,7 @@ namespace se
 /**
  * ECS System의 실행 순서를 관리하고 일괄 실행하는 스케줄러
  */
-class Schedule
+class SE_CORE_API Schedule
 {
 public:
     /**

--- a/EngineCore/Include/SimpleEngine/ECS/Schedule.h
+++ b/EngineCore/Include/SimpleEngine/ECS/Schedule.h
@@ -39,16 +39,16 @@ private:
     template <typename T>
     void AddInternal(T&& system_obj)
     {
-        using DecayedT = std::decay_t<T>;
+        using CleanType = std::remove_cvref_t<T>;
 
         // Callable 타입인 경우
-        if constexpr (traits::FunctionType<DecayedT>)
+        if constexpr (traits::FunctionType<CleanType>)
         {
             executables.Push(detail::BindCallable(std::forward<T>(system_obj)));
         }
 
         // System, SystemChain 타입인 경우
-        else if constexpr (traits::IsAnyOf<DecayedT, System, SystemChain>)
+        else if constexpr (traits::IsAnyOf<CleanType, System, SystemChain>)
         {
             executables.Push([obj = std::forward<T>(system_obj)](World* world) mutable -> void
             {
@@ -58,7 +58,7 @@ private:
 
         else
         {
-            static_assert(traits::AlwaysFalse<DecayedT>, "Invalid system parameter type");
+            static_assert(traits::AlwaysFalse<CleanType>, "Invalid system parameter type");
         }
     }
 

--- a/EngineCore/Include/SimpleEngine/ECS/Schedule.h
+++ b/EngineCore/Include/SimpleEngine/ECS/Schedule.h
@@ -1,0 +1,68 @@
+﻿#pragma once
+
+#include "SimpleEngine/Core/Container/Array.h"
+#include "SimpleEngine/Core/Functional/Function.h"
+#include "SimpleEngine/ECS/System.h"
+#include "SimpleEngine/ECS/SystemBinding.h"
+#include "SimpleEngine/ECS/SystemChain.h"
+#include "SimpleEngine/ECS/World.h"
+#include "SimpleEngine/Traits/TypeTraits.h"
+
+#include <type_traits>
+#include <utility>
+
+
+namespace se
+{
+/**
+ * ECS System의 실행 순서를 관리하고 일괄 실행하는 스케줄러
+ */
+class Schedule
+{
+public:
+    /**
+     * 함수, System, SystemChain 등을 스케줄에 추가합니다.
+     * @detail 함수 시그니처를 분석하여 필요한 인자를(Query, World* 등)을 자동으로 주입받습니다.
+     */
+    template <typename... Systems>
+    Schedule& Add(Systems&&... systems)
+    {
+        (AddInternal(std::forward<Systems>(systems)), ...);
+        return *this;
+    }
+
+    /** Schedule에 등록된 모든 System을 일괄 실행합니다. */
+    void Execute(World* world);
+
+private:
+    /** 다양한 시스템 타입을 Function<void(World*)> 형태로 type-erased하여 저장합니다. */
+    template <typename T>
+    void AddInternal(T&& system_obj)
+    {
+        using DecayedT = std::decay_t<T>;
+
+        // Callable 타입인 경우
+        if constexpr (traits::FunctionType<DecayedT>)
+        {
+            executables.Push(detail::BindCallable(std::forward<T>(system_obj)));
+        }
+
+        // System, SystemChain 타입인 경우
+        else if constexpr (traits::IsAnyOf<DecayedT, System, SystemChain>)
+        {
+            executables.Push([obj = std::forward<T>(system_obj)](World* world) mutable -> void
+            {
+                obj.Execute(world);
+            });
+        }
+
+        else
+        {
+            static_assert(traits::AlwaysFalse<DecayedT>, "Invalid system parameter type");
+        }
+    }
+
+private:
+    Array<Function<void(World*)>> executables;
+};
+} // namespace se

--- a/EngineCore/Include/SimpleEngine/ECS/System.h
+++ b/EngineCore/Include/SimpleEngine/ECS/System.h
@@ -1,0 +1,46 @@
+﻿#pragma once
+
+#include "SimpleEngine/Core/Container/Array.h"
+#include "SimpleEngine/Core/Functional/Function.h"
+#include "SimpleEngine/ECS/SystemBinding.h"
+#include "SimpleEngine/Traits/TypeTraits.h"
+
+#include <utility>
+
+
+namespace se
+{
+// forward declaration
+class World;
+
+/**
+ * ECS에서 사용하는 단일 System 클래스
+ */
+class System
+{
+public:
+    template <typename Fn>
+        requires traits::FunctionType<Fn>
+    explicit System(Fn&& in_system)
+        : system(detail::BindCallable(std::forward<Fn>(in_system)))
+    {
+    }
+
+public:
+    /** System의 실행 조건을 추가합니다. */
+    template <typename Fn>
+        requires traits::FunctionType<Fn>
+    System& RunIf(Fn&& condition)
+    {
+        preconditions.Push(detail::BindCallable(std::forward<Fn>(condition)));
+        return *this;
+    }
+
+    /** 모든 조건을 검사한 후 System을 실행합니다. */
+    void Execute(World* world);
+
+private:
+    Function<void(World*)> system;
+    Array<Function<bool(World*)>> preconditions;
+};
+} // namespace se

--- a/EngineCore/Include/SimpleEngine/ECS/System.h
+++ b/EngineCore/Include/SimpleEngine/ECS/System.h
@@ -16,7 +16,7 @@ class World;
 /**
  * ECS에서 사용하는 단일 System 클래스
  */
-class System
+class SE_CORE_API System
 {
 public:
     template <typename Fn>

--- a/EngineCore/Include/SimpleEngine/ECS/SystemBinding.h
+++ b/EngineCore/Include/SimpleEngine/ECS/SystemBinding.h
@@ -1,0 +1,60 @@
+﻿#pragma once
+
+#include "SimpleEngine/ECS/Query.h"
+#include "SimpleEngine/ECS/World.h"
+#include "SimpleEngine/Traits/FunctionTraits.h"
+#include "SimpleEngine/Traits/TypeTraits.h"
+
+#include <tuple>
+#include <utility>
+
+
+namespace se::detail
+{
+template <typename T>
+struct SystemParamExtractor
+{
+    static_assert(traits::AlwaysFalse<T>, "SystemParamExtractor<T> is not specialized for type T");
+};
+
+// World 포인터 자체를 요구할 때의 특수화
+template <>
+struct [[deprecated("use instead Query<Commands&, ...>")]] SystemParamExtractor<World*>
+{
+    static World* Fetch(World* world)
+    {
+        return world;
+    }
+};
+
+// Query<Ts...> 를 요구할 때의 특수화
+template <typename... Ts>
+struct SystemParamExtractor<Query<Ts...>>
+{
+    static Query<Ts...> Fetch(World* world)
+    {
+        return Query<Ts...>{ world };
+    }
+};
+
+/**
+ * 일반 함수나 조건식(RunIf)을 ECS에서 사용할 수 있도록 World* 기반 래퍼로 변환합니다.
+ * @details 함수의 인자 타입을 분석하여 자동 바인딩하며, 원본 함수의 반환 타입(void, bool 등)을 그대로 유지합니다.
+ */
+template <typename Fn>
+    requires traits::FunctionType<Fn>
+auto BindCallable(Fn&& func_obj) -> Function<typename traits::FunctionTraits<std::remove_cvref_t<Fn>>::ReturnType(World*)>
+{
+    using FnTrait = traits::FunctionTraits<std::remove_cvref_t<Fn>>;
+    using RetType = FnTrait::ReturnType;
+
+    return [func = std::forward<Fn>(func_obj)](World* world) mutable -> RetType
+    {
+        std::tuple tuple = traits::ApplyTypes<typename FnTrait::ArgumentTypes>([world]<typename... Ts>
+        {
+            return std::make_tuple(SystemParamExtractor<Ts>::Fetch(world)...);
+        });
+        return std::apply(func, std::move(tuple));
+    };
+}
+} // namespace se::detail

--- a/EngineCore/Include/SimpleEngine/ECS/SystemBinding.h
+++ b/EngineCore/Include/SimpleEngine/ECS/SystemBinding.h
@@ -52,7 +52,7 @@ auto BindCallable(Fn&& func_obj) -> Function<typename traits::FunctionTraits<std
     {
         std::tuple tuple = traits::ApplyTypes<typename FnTrait::ArgumentTypes>([world]<typename... Ts>
         {
-            return std::make_tuple(SystemParamExtractor<Ts>::Fetch(world)...);
+            return std::make_tuple(SystemParamExtractor<std::remove_cvref_t<Ts>>::Fetch(world)...);
         });
         return std::apply(func, std::move(tuple));
     };

--- a/EngineCore/Include/SimpleEngine/ECS/SystemChain.h
+++ b/EngineCore/Include/SimpleEngine/ECS/SystemChain.h
@@ -1,0 +1,44 @@
+﻿#pragma once
+
+#include "SimpleEngine/Core/Container/Array.h"
+#include "SimpleEngine/Core/Functional/Function.h"
+#include "SimpleEngine/ECS/System.h"
+
+#include <utility>
+
+
+namespace se
+{
+// forward declaration
+class World;
+
+/**
+ * 여러 System을 하나의 그룹으로 묶어 순차적으로 실행하는 클래스
+ */
+class SystemChain
+{
+public:
+    template <typename... Systems>
+    explicit SystemChain(Systems&&... systems)
+        : systems{ System{ std::forward<Systems>(systems) }... }
+    {
+    }
+
+public:
+    /** Chain 전체의 실행 조건을 추가합니다. */
+    template <typename Fn>
+        requires traits::FunctionType<Fn>
+    SystemChain& RunIf(Fn&& condition)
+    {
+        preconditions.Push(detail::BindCallable(std::forward<Fn>(condition)));
+        return *this;
+    }
+
+    /** System을 Chain 순서대로 호출합니다. */
+    void Execute(World* world);
+
+private:
+    Array<System> systems;
+    Array<Function<bool(World*)>> preconditions;
+};
+} // namespace se

--- a/EngineCore/Include/SimpleEngine/ECS/SystemChain.h
+++ b/EngineCore/Include/SimpleEngine/ECS/SystemChain.h
@@ -15,7 +15,7 @@ class World;
 /**
  * 여러 System을 하나의 그룹으로 묶어 순차적으로 실행하는 클래스
  */
-class SystemChain
+class SE_CORE_API SystemChain
 {
 public:
     template <typename... Systems>

--- a/EngineCore/Include/SimpleEngine/ECS/World.h
+++ b/EngineCore/Include/SimpleEngine/ECS/World.h
@@ -16,6 +16,7 @@
 
 namespace se
 {
+// forward declaration
 template <typename... Ts>
     requires QueryParameterPack<Ts...>
 class Query;
@@ -27,9 +28,6 @@ class Query;
 class SE_CORE_API World final
 {
 private:
-    template <typename... Ts>
-    friend class QueryData;
-
     friend class ComponentRegistry;
 
 public:
@@ -70,7 +68,7 @@ public:
     template <typename ComponentType>
     ComponentType& AddComponent(Entity entity, ComponentType&& init_component)
     {
-        auto& storage = GetOrCreateStorage<ComponentType>();
+        auto& storage = GetOrCreateSparseSet<ComponentType>();
         storage.Add(entity, std::forward<ComponentType>(init_component));
         return storage.Get(entity);
     }
@@ -78,7 +76,7 @@ public:
     template <typename ComponentType, typename... Args>
     ComponentType& AddComponent(Entity entity, Args&&... args)
     {
-        auto& storage = GetOrCreateStorage<ComponentType>();
+        auto& storage = GetOrCreateSparseSet<ComponentType>();
         storage.Add(entity, ComponentType{ std::forward<Args>(args)... });
         return storage.Get(entity);
     }
@@ -87,9 +85,9 @@ public:
     template <typename ComponentType>
     void RemoveComponent(Entity entity)
     {
-        if (Optional storage_opt = GetStorage<ComponentType>())
+        if (const auto storage = FindSparseSet<ComponentType>())
         {
-            storage_opt->Remove(entity);
+            storage->Remove(entity);
         }
     }
 
@@ -97,27 +95,27 @@ public:
     template <typename ComponentType, typename Self>
     traits::CopyConst<Self, ComponentType&> GetComponent(this Self&& self, Entity entity)
     {
-        return self.template GetStorage<ComponentType>()->Get(entity);
+        return self.template FindSparseSet<ComponentType>()->Get(entity);
     }
 
     /** Entity에서 ComponentType에 맞는 Component를 Optional로 가져옵니다. */
     template <typename ComponentType, typename Self>
     Optional<traits::CopyConst<Self, ComponentType&>> TryGetComponent(this Self&& self, Entity entity)
     {
-        if (const auto opt_storage = self.template GetStorage<ComponentType>())
+        if (const auto storage = self.template FindSparseSet<ComponentType>())
         {
-            return opt_storage->Find(entity);
+            return storage->Find(entity);
         }
         return NullOpt;
     }
 
     /** Entity가 특정 Component를 가지고 있는지 확인합니다. */
-    template <typename ComponentType>
-    [[nodiscard]] bool HasComponent(Entity entity) const
+    template <typename ComponentType, typename Self>
+    [[nodiscard]] bool HasComponent(this Self&& self, Entity entity)
     {
-        if (Optional opt_storage = GetStorage<ComponentType>())
+        if (auto storage = self.template FindSparseSet<ComponentType>())
         {
-            return opt_storage->Contains(entity);
+            return storage->Contains(entity);
         }
         return false;
     }
@@ -127,27 +125,52 @@ public:
      * Entity를 쿼리하는 Query 객체를 생성합니다.
      * @tparam Ts Component 목록 및 필터(With<...>, Without<...>)
      */
-    template <typename... Ts>
-        requires requires { Query<Ts...>{ std::declval<World*>() }; }
-    [[nodiscard]] Query<Ts...> QueryEntities() // TODO: QueryEntities를 const로 만들기
+    template <typename... Ts, typename Self>
+    [[nodiscard]] Query<Ts...> CreateQuery(this Self&& self)
     {
-        return Query<Ts...>{ this };
+        return Query<Ts...>{ &self };
     }
 
+public:
     /**
      * 주어진 TypeId에 해당하는 IStorage 포인터를 반환합니다.
      * @param type_id 검색할 타입의 TypeId
      * @return IStorage 포인터, 해당 타입이 없을 경우 nullptr 반환
      */
-    IStorage* GetStorage(const TypeId& type_id);
+    [[nodiscard]] IStorage* FindRawStorage(const TypeId& type_id);
+    [[nodiscard]] const IStorage* FindRawStorage(const TypeId& type_id) const;
+
+    /** template 타입에 맞는 IStorage 포인터를 반환합니다. */
+    template <typename ComponentType, typename Self>
+    traits::CopyConst<Self, IStorage*> FindRawStorage(this Self&& self)
+    {
+        using RawType = std::remove_cvref_t<ComponentType>;
+        return self.FindRawStorage(TypeId::Get<RawType>());
+    }
+
+    /**
+     * 주어진 TypeId에 해당하는 IStorage 포인터를 반환하거나,
+     * 해당 타입의 저장소가 없을 경우 새로 생성합니다.
+     * @param type_id 검색하거나 생성할 타입의 TypeId
+     * @return IStorage 포인터, 생성되거나 조회된 저장소를 반환
+     */
+    [[nodiscard]] IStorage* GetOrCreateRawStorage(const TypeId& type_id);
+
+    template <typename ComponentType>
+    [[nodiscard]] IStorage* GetOrCreateRawStorage()
+    {
+        using RawType = std::remove_cvref_t<ComponentType>;
+        return GetOrCreateRawStorage(TypeId::Get<RawType>());
+    }
 
 private:
+    /** 타입 매개변수에 맞는 ComponentStorage 래퍼 객체를 반환하거나 생성합니다. (ComponentRegistry 등에서 사용) */
     template <typename ComponentType>
-    ComponentStorage<std::decay_t<ComponentType>>& GetOrCreateStorageImpl()
+    ComponentStorage<std::remove_cvref_t<ComponentType>>& GetOrCreateComponentStorage()
     {
-        using RawType = std::decay_t<ComponentType>;
-
+        using RawType = std::remove_cvref_t<ComponentType>;
         const auto type_id = TypeId::Get<RawType>();
+
         auto& storage_ptr = component_storages
             .Entry(type_id)
             .OrInsertWith([]{ return std::make_unique<ComponentStorage<RawType>>(); });
@@ -155,35 +178,23 @@ private:
         return *static_cast<ComponentStorage<RawType>*>(storage_ptr.get());
     }
 
-    template <typename ComponentType>
-    SparseSet<std::decay_t<ComponentType>>& GetOrCreateStorage()
-    {
-        return GetOrCreateStorageImpl<ComponentType>().GetStorage();
-    }
-
+    /** 구체적 타입으로 캐스팅된 실제 Component Pool(SparseSet)을 검색합니다. */
     template <typename ComponentType, typename Self>
-    Optional<traits::CopyConst<Self, SparseSet<std::decay_t<ComponentType>>&>> GetStorage(this Self&& self)
+    Optional<traits::CopyConst<Self, SparseSet<std::remove_cvref_t<ComponentType>>&>> FindSparseSet(this Self&& self)
     {
-        using RawType = std::decay_t<ComponentType>;
-        if (traits::CopyConst<Self, IStorage*> storage = self.template GetIStorage<RawType>())
+        using RawType = std::remove_cvref_t<ComponentType>;
+        if (traits::CopyConst<Self, IStorage*> storage = self.template FindRawStorage<RawType>())
         {
             return static_cast<traits::CopyConst<Self, ComponentStorage<RawType>*>>(storage)->GetStorage();
         }
         return NullOpt;
     }
 
-    /** 타입에 맞는 IStorage 포인터를 반환합니다. 쿼리 시스템 내부에서 사용됩니다. */
-    template <typename ComponentType, typename Self>
-    traits::CopyConst<Self, IStorage*> GetIStorage(this Self&& self)
+    /** 타입 매개변수에 맞는 SparseSet을 가져오거나, 없으면 생성합니다. */
+    template <typename ComponentType>
+    SparseSet<std::remove_cvref_t<ComponentType>>& GetOrCreateSparseSet()
     {
-        using RawType = std::decay_t<ComponentType>;
-
-        const auto type_id = TypeId::Get<RawType>();
-        if (Optional storage_opt = self.component_storages.Find(type_id))
-        {
-            return storage_opt->get();
-        }
-        return nullptr;
+        return GetOrCreateComponentStorage<ComponentType>().GetStorage();
     }
 
 public:

--- a/EngineCore/Include/SimpleEngine/ECS/World.h
+++ b/EngineCore/Include/SimpleEngine/ECS/World.h
@@ -3,18 +3,13 @@
 #include "SimpleEngine/Core/Container/Array.h"
 #include "SimpleEngine/Core/Container/HashMap.h"
 #include "SimpleEngine/Core/Container/Optional.h"
-#include "SimpleEngine/Core/Functional/Function.h"
 #include "SimpleEngine/Core/Reflection/TypeId.h"
 #include "SimpleEngine/ECS/ComponentStorage.h"
 #include "SimpleEngine/ECS/EntityManager.h"
-#include "SimpleEngine/ECS/Phases.h"
 #include "SimpleEngine/ECS/QueryConcepts.h"
 #include "SimpleEngine/Traits/TypeTraits.h"
-#include "SimpleEngine/Utility/Debug.h"
 
-#include <concepts>
 #include <memory>
-#include <tuple>
 #include <type_traits>
 #include <utility>
 
@@ -26,15 +21,8 @@ template <typename... Ts>
 class Query;
 
 
-namespace detail
-{
-template <typename Fn>
-concept SystemFunctionType = traits::FunctionType<Fn>
-    && std::is_void_v<typename traits::FunctionTraits<Fn>::ReturnType>;
-}
-
 /**
- * ECS 월드의 모든 요소(엔티티, 컴포넌트)를 관리하는 중앙 클래스
+ * ECS 월드의 모든 요소(엔티티, 컴포넌트)를 관리하는 순수 데이터 클래스
  */
 class SE_CORE_API World final
 {
@@ -43,13 +31,6 @@ private:
     friend class QueryData;
 
     friend class ComponentRegistry;
-
-    EntityManager entity_manager;
-    Array<Entity> alive_entities;
-
-    // TODO: 추후 C++26에서 Annotation으로 Tag 검사
-    HashMap<TypeId, Array<Function<void()>>> systems;
-    HashMap<TypeId, std::unique_ptr<IStorage>> component_storages;
 
 public:
     class EntityChain;
@@ -75,7 +56,7 @@ public:
         return chain;
     }
 
-    /** Entity와 Entity와 연결된 Component를 제거합니다. */
+    /** Entity와 연결된 모든 Component를 제거합니다. */
     void DestroyEntity(Entity entity);
 
     /** Entity가 현재 살아있는지 확인합니다. */
@@ -84,7 +65,8 @@ public:
     /** 현재 살아있는 모든 Entity를 반환합니다. */
     [[nodiscard]] const Array<Entity>& GetAliveEntities() const { return alive_entities; }
 
-    /** Entity에 Component를 추가합니다. 만약 이미 존재하면 덮어씌워집니다. */
+public:
+    /** Entity에 Component를 추가합니다. 이미 존재하면 덮어씌워집니다. */
     template <typename ComponentType>
     ComponentType& AddComponent(Entity entity, ComponentType&& init_component)
     {
@@ -140,56 +122,10 @@ public:
         return false;
     }
 
-    /**
-     * 지정된 스케줄 단계에 시스템을 추가합니다.
-     * @detail 시스템은 함수 시그니처를 분석하여 필요한 자원(Query, World* 등)을 자동으로 주입받습니다.
-     * @tparam S 시스템을 추가할 스케줄 타입 (예: PreUpdate, Update, PostUpdate)
-     * @tparam Fn 시스템으로 등록할 함수 또는 람다
-     */
-    template <PhaseType S, detail::SystemFunctionType Fn>
-    void AddSystem(Fn&& system_func)
-    {
-        const auto type_id = TypeId::Get<S>();
-        systems[type_id].Push([this, sys_func = std::forward<Fn>(system_func)] mutable
-        {
-            using F = traits::FunctionTraits<Fn>;
-            std::tuple tuple = traits::ApplyTypes<typename F::ArgumentTypes>([this]<typename... Ts>
-            {
-                return std::make_tuple(CreateSystemParam<Ts>()...);
-            });
-            std::apply(sys_func, std::move(tuple));
-        });
-    }
-
 public:
-    /**
-     * 주어진 TypeId에 해당하는 IStorage 포인터를 반환합니다.
-     * @param type_id 검색할 타입의 TypeId
-     * @return IStorage 포인터, 해당 타입이 없을 경우 nullptr 반환
-     */
-    IStorage* GetStorage(const TypeId& type_id);
-
-    /**
-     * 지정된 스케줄에 등록된 모든 시스템을 순서대로 실행합니다.
-     * @tparam S 실행할 스케줄 타입
-     */
-    template <PhaseType S>
-    void RunPhase()
-    {
-        const auto type_id = TypeId::Get<S>();
-        if (Optional system_opt = systems.Find(type_id))
-        {
-            for (const Function<void()>& system : *system_opt)
-            {
-                system();
-            }
-        }
-    }
-
     /**
      * Entity를 쿼리하는 Query 객체를 생성합니다.
      * @tparam Ts Component 목록 및 필터(With<...>, Without<...>)
-     * @return Query 객체
      */
     template <typename... Ts>
         requires requires { Query<Ts...>{ std::declval<World*>() }; }
@@ -198,25 +134,12 @@ public:
         return Query<Ts...>{ this };
     }
 
-private:
-    template <typename T>
-    T CreateSystemParam()
-    {
-        using namespace traits;
-        if constexpr (std::same_as<T, World*>)
-        {
-            return this;
-        }
-        else if constexpr (IsSpecializationOf<T, Query>)
-        {
-            return T{ this };
-        }
-        else
-        {
-            static_assert(AlwaysFalse<T>, "Invalid system parameter type");
-            SE_UNREACHABLE();
-        }
-    }
+    /**
+     * 주어진 TypeId에 해당하는 IStorage 포인터를 반환합니다.
+     * @param type_id 검색할 타입의 TypeId
+     * @return IStorage 포인터, 해당 타입이 없을 경우 nullptr 반환
+     */
+    IStorage* GetStorage(const TypeId& type_id);
 
 private:
     template <typename ComponentType>
@@ -273,7 +196,7 @@ public:
         {
         }
 
-        /** Entity에 Component를 추가합니다. 만약 이미 존재하면 덮어씌워집니다. */
+        /** Entity에 Component를 추가합니다. 이미 존재하면 덮어씌워집니다. */
         template <typename ComponentType>
         EntityChain& AddComponent(ComponentType&& init_component)
         {
@@ -294,5 +217,11 @@ public:
         World* world;
         Entity entity;
     };
+
+private:
+    EntityManager entity_manager;
+    Array<Entity> alive_entities;
+
+    HashMap<TypeId, std::unique_ptr<IStorage>> component_storages;
 };
 } // namespace se

--- a/EngineCore/Include/SimpleEngine/ECS/World.h
+++ b/EngineCore/Include/SimpleEngine/ECS/World.h
@@ -27,9 +27,6 @@ class Query;
  */
 class SE_CORE_API World final
 {
-private:
-    friend class ComponentRegistry;
-
 public:
     class EntityChain;
 

--- a/EngineCore/Include/SimpleEngine/ECS/WorldContext.h
+++ b/EngineCore/Include/SimpleEngine/ECS/WorldContext.h
@@ -1,0 +1,72 @@
+﻿#pragma once
+
+#include "SimpleEngine/Core/Container/HashMap.h"
+#include "SimpleEngine/Core/Reflection/TypeId.h"
+#include "SimpleEngine/ECS/Phases.h"
+#include "SimpleEngine/ECS/Schedule.h"
+
+#include <memory>
+
+
+namespace se
+{
+// forward declaration
+class World;
+
+/**
+ * ECS World와 Phase별 Schedule을 하나의 단위로 묶는 Context
+ */
+class SE_CORE_API WorldContext
+{
+public:
+    WorldContext();
+    ~WorldContext();
+
+    // 이동만 허용
+    WorldContext(WorldContext&&) = default;
+    WorldContext& operator=(WorldContext&&) = default;
+    WorldContext(const WorldContext&) = delete;
+    WorldContext& operator=(const WorldContext&) = delete;
+
+public:
+    /**
+     * 함수, System, SystemChain 등을 스케줄에 추가합니다.
+     * @details 함수 시그니처를 분석하여 필요한 인자를(Query, World* 등)을 자동으로 주입받습니다.
+     * @tparam P 시스템을 추가할 스케줄 타입 (예: PreUpdate, Update, PostUpdate)
+     */
+    template <PhaseType P, typename... Systems>
+    Schedule& AddSystem(Systems&&... in_systems)
+    {
+        return schedules.Entry(TypeId::Get<P>()).OrDefault().Add(std::forward<Systems>(in_systems)...);
+    }
+
+    /**
+     * Phase에 등록된 모든 시스템을 실행합니다.
+     * 만약 등록된 시스템이 없으면 아무 동작도 하지 않습니다.
+     */
+    template <PhaseType P>
+    void RunPhase()
+    {
+        if (const auto schedule = GetSchedule<P>())
+        {
+            schedule->Execute(world.get());
+        }
+    }
+
+    /**
+     * Phase의 Schedule을 반환합니다.
+     * 만약, 등록된 시스템이 없으면 NullOpt를 반환합니다. */
+    template <PhaseType P>
+    Optional<Schedule&> GetSchedule()
+    {
+        return schedules.Find(TypeId::Get<P>());
+    }
+
+    [[nodiscard]] World& GetWorld() { return *world; }
+    [[nodiscard]] const World& GetWorld() const { return *world; }
+
+private:
+    std::unique_ptr<World> world;
+    HashMap<TypeId, Schedule> schedules;
+};
+} // namespace se

--- a/EngineCore/Include/SimpleEngine/Graphics/Scene/CollectDrawData.h
+++ b/EngineCore/Include/SimpleEngine/Graphics/Scene/CollectDrawData.h
@@ -9,5 +9,5 @@ namespace se { class World; }
 namespace se::graphics
 {
 /** ECS World에서 렌더링 가능한 엔티티를 수집하여 SceneDrawData를 생성합니다. */
-[[nodiscard]] SE_CORE_API SceneDrawData CollectDrawData(World& world);
+[[nodiscard]] SE_CORE_API SceneDrawData CollectDrawData(const World& world);
 } // namespace se::graphics

--- a/EngineCore/Source/ECS/EntitySubsystem.cpp
+++ b/EngineCore/Source/ECS/EntitySubsystem.cpp
@@ -1,7 +1,10 @@
 #include "SimpleEngine/ECS/EntitySubsystem.h"
 
 #include "SimpleEngine/Core/Subsystem/SubsystemRegistration.h"
-#include "SimpleEngine/ECS/World.h"
+#include "SimpleEngine/ECS/Phases.h"
+#include "SimpleEngine/Utility/Debug.h"
+
+#include <ranges>
 
 
 namespace se
@@ -14,30 +17,70 @@ SE_END_REFLECT(EntitySubsystem)
 
 bool EntitySubsystem::Initialize()
 {
-    world = std::make_unique<World>();
+    GetOrCreateWorld(GetMainWorldName());
     return true;
 }
 
 void EntitySubsystem::Release()
 {
-    world.reset();
+    worlds.Clear();
 }
 
 void EntitySubsystem::PreUpdate()
 {
-    world->RunPhase<PreUpdatePhase>();
+    for (WorldContext& ctx : worlds | std::views::values)
+    {
+        ctx.RunPhase<PreUpdatePhase>();
+    }
 }
 
 void EntitySubsystem::Update(float delta_time)
 {
-    // TODO: delta_time ECS에서 사용할 수 있도록 수정
+    // TODO: Time Resource 주입하도록 수정
     (void)delta_time;
 
-    world->RunPhase<UpdatePhase>();
+    for (WorldContext& ctx : worlds | std::views::values)
+    {
+        ctx.RunPhase<UpdatePhase>();
+    }
 }
 
 void EntitySubsystem::PostUpdate()
 {
-    world->RunPhase<PostUpdatePhase>();
+    for (WorldContext& ctx : worlds | std::views::values)
+    {
+        ctx.RunPhase<PostUpdatePhase>();
+    }
+}
+
+WorldContext& EntitySubsystem::GetOrCreateWorld(const StringName& name)
+{
+    return worlds.Entry(name).OrInsertWith([]{ return WorldContext{}; });
+}
+
+Optional<WorldContext&> EntitySubsystem::FindWorld(const StringName& name)
+{
+    return worlds.Find(name);
+}
+
+WorldContext& EntitySubsystem::GetMainWorld()
+{
+    return worlds.FindChecked(GetMainWorldName());
+}
+
+const WorldContext& EntitySubsystem::GetMainWorld() const
+{
+    return worlds.FindChecked(GetMainWorldName());
+}
+
+void EntitySubsystem::DestroyWorld(const StringName& name)
+{
+    worlds.Remove(name);
+}
+
+const StringName& EntitySubsystem::GetMainWorldName()
+{
+    static const StringName main_world_name = "Main";
+    return main_world_name;
 }
 } // namespace se

--- a/EngineCore/Source/ECS/EntitySubsystem.cpp
+++ b/EngineCore/Source/ECS/EntitySubsystem.cpp
@@ -1,4 +1,4 @@
-#include "SimpleEngine/ECS/WorldSubsystem.h"
+#include "SimpleEngine/ECS/EntitySubsystem.h"
 
 #include "SimpleEngine/Core/Subsystem/SubsystemRegistration.h"
 #include "SimpleEngine/ECS/World.h"
@@ -6,29 +6,29 @@
 
 namespace se
 {
-SE_REGISTER_SUBSYSTEM(WorldSubsystem);
+SE_REGISTER_SUBSYSTEM(EntitySubsystem);
 
-SE_BEGIN_REFLECT(WorldSubsystem, meta::Internal)
+SE_BEGIN_REFLECT(EntitySubsystem, meta::Internal)
     SE_REFLECT_INTERFACE(IUpdatable)
-SE_END_REFLECT(WorldSubsystem)
+SE_END_REFLECT(EntitySubsystem)
 
-bool WorldSubsystem::Initialize()
+bool EntitySubsystem::Initialize()
 {
     world = std::make_unique<World>();
     return true;
 }
 
-void WorldSubsystem::Release()
+void EntitySubsystem::Release()
 {
     world.reset();
 }
 
-void WorldSubsystem::PreUpdate()
+void EntitySubsystem::PreUpdate()
 {
     world->RunPhase<PreUpdatePhase>();
 }
 
-void WorldSubsystem::Update(float delta_time)
+void EntitySubsystem::Update(float delta_time)
 {
     // TODO: delta_time ECS에서 사용할 수 있도록 수정
     (void)delta_time;
@@ -36,7 +36,7 @@ void WorldSubsystem::Update(float delta_time)
     world->RunPhase<UpdatePhase>();
 }
 
-void WorldSubsystem::PostUpdate()
+void EntitySubsystem::PostUpdate()
 {
     world->RunPhase<PostUpdatePhase>();
 }

--- a/EngineCore/Source/ECS/Schedule.cpp
+++ b/EngineCore/Source/ECS/Schedule.cpp
@@ -1,0 +1,13 @@
+﻿#include "SimpleEngine/ECS/Schedule.h"
+
+
+namespace se
+{
+void Schedule::Execute(World* world)
+{
+    for (Function<void(World*)>& executable : executables)
+    {
+        executable(world);
+    }
+}
+} // namespace se

--- a/EngineCore/Source/ECS/System.cpp
+++ b/EngineCore/Source/ECS/System.cpp
@@ -1,0 +1,20 @@
+﻿#include "SimpleEngine/ECS/System.h"
+
+#include <ranges>
+
+
+namespace se
+{
+void System::Execute(World* world)
+{
+    const bool should_execute = std::ranges::all_of(preconditions, [world](const auto& condition)
+    {
+        return condition(world);
+    });
+
+    if (should_execute)
+    {
+        system(world);
+    }
+}
+} // namespace se

--- a/EngineCore/Source/ECS/SystemChain.cpp
+++ b/EngineCore/Source/ECS/SystemChain.cpp
@@ -1,0 +1,23 @@
+﻿#include "SimpleEngine/ECS/SystemChain.h"
+
+#include <ranges>
+
+
+namespace se
+{
+void SystemChain::Execute(World* world)
+{
+    const bool should_execute = std::ranges::all_of(preconditions, [world](const auto& condition)
+    {
+        return condition(world);
+    });
+
+    if (should_execute)
+    {
+        for (System& system : systems)
+        {
+            system.Execute(world);
+        }
+    }
+}
+} // namespace se

--- a/EngineCore/Source/ECS/World.cpp
+++ b/EngineCore/Source/ECS/World.cpp
@@ -15,6 +15,7 @@ void World::DestroyEntity(Entity entity)
         storage->Remove(entity);
     }
 
+    // TODO: 여기 최적화의 여지가 있음. 지금 선형 탐색중, 추후 FlatSet이나 이진탐색으로 최적화 가능
     if (const Optional<usize> idx = alive_entities.Find(entity))
     {
         alive_entities.RemoveAtSwap(*idx);
@@ -23,17 +24,38 @@ void World::DestroyEntity(Entity entity)
     entity_manager.Destroy(entity);
 }
 
-IStorage* World::GetStorage(const TypeId& type_id)
+IStorage* World::GetOrCreateRawStorage(const TypeId& type_id)
 {
-    if (const Optional storage = component_storages.Find(type_id))
+    if (const auto storage = component_storages.Find(type_id))
     {
         return storage->get();
     }
 
-    if (const Optional ops = ComponentRegistry::Get().GetOps(type_id))
+    if (const auto ops = ComponentRegistry::Get().GetOps(type_id))
     {
         return ops->ensure_storage(*this);
     }
+
+    return nullptr;
+}
+
+IStorage* World::FindRawStorage(const TypeId& type_id)
+{
+    if (const auto storage = component_storages.Find(type_id))
+    {
+        return storage->get();
+    }
+
+    return nullptr;
+}
+
+const IStorage* World::FindRawStorage(const TypeId& type_id) const
+{
+    if (const auto storage = component_storages.Find(type_id))
+    {
+        return storage->get();
+    }
+
     return nullptr;
 }
 } // namespace se

--- a/EngineCore/Source/ECS/WorldContext.cpp
+++ b/EngineCore/Source/ECS/WorldContext.cpp
@@ -1,0 +1,13 @@
+﻿#include "SimpleEngine/ECS/WorldContext.h"
+#include "SimpleEngine/ECS/World.h"
+
+
+namespace se
+{
+WorldContext::WorldContext()
+    : world(std::make_unique<World>())
+{
+}
+
+WorldContext::~WorldContext() = default;
+} // namespace se

--- a/EngineCore/Source/Graphics/Scene/CollectDrawData.cpp
+++ b/EngineCore/Source/Graphics/Scene/CollectDrawData.cpp
@@ -29,11 +29,12 @@ namespace
 } // namespace
 
 
-SceneDrawData CollectDrawData(World& world)
+SceneDrawData CollectDrawData(const World& world)
 {
     SceneDrawData result;
 
-    auto query = world.QueryEntities<const TransformComponent&, const StaticMeshComponent&, const MaterialHandleComponent&>();
+    // TODO: const Query 사용할 수 있게 만든 뒤, const_cast 제거 및 CollectDrawData를 const World& 로 변경할 것
+    auto query = const_cast<World&>(world).QueryEntities<const TransformComponent&, const StaticMeshComponent&, const MaterialHandleComponent&>();
     for (const auto [transform, mesh, material] : query)
     {
         result.opaque_commands.Push({

--- a/EngineCore/Source/Graphics/Scene/CollectDrawData.cpp
+++ b/EngineCore/Source/Graphics/Scene/CollectDrawData.cpp
@@ -34,7 +34,7 @@ SceneDrawData CollectDrawData(const World& world)
     SceneDrawData result;
 
     // TODO: const Query 사용할 수 있게 만든 뒤, const_cast 제거 및 CollectDrawData를 const World& 로 변경할 것
-    auto query = const_cast<World&>(world).QueryEntities<const TransformComponent&, const StaticMeshComponent&, const MaterialHandleComponent&>();
+    auto query = const_cast<World&>(world).CreateQuery<const TransformComponent&, const StaticMeshComponent&, const MaterialHandleComponent&>();
     for (const auto [transform, mesh, material] : query)
     {
         result.opaque_commands.Push({

--- a/EngineTest/Source/UnitTests/ECS_Test.cpp
+++ b/EngineTest/Source/UnitTests/ECS_Test.cpp
@@ -2,187 +2,169 @@
 
 #include "SimpleEngine/ECS/Query.h"
 #include "SimpleEngine/ECS/QueryData.h"
-#include "SimpleEngine/ECS/World.h"
+#include "SimpleEngine/ECS/WorldContext.h"
 #include "SimpleEngine/ECS/Components/StaticMeshComponent.h"
 #include "SimpleEngine/ECS/Components/TransformComponent.h"
 
 using namespace se;
 
-class ECSTest : public ::testing::Test {};
+class ECSTest : public ::testing::Test
+{
+};
 
-// A simple component for testing
 struct TestValueComponent
 {
     int value;
 };
 
-// A tag component for testing queries
 struct TestTagComponent
 {
 };
 
+
+// Phase 순서(PreUpdate -> Update -> PostUpdate)가 보장되는지 검증합니다.
 TEST_F(ECSTest, ECSScheduleAndSystemExecutionOrder)
 {
-    World world;
-    std::vector<std::u8string> execution_log;
+    WorldContext ctx;
 
-    // Add systems to different schedules
-    world.AddSystem<PreUpdatePhase>([&]
-    {
-        execution_log.emplace_back(u8"PreUpdate");
-    });
+    int call_index = 0;
+    int pre_order = -1;
+    int update_order = -1;
+    int post_order = -1;
 
-    world.AddSystem<UpdatePhase>([&]
-    {
-        execution_log.emplace_back(u8"Update");
-    });
+    ctx.AddSystem<PreUpdatePhase>([&] { pre_order = call_index++; });
+    ctx.AddSystem<UpdatePhase>([&] { update_order = call_index++; });
+    ctx.AddSystem<PostUpdatePhase>([&] { post_order = call_index++; });
 
-    world.AddSystem<PostUpdatePhase>([&]
-    {
-        execution_log.emplace_back(u8"PostUpdate");
-    });
+    ctx.RunPhase<PreUpdatePhase>();
+    ctx.RunPhase<UpdatePhase>();
+    ctx.RunPhase<PostUpdatePhase>();
 
-    // Run schedules in a specific order
-    world.RunPhase<PreUpdatePhase>();
-    world.RunPhase<UpdatePhase>();
-    world.RunPhase<PostUpdatePhase>();
-
-    // Verify the execution order
-    ASSERT_EQ(execution_log.size(), 3);
-    EXPECT_TRUE(execution_log[0].contains(u8"PreUpdate"));
-    EXPECT_TRUE(execution_log[1].contains(u8"Update"));
-    EXPECT_TRUE(execution_log[2].contains(u8"PostUpdate"));
+    ASSERT_EQ(call_index, 3) << "All 3 systems must run.";
+    EXPECT_LT(pre_order, update_order) << "PreUpdate must run before Update.";
+    EXPECT_LT(update_order, post_order) << "Update must run before PostUpdate.";
 }
 
+
+// With<>/Without<> 필터 조건에 따라 시스템 실행 여부가 올바르게 제어되는지 검증합니다.
 TEST_F(ECSTest, ECSSystemComponentModificationAndQueries)
 {
-    World world;
+    WorldContext ctx;
 
-    // Create an entity with a component to be modified
-    auto entity = world.SpawnEntity()
-                       .AddComponent<TestValueComponent>({ .value = 10 })
-                       .AddComponent<TestTagComponent>();
+    // TestTagComponent 보유: With<TestTagComponent> 매칭, Without<TestTagComponent> 미매칭
+    auto entity = ctx.GetWorld().SpawnEntity()
+                     .AddComponent<TestValueComponent>({ .value = 10 })
+                     .AddComponent<TestTagComponent>();
 
-    // System to run in PreUpdate to add a value
-    world.AddSystem<PreUpdatePhase>([](Query<TestValueComponent&> query)
+    ctx.AddSystem<PreUpdatePhase>([](Query<TestValueComponent&> query)
     {
         for (auto [val] : query)
         {
-            val.value += 5; // 10 + 5 = 15
+            val.value += 5; // 10 -> 15
         }
     });
 
-    // System to run in Update to multiply the value
-    world.AddSystem<UpdatePhase>([](Query<TestValueComponent&, With<TestTagComponent>> query)
+    // With<TestTagComponent>: Tag 보유 엔티티만 매칭
+    ctx.AddSystem<UpdatePhase>([](Query<TestValueComponent&, With<TestTagComponent>> query)
     {
         for (auto [val] : query)
         {
-            val.value *= 2; // 15 * 2 = 30
+            val.value *= 2; // 15 -> 30
         }
     });
 
-    // System to run in PostUpdate on entities without the tag (should not run)
-    world.AddSystem<PostUpdatePhase>([](Query<TestValueComponent&, Without<TestTagComponent>> query)
+    // Without<TestTagComponent>: Tag 미보유 엔티티만 매칭 -> 현재 실행되지 않아야 합니다.
+    ctx.AddSystem<PostUpdatePhase>([](Query<TestValueComponent&, Without<TestTagComponent>> query)
     {
         for (auto [val] : query)
         {
-            val.value = 0; // This should not be executed
+            val.value = 0; // must not execute
         }
     });
 
+    ctx.RunPhase<PreUpdatePhase>();
+    ctx.RunPhase<UpdatePhase>();
+    ctx.RunPhase<PostUpdatePhase>();
 
-    // Run the schedules
-    world.RunPhase<PreUpdatePhase>();
-    world.RunPhase<UpdatePhase>();
-    world.RunPhase<PostUpdatePhase>();
-
-    // Verify the final value of the component
-    auto component = world.TryGetComponent<TestValueComponent>(entity);
+    auto component = ctx.GetWorld().TryGetComponent<TestValueComponent>(entity);
     ASSERT_TRUE(component.HasValue());
-    EXPECT_EQ(component->value, 30);
+    EXPECT_EQ(component->value, 30) << "Without<> system must not run while entity has the tag.";
 
-    // Verify that removing a component works with queries
-    world.RemoveComponent<TestTagComponent>(entity);
+    // Tag 제거 후: Without<> 시스템이 매칭되어 실행되어야 합니다.
+    ctx.GetWorld().RemoveComponent<TestTagComponent>(entity);
+    ctx.RunPhase<PostUpdatePhase>();
 
-    // This system should now run and set the value to 0
-    world.RunPhase<PostUpdatePhase>();
-
-    component = world.TryGetComponent<TestValueComponent>(entity);
+    component = ctx.GetWorld().TryGetComponent<TestValueComponent>(entity);
     ASSERT_TRUE(component.HasValue());
-    EXPECT_EQ(component->value, 0);
+    EXPECT_EQ(component->value, 0) << "Without<> system must run after tag is removed.";
 }
 
-// Keep the user's original test case as a compile-time check
-TEST_F(ECSTest, ECSSystemParameterCompilationTest)
+
+// 다중 Query 파라미터 주입, With<> 필터 동작, World* 파라미터 주입을 검증합니다.
+TEST_F(ECSTest, ECSQueryParameterInjection)
 {
-    World world;
+    WorldContext ctx;
 
-    world.SpawnEntity()
-         .AddComponent<TransformComponent>()
-         .AddComponent<StaticMeshComponent>();
+    // entity_a, entity_b: TransformComponent + StaticMeshComponent 모두 보유
+    ctx.GetWorld().SpawnEntity()
+       .AddComponent<TransformComponent>()
+       .AddComponent<StaticMeshComponent>();
 
-    world.SpawnEntity(
+    ctx.GetWorld().SpawnEntity(
         TransformComponent{
             .rotation = { 0.0, 0.0, 0.0, 1.0 },
             .position = { 1.0, 2.0, 3.0 },
             .scale = { 1.0, 1.0, 1.0 },
         },
-        StaticMeshComponent{
-            .mesh_id = asset::AssetId{ Guid::NewGuid() }
-        }
+        StaticMeshComponent{ .mesh_id = asset::AssetId{ Guid::NewGuid() } }
     );
 
-    // These AddSystem calls are primarily for compile-time validation of different parameter types.
-    // They don't need to be executed to be valuable.
-    world.AddSystem<UpdatePhase>([](
-        [[maybe_unused]] Query<TransformComponent&, With<>, Without<>> query1,
-        [[maybe_unused]] Query<TransformComponent&, With<StaticMeshComponent>, Without<>> query2,
-        [[maybe_unused]] Query<Entity, With<>, Without<>> query3
+    // entity_c: TransformComponent만 보유 (StaticMeshComponent 없음)
+    ctx.GetWorld().SpawnEntity()
+       .AddComponent<TransformComponent>();
+
+    // 타입이 다른 Query 3개가 동일 시스템에 동시에 주입되고,
+    // With<> 필터가 실제로 결과 집합을 좁히는지 카운트로 검증합니다.
+    ctx.AddSystem<UpdatePhase>([](
+        Query<TransformComponent&> query_all,
+        Query<TransformComponent&, With<StaticMeshComponent>> query_with_mesh,
+        Query<Entity> query_entity
     )
         {
-            constexpr usize query1_size = sizeof(query1);
-            constexpr usize query2_size = sizeof(query2);
-            constexpr usize query3_size = sizeof(query3);
+            usize count_all = 0;
+            usize count_mesh = 0;
+            usize count_entity = 0;
+            for ([[maybe_unused]] auto _ : query_all) ++count_all;
+            for ([[maybe_unused]] auto _ : query_with_mesh) ++count_mesh;
+            for ([[maybe_unused]] auto _ : query_entity) ++count_entity;
 
-            static_assert(query1_size == query2_size || query1_size != query3_size);
-            SUCCEED() << "System with multiple queries compiled and ran successfully.";
+            EXPECT_EQ(count_all, 3u) << "Expected 3 entities with TransformComponent.";
+            EXPECT_EQ(count_mesh, 2u) << "Expected 2 entities after With<StaticMeshComponent> filter.";
+            EXPECT_EQ(count_entity, 3u) << "Expected 3 total entities.";
+            EXPECT_LT(count_mesh, count_all) << "With<> filter must narrow the result set.";
         });
 
-    world.AddSystem<UpdatePhase>([](World* w)
+    // World* 파라미터가 null 없이 올바르게 주입되는지 검증합니다.
+    ctx.AddSystem<UpdatePhase>([](World* world)
     {
-        ASSERT_NE(w, nullptr) << "System received a null World pointer.";
+        ASSERT_NE(world, nullptr) << "World* parameter must not be null.";
     });
 
-    world.AddSystem<UpdatePhase>([](Query<Entity> query)
-    {
-        ASSERT_TRUE(!query.IsEmpty());
-        for (const auto& [entity] : query)
-        {
-            auto opt = query.Get(entity);
-            auto [ent] = *opt;
-
-            EXPECT_EQ(ent, entity);
-        }
-    });
-
-    [[maybe_unused]] Query query = world.QueryEntities<TransformComponent>();
-    [[maybe_unused]] Query query_entity = world.QueryEntities<Entity>();
-
-    world.RunPhase<UpdatePhase>();
+    ctx.RunPhase<UpdatePhase>();
 }
 
+
+// Optional<T&> 파라미터로 컴포넌트 유무에 관계없이 전 엔티티를 순회할 수 있는지 검증합니다.
 TEST_F(ECSTest, ECSSystemWithOptionalComponents)
 {
-    World world;
+    WorldContext ctx;
 
-    // Create entities
-    auto entity_with_component = world.SpawnEntity()
-                                      .AddComponent<TestValueComponent>({ .value = 100 });
+    auto entity_with = ctx.GetWorld().SpawnEntity()
+                          .AddComponent<TestValueComponent>({ .value = 100 });
+    auto entity_without = ctx.GetWorld().SpawnEntity(); // TestValueComponent 없음
 
-    auto entity_without_component = world.SpawnEntity();
-
-    // System that uses Optional to modify a component if it exists
-    world.AddSystem<UpdatePhase>([](Query<Optional<TestValueComponent&>> query)
+    // Optional<T&>: 컴포넌트가 없는 엔티티도 순회하되, HasValue()로 존재 여부를 확인합니다.
+    ctx.AddSystem<UpdatePhase>([](Query<Optional<TestValueComponent&>> query)
     {
         for (const auto& [opt_val] : query)
         {
@@ -193,35 +175,30 @@ TEST_F(ECSTest, ECSSystemWithOptionalComponents)
         }
     });
 
-    // Run the Phase
-    world.RunPhase<UpdatePhase>();
+    ctx.RunPhase<UpdatePhase>();
 
-    // Verify the component on the first entity was modified
-    auto component = world.TryGetComponent<TestValueComponent>(entity_with_component);
-    ASSERT_TRUE(component.HasValue());
-    EXPECT_EQ(component->value, 200);
+    auto comp_with = ctx.GetWorld().TryGetComponent<TestValueComponent>(entity_with);
+    ASSERT_TRUE(comp_with.HasValue());
+    EXPECT_EQ(comp_with->value, 200);
 
-    // Verify the second entity still does not have the component
-    auto component2 = world.TryGetComponent<TestValueComponent>(entity_without_component);
-    EXPECT_FALSE(component2.HasValue());
+    // 컴포넌트가 없는 엔티티는 영향을 받지 않아야 합니다.
+    EXPECT_FALSE(ctx.GetWorld().TryGetComponent<TestValueComponent>(entity_without).HasValue());
 
-    // System that adds the component if it's missing
-    world.AddSystem<PostUpdatePhase>([](Query<Entity, Optional<TestValueComponent&>> query, World* in_world)
+    // Optional + World* 혼합: 컴포넌트가 없는 엔티티에 새 컴포넌트를 추가합니다.
+    ctx.AddSystem<PostUpdatePhase>([](Query<Entity, Optional<TestValueComponent&>> query, World* world)
     {
         for (const auto& [entity, opt_val] : query)
         {
             if (!opt_val.HasValue())
             {
-                in_world->AddComponent<TestValueComponent>(entity, { .value = 50 });
+                world->AddComponent<TestValueComponent>(entity, { .value = 50 });
             }
         }
     });
 
-    // Run the second Phase
-    world.RunPhase<PostUpdatePhase>();
+    ctx.RunPhase<PostUpdatePhase>();
 
-    // Verify the second entity now has the component with the correct value
-    auto component3 = world.TryGetComponent<TestValueComponent>(entity_without_component);
-    ASSERT_TRUE(component3.HasValue());
-    EXPECT_EQ(component3->value, 50);
+    auto comp_added = ctx.GetWorld().TryGetComponent<TestValueComponent>(entity_without);
+    ASSERT_TRUE(comp_added.HasValue());
+    EXPECT_EQ(comp_added->value, 50);
 }


### PR DESCRIPTION
## 개요

기존 ECS 코어 로직을 전체적으로 개선하고, 주요 API를 역할에 맞도록 리네이밍, 정리를 하였습니다.

## 주요 변경사항

- `WorldSubsystem` -> `EntitySubsystem`으로 이름을 변경하였습니다.
- 기존 `World`는 ECS의 모든 역할을 담당하는 슈퍼클래스였으나, `World`(Entity, Component), `Schedule`(System)으로 역할을 분리하였습니다.
- `World`와 `Schedule`을 멤버로 가지는 `WorldContext`를 새로 추가하였습니다. 이제 `EntitySubsystem`에서는 `World`가 아닌, `WorldContext`를 관리합니다.
- 기존 System은 Functor객체만 받을 수 있어, System에 대해 추가 기능을 만들지 못했는데, Functor객체를 받는 `System`, `SystemChain` 클래스를 새로 추가하였습니다. 이로써 기존 System에서는 못했던 `.RunIf()`나 Chain 설정이 가능해졌습니다.
- `Query<Ts...>`의 requires문을 `QueryValidator`를 이용하여 최적화하였습니다.
- 기존 `World`에서 목적이 모호했던 API를 대거 정리하고, 역할에 맞게 리네이밍 하였습니다.
    - 사용하지 않는 friend 정리
    - System 관련 함수 제거
    - 로직이 중복되는 함수에 대해서 deducing this 적용
    - `QueryEntities` -> `CreateQuery`
    - `GetStorage` -> `FindSparseSet`
    - `GetOrCreateStorage` -> `GetOrCreateSparseSet`
    - public `GetStorage` -> `FindRawStorage`, `GetOrCreateRawStorage`로 명확하게 분리
- `std::decay_t`대신 `std::remove_cvref_t`를 사용하여, 의도치 않은 타입 변환(Array-to-Pointer 붕괴 등)을 방지하고 타입 안전성을 높였습니다.
