### PR TITLE
[Optimize] ECS Query 순회 로직 최적화

### DIFF
--- a/EngineCore/Include/SimpleEngine/ECS/Query.h
+++ b/EngineCore/Include/SimpleEngine/ECS/Query.h
@@ -15,28 +15,88 @@
 
 namespace se
 {
+namespace detail
+{
+/** 쿼리 파라미터(T)의 읽기/쓰기 권한에 맞는 Pool(SparseSet) 포인터 타입을 추론합니다. */
+template <typename T>
+using PoolPtrType = std::conditional_t<
+    std::same_as<std::remove_cvref_t<T>, Entity>,
+    void*, // Entity는 Pool이 필요 없으므로 더미 포인터 반환
+    std::conditional_t<
+        IsReadOnlyType<T>::Value,
+        const SparseSet<std::remove_cvref_t<traits::InnerOf<T>>>*, // 읽기 전용 쿼리 -> const Pool
+        SparseSet<std::remove_cvref_t<traits::InnerOf<T>>>*        // 쓰기 가능 쿼리 -> 일반 Pool
+    >
+>;
+
+/** World에서 캐싱 용도로 사용할 SparseSet 포인터를 추출합니다. */
+template <typename TargetWorld, typename T>
+static PoolPtrType<T> GetPoolPtr(TargetWorld& world)
+{
+    // Entity는 무시
+    if constexpr (std::same_as<std::remove_cvref_t<T>, Entity>)
+    {
+        return nullptr;
+    }
+    else
+    {
+        using ComponentType = std::remove_cvref_t<traits::InnerOf<T>>;
+
+        auto opt = world.template FindSparseSet<ComponentType>();
+        return opt ? std::addressof(*opt) : nullptr;
+    }
+}
+} // namespace detail
+
 /**
- * 조건에 맞는 엔티티와 컴포넌트들을 순회(iterate)하기 위한 인터페이스입니다.
+ * 조건에 맞는 Entity와 컴포넌트들을 순회(iterate)하기 위한 인터페이스입니다.
  * @tparam Ts 조회할 컴포넌트 타입들
  */
 template <typename... Ts>
-    requires QueryParameterPack<Ts...>
 class Query
 {
+    using Validator = detail::QueryValidator<Ts...>;
+
+    static_assert(Validator::HasElements,
+        "Query requires at least one component or filter tag.");
+
+    static_assert(Validator::IsUnique,
+        "Query parameters must be unique. Duplicate types are not allowed.");
+
+    static_assert(Validator::NoPointers,
+        "Raw pointers are not permitted in Query. Use value (T) or reference (T&) types.");
+
+    static_assert(Validator::AllValidComponents,
+        "Query parameters must be valid component types (class/struct) or filter tags (With/Without).");
+
+private:
     friend class Iterator;
 
+    /** 필터링 조건 및 스토리지 캐싱 관리 */
     using QueryDataType = detail::QueryData<Ts...>;
-    using FetchTypes = QueryDataType::FetchTypes;
+
+    /** Query 권한에 따른 월드 타입 (const World / World) */
     using TargetWorld = QueryDataType::TargetWorld;
 
-    static constexpr bool HasBasePool = std::tuple_size_v<typename QueryDataType::PredicateTypes> > 0;
-    using IterationSourceType = std::conditional_t<HasBasePool, const IStorage*, const Array<Entity>*>;
+    /** 순회 시 반환할 컴포넌트 팩 (Tuple) */
+    using FetchTypes = QueryDataType::FetchTypes;
+
+    /** 조회를 위한 SparseSet 포인터 Tuple */
+    template <typename T>
+    using PoolPtrWrapper = detail::PoolPtrType<T>;
+    using FetchPoolsTuple = traits::TupleMap<FetchTypes, PoolPtrWrapper>;
+
+    /** 쿼리의 순회 범위가 특정 컴포넌트로 제한되는지 여부 (필수 컴포넌트 존재 여부) */
+    static constexpr bool IsComponentRestricted = QueryDataType::NumPredicates > 0;
+
+    /** 순회 대상 소스 타입: 제한된 경우 IStorage(Pool), 아닌 경우 전체 Entity 배열 */
+    using IterationSourceType = std::conditional_t<IsComponentRestricted, const IStorage*, const Array<Entity>*>;
 
 public:
     explicit Query(TargetWorld& in_world)
         : query_data(in_world)
     {
-        if constexpr (HasBasePool)
+        if constexpr (IsComponentRestricted)
         {
             iteration_source = query_data.FindSmallestPool();
         }
@@ -44,6 +104,12 @@ public:
         {
             iteration_source = &in_world.GetAliveEntities();
         }
+
+        // FetchPool 캐싱
+        fetch_pools = traits::ApplyTypes<FetchTypes>([&in_world]<typename... FetchTs>
+        {
+            return FetchPoolsTuple{ detail::GetPoolPtr<TargetWorld, FetchTs>(in_world)... };
+        });
     }
 
     ~Query() = default;
@@ -54,22 +120,15 @@ public:
     Query& operator=(Query&&) noexcept = default;
 
 public:
-    /** 쿼리 결과가 비어있는지 확인합니다. */
-    [[nodiscard]] bool IsEmpty() const
-    {
-        return begin() == end();
-    }
-
-    /** 특정 엔티티가 쿼리 조건을 만족하는 경우, 해당 컴포넌트들을 반환합니다. */
+    /** 특정 Entity가 쿼리 조건을 만족하는 경우, 해당 컴포넌트들을 반환합니다. */
     [[nodiscard]] Optional<FetchTypes> TryGet(Entity entity) const
     {
         if (query_data.IsEntityValid(entity))
         {
-            TargetWorld& world = query_data.GetWorld();
-            return traits::ApplyTypes<FetchTypes>([&world, entity]<typename... FetchComps>
+            return [this, entity]<usize... Is>(std::index_sequence<Is...>)
             {
-                return FetchTypes{ Fetch<FetchComps>(world, entity)... };
-            });
+                return FetchTypes{ FetchComponent<std::tuple_element_t<Is, FetchTypes>, Is>(entity)... };
+            }(std::make_index_sequence<std::tuple_size_v<FetchTypes>>{});
         }
         return NullOpt;
     }
@@ -106,23 +165,19 @@ public:
         return result;
     }
 
+    /** 쿼리 결과가 비어있는지 확인합니다. */
+    [[nodiscard]] bool IsEmpty() const
+    {
+        return begin() == end();
+    }
+
 private:
-    template <typename T>
-    static decltype(auto) Fetch(TargetWorld& world, Entity entity)
+    template <typename T, usize Idx>
+    T FetchComponent(Entity entity) const
     {
         using RawType = std::remove_cvref_t<T>;
 
-        if constexpr (traits::OptionalLike<RawType>)
-        {
-            static_assert(
-                !std::is_reference_v<T>,
-                "Optional<T> in a Query must be fetched by value, not by reference."
-            );
-
-            using InnerType = std::remove_cvref_t<traits::InnerOf<RawType>>;
-            return world.template TryGetComponent<InnerType>(entity);
-        }
-        else if constexpr (std::same_as<RawType, Entity>)
+        if constexpr (std::same_as<RawType, Entity>)
         {
             static_assert(
                 !std::is_reference_v<T>,
@@ -130,9 +185,24 @@ private:
             );
             return entity;
         }
+        else if constexpr (traits::OptionalLike<RawType>)
+        {
+            static_assert(
+                !std::is_reference_v<T>,
+                "Optional<T> in a Query must be fetched by value, not by reference."
+            );
+
+            if (auto* pool = std::get<Idx>(fetch_pools))
+            {
+                return pool->Find(entity);
+            }
+            return NullOpt;
+        }
         else
         {
-            return world.template GetComponent<RawType>(entity);
+            auto* pool = std::get<Idx>(fetch_pools);
+            SE_ASSERT(pool != nullptr, "Query fetch failed: Required component pool is missing!");
+            return pool->Get(entity);
         }
     }
 
@@ -145,19 +215,18 @@ public:
         using difference_type = std::ptrdiff_t;
 
     public:
-        Iterator(const Query* self, usize in_index)
-            : query_data(&self->query_data)
+        Iterator(const Query* in_query, usize in_index)
+            : query(in_query)
             , storage_index(in_index)
-            , iteration_source(self->iteration_source)
+            , iteration_source(in_query->iteration_source)
         {
             AdvanceToValid();
         }
 
         value_type operator*() const noexcept
         {
-            TargetWorld& world = query_data->GetWorld();
             Entity entity;
-            if constexpr (HasBasePool)
+            if constexpr (IsComponentRestricted)
             {
                 entity = iteration_source->GetEntityByIndex(storage_index).Value();
             }
@@ -166,11 +235,11 @@ public:
                 entity = (*iteration_source)[storage_index];
             }
 
-            // FetchTypes에 명시된 컴포넌트들을 월드에서 가져와 튜플로 묶어 반환
-            return traits::ApplyTypes<value_type>([&world, entity]<typename... FetchComps>
+            // 해시맵 조회 없이 인덱스 시퀀스를 이용해 다이렉트 접근
+            return [this, entity]<usize... Is>(std::index_sequence<Is...>)
             {
-                return value_type{ Fetch<FetchComps>(world, entity)... };
-            });
+                return value_type{ query->FetchComponent<std::tuple_element_t<Is, FetchTypes>, Is>(entity)... };
+            }(std::make_index_sequence<std::tuple_size_v<FetchTypes>>{});
         }
 
         Iterator& operator++()
@@ -188,19 +257,19 @@ public:
     private:
         void AdvanceToValid()
         {
-            if constexpr (HasBasePool)
+            if constexpr (IsComponentRestricted)
             {
                 if (!iteration_source) [[unlikely]]
                 {
-                    // FindSmallestPool이 nullptr을 반환하는 경우 (예: 해당 컴포넌트를 가진 엔티티가 없음)
+                    // FindSmallestPool이 nullptr을 반환하는 경우 (예: 해당 컴포넌트를 가진 Entity가 없음)
                     storage_index = 0;
                     return;
                 }
                 while (storage_index < iteration_source->Len())
                 {
-                    if (Optional entity_opt = iteration_source->GetEntityByIndex(storage_index))
+                    if (const auto entity = iteration_source->GetEntityByIndex(storage_index))
                     {
-                        if (query_data->IsEntityValid(*entity_opt))
+                        if (query->query_data.IsEntityValid(*entity))
                         {
                             return;
                         }
@@ -212,10 +281,11 @@ public:
             {
                 SE_ASSERT(iteration_source);
 
+                // ReSharper disable once CppDFANullDereference
                 const auto& entities = *iteration_source;
                 while (storage_index < entities.Len())
                 {
-                    if (query_data->IsEntityValid(entities[storage_index]))
+                    if (query->query_data.IsEntityValid(entities[storage_index]))
                     {
                         return;
                     }
@@ -225,7 +295,7 @@ public:
         }
 
     private:
-        const QueryDataType* query_data;
+        const Query* query;
         usize storage_index;
         IterationSourceType iteration_source;
     };
@@ -237,23 +307,13 @@ public:
 
     [[nodiscard]] Iterator end() const
     {
-        usize end_index = 0;
-        if constexpr (HasBasePool)
-        {
-            if (iteration_source)
-            {
-                end_index = iteration_source->Len();
-            }
-        }
-        else
-        {
-            end_index = iteration_source->Len();
-        }
+        usize end_index = iteration_source ? iteration_source->Len() : 0;
         return Iterator{ this, end_index };
     }
 
 private:
     QueryDataType query_data;
+    FetchPoolsTuple fetch_pools;
     IterationSourceType iteration_source;
 };
 } // namespace se

--- a/EngineCore/Include/SimpleEngine/ECS/Query.h
+++ b/EngineCore/Include/SimpleEngine/ECS/Query.h
@@ -21,7 +21,7 @@ namespace detail
 template <typename T>
 using PoolPtrType = std::conditional_t<
     std::same_as<std::remove_cvref_t<T>, Entity>,
-    void*, // Entity는 Pool이 필요 없으므로 더미 포인터 반환
+    EmptyType, // Entity는 Pool이 필요 없음
     std::conditional_t<
         IsReadOnlyType<T>::Value,
         const SparseSet<std::remove_cvref_t<traits::InnerOf<T>>>*, // 읽기 전용 쿼리 -> const Pool
@@ -36,7 +36,7 @@ static PoolPtrType<T> GetPoolPtr(TargetWorld& world)
     // Entity는 무시
     if constexpr (std::same_as<std::remove_cvref_t<T>, Entity>)
     {
-        return nullptr;
+        return EmptyType{};
     }
     else
     {

--- a/EngineCore/Include/SimpleEngine/ECS/QueryConcepts.h
+++ b/EngineCore/Include/SimpleEngine/ECS/QueryConcepts.h
@@ -52,15 +52,14 @@ concept IsFetchType = !(traits::IsSpecializationOf<T, With> || traits::IsSpecial
 template <typename T>
 concept IsRequiredComponent = IsFetchType<T> && !(traits::OptionalLike<T> || std::same_as<T, Entity>);
 
-/** Query로 들어온 인자가 올바른 타입인지 확인합니다. */
 template <typename... Ts>
-struct QueryValidator;
+struct QueryValidatorImpl;
 
 template <
     template <typename...> typename TupleLike,
     typename... ProcessedTs
 >
-struct QueryValidator<TupleLike<ProcessedTs...>>
+struct QueryValidatorImpl<TupleLike<ProcessedTs...>>
 {
     // 최소 1개 이상의 파라미터가 있는지
     static constexpr bool HasElements = sizeof...(ProcessedTs) > 0;
@@ -73,9 +72,6 @@ struct QueryValidator<TupleLike<ProcessedTs...>>
 
     // 모든 타입이 유효한 컴포넌트(class/struct)인지
     static constexpr bool AllValidComponents = (std::is_class_v<ProcessedTs> && ...);
-
-    // 최종 결과
-    static constexpr bool IsValidPack = HasElements && IsUnique && NoPointers && AllValidComponents;
 };
 
 /**
@@ -89,6 +85,10 @@ using ProcessedQueryTuple = traits::TupleMap<
     std::remove_cvref_t
 >;
 
+/** Query로 들어온 인자가 올바른 타입인지 확인합니다. */
+template <typename... Ts>
+using QueryValidator = QueryValidatorImpl<ProcessedQueryTuple<Ts...>>;
+
 /** 단일 쿼리 파라미터가 원본 데이터를 수정하지 않는 읽기 전용 타입인지 확인합니다. */
 template <typename T>
 struct IsReadOnlyType
@@ -101,7 +101,4 @@ struct IsReadOnlyType
 template <typename... Ts>
 constexpr bool IsReadOnlyQueryPack = (IsReadOnlyType<Ts>::Value && ...);
 } // namespace detail
-
-template <typename... Ts>
-concept QueryParameterPack = detail::QueryValidator<detail::ProcessedQueryTuple<Ts...>>::IsValidPack;
 } // namespace se

--- a/EngineCore/Include/SimpleEngine/ECS/QueryData.h
+++ b/EngineCore/Include/SimpleEngine/ECS/QueryData.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "SimpleEngine/Core/Container/FixedArray.h"
 #include "SimpleEngine/Core/Container/Optional.h"
 #include "SimpleEngine/ECS/Entity.h"
 #include "SimpleEngine/ECS/IStorage.h"
@@ -8,6 +9,7 @@
 #include "SimpleEngine/Traits/TupleTraits.h"
 #include "SimpleEngine/Traits/TypeTraits.h"
 
+#include <algorithm>
 #include <memory>
 #include <tuple>
 #include <type_traits>
@@ -88,10 +90,18 @@ public:
         // Without Storage 캐싱
         if constexpr (NumWithout > 0)
         {
-            without_pools = traits::ApplyTypes<WithoutTypes>([this]<typename... WithoutComps> -> decltype(without_pools)
+            auto temp_without_pools = traits::ApplyTypes<WithoutTypes>([this]<typename... WithoutComps> -> decltype(without_pools)
             {
                 return { world->template FindRawStorage<std::remove_cvref_t<WithoutComps>>()... };
             });
+
+            for (const IStorage* pool : temp_without_pools)
+            {
+                if (pool != nullptr)
+                {
+                    without_pools[valid_without_count++] = pool;
+                }
+            }
         }
     }
 
@@ -117,10 +127,10 @@ public:
 
         // 제외 조건 확인 (Without 목록)
         // ComponentPool에 Entity가 하나라도 존재하면 안 됨
-        for (const IStorage* pool : without_pools)
+        for (usize i = 0; i < valid_without_count; ++i)
         {
             // 제외 조건에 있을경우 return
-            if (pool && pool->Contains(entity))
+            if (without_pools[i]->Contains(entity))
             {
                 return false;
             }
@@ -157,7 +167,7 @@ private:
     // 매번 HashMap 조회를 피하기 위한 IStorage* 배열
     FixedArray<const IStorage*, NumPredicates> predicate_pools{};
     FixedArray<const IStorage*, NumWithout> without_pools{};
-
+    usize valid_without_count = 0;
     // 쿼리가 유효한지 검증하는 flag
     bool is_valid_query = true;
 };

--- a/EngineCore/Include/SimpleEngine/ECS/QueryData.h
+++ b/EngineCore/Include/SimpleEngine/ECS/QueryData.h
@@ -8,7 +8,6 @@
 #include "SimpleEngine/Traits/TupleTraits.h"
 #include "SimpleEngine/Traits/TypeTraits.h"
 
-#include <concepts>
 #include <memory>
 #include <tuple>
 #include <type_traits>
@@ -48,14 +47,14 @@ struct WithoutTagPred { static constexpr bool Value = traits::IsSpecializationOf
 
 
 /**
- * 쿼리 파라미터를 분석하고, 엔티티 유효성을 검증하는 로직을 캡슐화한 클래스
+ * 쿼리 파라미터를 분석하고, Entity 유효성을 검증하는 로직을 캡슐화한 클래스
  * @tparam Ts 쿼리 파라미터 타입들 (컴포넌트 타입 및 필터 태그)
  */
 template <typename... Ts>
 class QueryData
 {
 public:
-    // Query가 읽기 전용인지 확인 (const World 참조)
+    // Query가 읽기 전용인지 확인
     static constexpr bool IsReadOnly = IsReadOnlyQueryPack<Ts...>;
     using TargetWorld = std::conditional_t<IsReadOnly, const World, World>;
 
@@ -64,70 +63,88 @@ public:
     using WithTypes = FlatFilterTypes<WithTagPred, Ts...>;
     using WithoutTypes = FlatFilterTypes<WithoutTagPred, Ts...>;
 
-    // 실제 Query 검증에 사용되는 타입들
+    // 실제 Query 검증에 사용되는 타입들(Fetch(Optional, Entity 제외) + With)
     using PredicateTypes = traits::TupleCat<FlatFilterTypes<RequiredComponentPred, Ts...>, WithTypes>;
+
+    static constexpr usize NumPredicates = std::tuple_size_v<PredicateTypes>;
+    static constexpr usize NumWithout = std::tuple_size_v<WithoutTypes>;
 
 public:
     explicit QueryData(TargetWorld& in_world)
         : world(std::addressof(in_world))
     {
-    }
-
-    /** 엔티티가 쿼리의 모든 조건(With, Without)을 만족하는지 검증합니다. */
-    [[nodiscard]] bool IsEntityValid(Entity entity) const
-    {
-        // FIXME: 이 함수에서 제일 병목이 심함.
-        //        Query<...>::Iterator::AdvanceToValid -> IsEntityValid
-        //        HasComponent -> FindSparseSet -> FindRawStorage -> component_storages.Find(type_id)
-        //        HashMap의 조회비용이 Query의 가장 큰 병목으로 확인
-        //
-        // 현재는 매번 Smallest Component Storage의 Entity마다 HasComponent를 호출하고 있음.
-
-        // Fetch(Optional<T> 제외)와 With 목록의 모든 컴포넌트를 가졌는지 확인
-        const bool has_all_required =
-            traits::ApplyTypes<PredicateTypes>([this, entity]<typename... PredComps>
-            {
-                return (world->template HasComponent<std::remove_cvref_t<PredComps>>(entity) && ...);
-            });
-
-        if (!has_all_required)
+        // Predicate Storage 캐싱
+        if constexpr (NumPredicates > 0)
         {
-            return false;
-        }
-
-        // Without 목록의 컴포넌트를 하나라도 가졌는지 확인
-        const bool has_any_excluded =
-            traits::ApplyTypes<WithoutTypes>([this, entity]<typename... WithoutComps>
-            {
-                return (world->template HasComponent<std::remove_cvref_t<WithoutComps>>(entity) || ...);
-            });
-
-        return !has_any_excluded;
-    }
-
-    /** 순회 범위를 최소화하기 위해 가장 작은 컴포넌트 풀(Storage)을 찾습니다. */
-    [[nodiscard]] const IStorage* FindSmallestPool() const
-    {
-        // 순회의 기준이 될 PredicateTypes(필수 컴포넌트 + With)의 총 개수
-        constexpr usize pool_size = std::tuple_size_v<PredicateTypes>;
-        if constexpr (pool_size == 0)
-        {
-            return nullptr;
-        }
-
-        // 각 컴포넌트 스토리지 포인터를 배열에 수집
-        const auto pools =
-            traits::ApplyTypes<PredicateTypes>([this]<typename... PredComps> -> FixedArray<const IStorage*, pool_size>
+            predicate_pools = traits::ApplyTypes<PredicateTypes>([this]<typename... PredComps> -> decltype(predicate_pools)
             {
                 return { world->template FindRawStorage<std::remove_cvref_t<PredComps>>()... };
             });
 
-        // 수집된 스토리지 중 가장 크기가 작은 것을 찾아 반환
-        return *std::ranges::min_element(pools, [](const IStorage* a, const IStorage* b)
-        {
-            if (!a) { return false; }
-            if (!b) { return true; }
+            // 아직 만들어지지 않은 Storage가 1개라도 있는 경우 -> 조건에 부합하지 않음
+            is_valid_query = std::ranges::all_of(predicate_pools, [](const IStorage* pool) { return pool != nullptr; });
+        }
 
+        // Without Storage 캐싱
+        if constexpr (NumWithout > 0)
+        {
+            without_pools = traits::ApplyTypes<WithoutTypes>([this]<typename... WithoutComps> -> decltype(without_pools)
+            {
+                return { world->template FindRawStorage<std::remove_cvref_t<WithoutComps>>()... };
+            });
+        }
+    }
+
+    /** Entity가 쿼리의 모든 조건(With, Without)을 만족하는지 검증합니다. */
+    [[nodiscard]] bool IsEntityValid(Entity entity) const
+    {
+        // 쿼리 자체가 유효하지 않으면 return
+        if (!is_valid_query)
+        {
+            return false;
+        }
+
+        // 필수 포함 조건 확인 (Fetch(Optional<T> 제외)와 With 목록)
+        // 모든 ComponentPool에 Entity가 존재해야 함
+        for (const IStorage* pool : predicate_pools)
+        {
+            // 필수 조건에 부합하지 않으면 return
+            if (!pool->Contains(entity))
+            {
+                return false;
+            }
+        }
+
+        // 제외 조건 확인 (Without 목록)
+        // ComponentPool에 Entity가 하나라도 존재하면 안 됨
+        for (const IStorage* pool : without_pools)
+        {
+            // 제외 조건에 있을경우 return
+            if (pool && pool->Contains(entity))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /** 순회 범위를 최소화하기 위해 가장 작은 ComponentPool을 찾습니다. */
+    [[nodiscard]] const IStorage* FindSmallestPool() const
+    {
+        if constexpr (NumPredicates == 0)
+        {
+            return nullptr;
+        }
+
+        if (!is_valid_query)
+        {
+            return nullptr;
+        }
+
+        // 필수 ComponentPool 중 가장 크기가 작은 것을 찾아 반환
+        return *std::ranges::min_element(predicate_pools, [](const IStorage* a, const IStorage* b)
+        {
             return a->Len() < b->Len();
         });
     }
@@ -136,5 +153,12 @@ public:
 
 private:
     TargetWorld* world;
+
+    // 매번 HashMap 조회를 피하기 위한 IStorage* 배열
+    FixedArray<const IStorage*, NumPredicates> predicate_pools{};
+    FixedArray<const IStorage*, NumWithout> without_pools{};
+
+    // 쿼리가 유효한지 검증하는 flag
+    bool is_valid_query = true;
 };
 } // namespace se::detail

--- a/EngineCore/Include/SimpleEngine/ECS/SparseSet.h
+++ b/EngineCore/Include/SimpleEngine/ECS/SparseSet.h
@@ -16,16 +16,6 @@ namespace se
 template <typename ComponentType>
 class SparseSet
 {
-private:
-    /** EntityID -> DenseIdx */
-    Array<Optional<usize>> sparse;
-
-    /** Entity array */
-    Array<Entity> dense;
-
-    /** Component array */
-    Array<ComponentType> components;
-
 public:
     explicit SparseSet() = default;
 
@@ -36,13 +26,13 @@ public:
     {
         if (entity.GetId() >= sparse.Len())
         {
-            sparse.Resize(entity.GetId() + 1, NullOpt);
+            sparse.Resize(entity.GetId() + 1, INVALID_INDEX);
         }
 
         // 이미 존재하면 덮어쓰기
         if (Contains(entity))
         {
-            components[*sparse[entity.GetId()]] = std::forward<T>(component);
+            components[sparse[entity.GetId()]] = std::forward<T>(component);
             return;
         }
 
@@ -60,7 +50,7 @@ public:
             return;
         }
 
-        const usize remove_idx = *sparse[entity.GetId()];
+        const usize remove_idx = sparse[entity.GetId()];
         const Entity last_entity = *dense.Back();
 
         // swap-remove
@@ -71,7 +61,7 @@ public:
 
         dense.Pop();
         components.Pop();
-        sparse[entity.GetId()] = NullOpt;
+        sparse[entity.GetId()] = INVALID_INDEX;
     }
 
     /** Set에 Entity가 있는지 확인합니다. */
@@ -82,12 +72,8 @@ public:
             return false;
         }
 
-        if (const Optional<usize> dense_idx_opt = sparse[entity.GetId()])
-        {
-            const auto dense_idx = *dense_idx_opt;
-            return dense_idx < dense.Len() && dense[dense_idx] == entity;
-        }
-        return false;
+        const auto dense_idx = sparse[entity.GetId()];
+        return dense_idx < dense.Len() && dense[dense_idx] == entity;
     }
 
     /** Dense 배열의 인덱스로 Entity를 가져옵니다. */
@@ -113,7 +99,7 @@ public:
     {
         if (self.Contains(entity))
         {
-            return self.components[*self.sparse[entity.GetId()]];
+            return self.components[self.sparse[entity.GetId()]];
         }
         return NullOpt;
     }
@@ -206,5 +192,18 @@ public:
     [[nodiscard]] IteratorType end() { return IteratorType(dense.end(), components.end()); }
     [[nodiscard]] ConstIteratorType begin() const { return ConstIteratorType(dense.begin(), components.begin()); }
     [[nodiscard]] ConstIteratorType end() const { return ConstIteratorType(dense.end(), components.end()); }
+
+private:
+    static constexpr usize INVALID_INDEX = std::numeric_limits<usize>::max();
+
+    /** EntityID -> DenseIdx */
+    Array<usize> sparse;
+
+    /** Entity array */
+    Array<Entity> dense;
+
+    /** Component array */
+    Array<ComponentType> components;
+
 };
 } // namespace se

--- a/EngineCore/Include/SimpleEngine/ECS/World.h
+++ b/EngineCore/Include/SimpleEngine/ECS/World.h
@@ -18,7 +18,6 @@ namespace se
 {
 // forward declaration
 template <typename... Ts>
-    requires QueryParameterPack<Ts...>
 class Query;
 
 

--- a/EngineTest/Source/Benchmark/ECSBenchmark.cpp
+++ b/EngineTest/Source/Benchmark/ECSBenchmark.cpp
@@ -1,0 +1,147 @@
+#include <benchmark/benchmark.h>
+#include "SimpleEngine/ECS/World.h"
+#include "SimpleEngine/ECS/Query.h"
+
+namespace se::benchmark_test
+{
+    struct Position { float x, y, z; };
+    struct Velocity { float vx, vy, vz; };
+    struct Acceleration { float ax, ay, az; };
+
+    static void BM_ECS_Query_SingleComponent(benchmark::State& state)
+    {
+        World world;
+        const int n = static_cast<int>(state.range(0));
+        for (int i = 0; i < n; ++i)
+        {
+            world.SpawnEntity(Position{ (float)i, (float)i, (float)i });
+        }
+
+        auto query = world.CreateQuery<Position&>();
+
+        for (auto _ : state)
+        {
+            for (auto [pos] : query)
+            {
+                pos.x += 1.0f;
+                benchmark::DoNotOptimize(pos);
+            }
+        }
+    }
+    BENCHMARK(BM_ECS_Query_SingleComponent)->Range(100, 100000);
+
+    static void BM_ECS_Query_TwoComponents(benchmark::State& state)
+    {
+        World world;
+        const int n = static_cast<int>(state.range(0));
+        for (int i = 0; i < n; ++i)
+        {
+            auto entity = world.SpawnEntity(Position{ (float)i, (float)i, (float)i });
+            if (i % 2 == 0)
+            {
+                world.AddComponent(entity, Velocity{ 1.0f, 1.0f, 1.0f });
+            }
+        }
+
+        auto query = world.CreateQuery<Position&, Velocity&>();
+
+        for (auto _ : state)
+        {
+            for (auto [pos, vel] : query)
+            {
+                pos.x += vel.vx;
+                benchmark::DoNotOptimize(pos);
+                benchmark::DoNotOptimize(vel);
+            }
+        }
+    }
+    BENCHMARK(BM_ECS_Query_TwoComponents)->Range(100, 100000);
+
+    static void BM_ECS_Query_ThreeComponents(benchmark::State& state)
+    {
+        World world;
+        const int n = static_cast<int>(state.range(0));
+        for (int i = 0; i < n; ++i)
+        {
+            auto entity = world.SpawnEntity(Position{ (float)i, (float)i, (float)i });
+            if (i % 2 == 0)
+            {
+                world.AddComponent(entity, Velocity{ 1.0f, 1.0f, 1.0f });
+            }
+            if (i % 3 == 0)
+            {
+                world.AddComponent(entity, Acceleration{ 0.1f, 0.1f, 0.1f });
+            }
+        }
+
+        auto query = world.CreateQuery<Position&, Velocity&, Acceleration&>();
+
+        for (auto _ : state)
+        {
+            for (auto [pos, vel, acc] : query)
+            {
+                vel.vx += acc.ax;
+                pos.x += vel.vx;
+                benchmark::DoNotOptimize(pos);
+                benchmark::DoNotOptimize(vel);
+                benchmark::DoNotOptimize(acc);
+            }
+        }
+    }
+    BENCHMARK(BM_ECS_Query_ThreeComponents)->Range(100, 100000);
+
+    // Filter benchmarks (With/Without)
+    static void BM_ECS_Query_Filter_With(benchmark::State& state)
+    {
+        World world;
+        const int n = static_cast<int>(state.range(0));
+        for (int i = 0; i < n; ++i)
+        {
+            auto entity = world.SpawnEntity(Position{ (float)i, (float)i, (float)i });
+            if (i % 10 == 0)
+            {
+                world.AddComponent(entity, Velocity{ 1.0f, 1.0f, 1.0f });
+            }
+        }
+
+        // Only iterate entities with Position AND Velocity, but only fetch Position
+        auto query = world.CreateQuery<Position&, With<Velocity>>();
+
+        for (auto _ : state)
+        {
+            for (auto [pos] : query)
+            {
+                pos.x += 1.0f;
+                benchmark::DoNotOptimize(pos);
+            }
+        }
+    }
+    BENCHMARK(BM_ECS_Query_Filter_With)->Range(100, 100000);
+
+    static void BM_ECS_Query_Filter_Without(benchmark::State& state)
+    {
+        World world;
+        const int n = static_cast<int>(state.range(0));
+        for (int i = 0; i < n; ++i)
+        {
+            auto entity = world.SpawnEntity(Position{ (float)i, (float)i, (float)i });
+            if (i % 10 == 0)
+            {
+                world.AddComponent(entity, Velocity{ 1.0f, 1.0f, 1.0f });
+            }
+        }
+
+        // Iterate entities with Position but WITHOUT Velocity
+        auto query = world.CreateQuery<Position&, Without<Velocity>>();
+
+        for (auto _ : state)
+        {
+            for (auto [pos] : query)
+            {
+                pos.x += 1.0f;
+                benchmark::DoNotOptimize(pos);
+            }
+        }
+    }
+    BENCHMARK(BM_ECS_Query_Filter_Without)->Range(100, 100000);
+}


### PR DESCRIPTION
## 1. 배경 및 문제 상황

- 벤치마크를 돌려본 결과, ECS `Query` 순회 성능이 생각보다 엄청 느렸음.

## 2. 프로파일링 결과 (원인 분석)

- 성능 저하의 원인을 찾기 위해 프로파일러를 돌려본 결과, 런타임의 대부분이 `FindRawStorage`에서 낭비되고 있음을 확인
- `FindRawStorage` 다음으로는 `SparseSet`의 `Contains`에서 허비됨.

> **빌드 프리셋**: Development
> JetBrains DotTrace와 Visual Studio 18의 Profiler를 사용하여 측정

- **현상**: 순회 루프를 돌 때마다 컴포넌트를 가져오기 위해 `FindRawStorage`가 반복 호출됨.
- **병목 수치 (BM 기준)**:
  - `Query<Pos&, Vel&>` (컴포넌트 2개): 단일 쿼리 실행 시간의 **약 72%**가 해시맵 조회에 낭비.
  - `With`, `Without` 필터 적용 시에도 최대 **71%** 이상의 낭비 발생.
- **결론**: 매 루프마다 발생하는 해시맵 조회와 내부 `StringView` 생성 비용이 CPU 캐시 라인을 파괴하여 성능을 심각하게 갉아먹고 있었음을 확인. 또한 `SparseSet` 에서는 `sparse` Array가 `Optional<usize>`를 가지고 있어, 캐시 효율이 급감하는것을 확인

## 3. 해결 방안 (아키텍처 개선)

- **포인터 캐싱 도입($O(1)$ 접근)**: `Query` 생성 시점에 `TargetWorld`로부터 필요한 `SparseSet` 포인터들을 미리 찾아 `FetchPoolsTuple`에 캐싱
- **Optional 대신 INVALID_INDEX 도입 (메모리 및 캐시 최적화)**: `SparseSet`의 `sparse` 멤버를 `Array<Optional<usize>>`에서 `Array<usize>`로 변경하여 `Optional`의 bool 플래그로 인해 발생하던 메모리 패딩(16바이트)을 제거. 데이터 크기를 절반(8바이트)으로 줄여 한 번에 L1 캐시에 올라가는 데이터양을 두 배로 늘리고, 불필요한 조건 분기를 없애 메모리 접근 대역폭을 극대화함.

## 4. 벤치마크 결과

### 4.1. 1차 최적화 결과 (포인터 캐싱 도입)
- **테스트 파일**: `EngineTest/Source/Benchmark/ECSBenchmark.cpp`
- **테스트 환경**: 엔티티 100,000개 기준 (가장 부하가 큰 스트레스 테스트 조건)

| 벤치마크 (100,000 Entities) | Before | After | 배수 (Speedup) |
| :--- | :--- | :--- | :--- |
| `BM_ECS_Query_SingleComponent` | 3.84 ms | **0.53 ms** | **7.23x** |
| `BM_ECS_Query_TwoComponents` | 4.00 ms | **0.46 ms** | **8.68x** |
| `BM_ECS_Query_ThreeComponents` | 2.49 ms | **0.27 ms** | **9.21x** |
| `BM_ECS_Query_Filter_With` | 0.60 ms | **0.07 ms** | **8.39x** |
| `BM_ECS_Query_Filter_Without` | 6.14 ms | **0.64 ms** | **9.57x** |

<img width="1100" height="800" alt="Figure_1" src="https://github.com/user-attachments/assets/8ca2a8e7-7815-4163-ac1f-46a3adc4d326" />

### 4.2. 2차 최적화 결과 (L1 캐시 라인 최적화)
1차 최적화 이후 `SparseSet::Contains`에서 발생하던 메모리 병목을 타파하기 위해, `Optional`을 제거하고 `INVALID_INDEX`를 도입한 결과

| 벤치마크 (100,000 Entities) | 1차 After (ms) | 최종 After (ms) | 추가 성능 향상 |
| :--- | :--- | :--- | :--- |
| `BM_ECS_Query_SingleComponent` | 0.53 ms | 0.52 ms | **+ 3%** (1.03x) |
| `BM_ECS_Query_TwoComponents` | 0.46 ms | 0.39 ms | **+ 17%** (1.17x) |
| `BM_ECS_Query_ThreeComponents` | 0.27 ms | 0.22 ms | **+ 23%** (1.23x) |
| `BM_ECS_Query_Filter_With` | 0.07 ms | 0.06 ms | **+ 22%** (1.22x) |
| `BM_ECS_Query_Filter_Without` | 0.64 ms | 0.61 ms | **+ 5%** (1.05x) |

<img width="1100" height="800" alt="Figure_2" src="https://github.com/user-attachments/assets/01bdc492-8f68-4313-844f-a17b6daff40c" />

## 5. 결론 및 요약

1. **조회 병목 개선 (포인터 캐싱)**
   - 쿼리 생성 시점에 포인터를 캐싱하여 순회 루프 내부의 반복적인 HashMap 조회를 제거.
   - 결과적으로 기존 대비 평균 8~9배 수준의 런타임 성능 향상 확인.

2. **메모리 및 캐시 라인 최적화 (데이터 크기 축소)**
   - `SparseSet` 내부 배열의 요소를 16바이트(`Optional`)에서 8바이트(Raw Type + Invalid Index)로 축소하여 메모리 접근 밀도 개선.
   - 캐시 미스(Cache Miss)가 줄어들면서, 교집합 연산이 빈번한 다중 컴포넌트 쿼리(`ThreeComponents`, `With` 등)에서 1차 최적화 대비 약 20%의 추가 성능 향상.