### PR TITLE
refactor/binary-hash-digest

### DIFF
--- a/Editor/Include/SimpleEditor/App/EditorApplication.h
+++ b/Editor/Include/SimpleEditor/App/EditorApplication.h
@@ -4,7 +4,7 @@
 #include "SimpleEngine/App/Application.h"
 #include "SimpleEngine/Asset/AssetId.h"
 #include "SimpleEngine/Core/Container/HashMap.h"
-#include "SimpleEngine/Core/Container/String.h"
+#include "SimpleEngine/Core/Types/HashDigest.h"
 
 #include "SDL3/SDL.h"
 
@@ -36,8 +36,8 @@ private:
     // GPU에 업로드된 메시의 해시 쌍을 추적합니다 (Hot-reload 감지용)
     struct MeshCookKey
     {
-        String source_hash;
-        String settings_hash;
+        ContentHash source_hash;
+        ContentHash settings_hash;
 
         bool operator==(const MeshCookKey&) const = default;
     };

--- a/Editor/Source/Asset/EditorAssetSubsystem.cpp
+++ b/Editor/Source/Asset/EditorAssetSubsystem.cpp
@@ -278,11 +278,11 @@ void EditorAssetSubsystem::ScanWorkspace(const Path& root_path, bool is_hot_star
     }
 
     // === 고아 .meta 해시 인덱스 구축 (이동 감지용) ===
-    HashMap<String, uint32> orphan_by_hash;
+    HashMap<ContentHash, uint32> orphan_by_hash;
     for (const auto [n, orphan_meta] : orphan_metas | std::views::enumerate)
     {
-        const String& hash = orphan_meta.content.metadata.source_hash;
-        if (!hash.IsEmpty())
+        const ContentHash& hash = orphan_meta.content.metadata.source_hash;
+        if (!hash.IsZero())
         {
             orphan_by_hash.Insert(hash, static_cast<uint32>(n));
         }
@@ -309,7 +309,7 @@ void EditorAssetSubsystem::ScanWorkspace(const Path& root_path, bool is_hot_star
         else if (!orphan_by_hash.IsEmpty())
         {
             // .meta 없음 -> 해시 매칭으로 오프라인 이동 감지
-            const String hash = SHA256::HashFile(file_path);
+            const ContentHash hash = SHA256::HashFile(file_path);
             if (const Optional idx = orphan_by_hash.Find(hash))
             {
                 OrphanMeta& orphan = orphan_metas[*idx];
@@ -592,7 +592,7 @@ bool EditorAssetSubsystem::CookAsset(const VPath& file_vpath)
     const ImportResult& result = result_exp.Value();
 
     // 메타데이터 및 해시 계산
-    const String source_hash = SHA256::HashFile(file_path); // TODO: 나중에 xxHash로 변경
+    const ContentHash source_hash = SHA256::HashFile(file_path);
     constexpr uint32 current_cache_version = 1;
     const uint64 file_mtime = FileSystem::LastWriteTime(file_path).ValueOrDefault();
     const uint64 file_size = static_cast<uint64>(FileSystem::FileSize(file_path).ValueOrDefault());
@@ -603,7 +603,7 @@ bool EditorAssetSubsystem::CookAsset(const VPath& file_vpath)
         MemoryWriter writer(settings_bytes);
         writer << import_profile;
     }
-    const String settings_hash = SHA256::HashBytes(settings_bytes);
+    const ContentHash settings_hash = SHA256::HashBytes(settings_bytes);
 
     asset::AssetRegistry& registry = asset_subsystem->GetRegistry();
     asset::DerivedDataCache& ddc = asset_subsystem->GetDDC();
@@ -674,7 +674,7 @@ bool EditorAssetSubsystem::CookAsset(const VPath& file_vpath)
         registry.RegisterAsset(asset_id, asset_type, std::move(asset_path), std::move(sub_meta));
 
         // DDC 굽기 (직렬화)
-        if (!source_hash.IsEmpty())
+        if (!source_hash.IsZero())
         {
             Array<uint8> payload = asset::AssetSubsystem::SerializeAssetPayload(*asset);
             if (!payload.IsEmpty())
@@ -814,7 +814,7 @@ bool EditorAssetSubsystem::IsAssetDirty(const Path& source_path, const asset::As
 
     // mtime 변경 + size 동일 -> SHA256 해시로 최종 확인
     // (git branch 전환, touch 등으로 mtime만 바뀐 경우 불필요한 reimport 방지)
-    const String current_hash = SHA256::HashFile(source_path);
+    const ContentHash current_hash = SHA256::HashFile(source_path);
     return current_hash != meta.source_hash;
 }
 

--- a/EngineCore/Assets/AxisCheck_Monkey.obj.meta
+++ b/EngineCore/Assets/AxisCheck_Monkey.obj.meta
@@ -8,8 +8,8 @@ global_scale = 1.0
 [metadata]
 cache_version = 1
 guid = '01d69dd4-af80-4c24-b55d-cfd97aef4a1e'
-settings_hash = 'sha256:82a967f4e418eb518b3e599736e29c936cf3452045c20b375a5d854590bc417a'
-source_hash = 'sha256:72f9007e01fd1d02ac1615eca372ed1a10499e93526c8eef6f1e14c6156fbb28'
+settings_hash = '82a967f4e418eb518b3e599736e29c936cf3452045c20b375a5d854590bc417a'
+source_hash = '72f9007e01fd1d02ac1615eca372ed1a10499e93526c8eef6f1e14c6156fbb28'
 source_mtime = 1775721082529359500
 source_size = 63009
 

--- a/EngineCore/Assets/Cube.obj.meta
+++ b/EngineCore/Assets/Cube.obj.meta
@@ -8,8 +8,8 @@ global_scale = 1.0
 [metadata]
 cache_version = 1
 guid = 'd46a15ad-c9cb-4843-a677-90c194a24738'
-settings_hash = 'sha256:82a967f4e418eb518b3e599736e29c936cf3452045c20b375a5d854590bc417a'
-source_hash = 'sha256:44cef8efa27cc51242067df382cc419a7b50e43e866ef5b467f7efa46eaddeeb'
+settings_hash = '82a967f4e418eb518b3e599736e29c936cf3452045c20b375a5d854590bc417a'
+source_hash = '44cef8efa27cc51242067df382cc419a7b50e43e866ef5b467f7efa46eaddeeb'
 source_mtime = 1775110252411093200
 source_size = 945
 

--- a/EngineCore/Include/SimpleEngine/Asset/AssetMetadata.h
+++ b/EngineCore/Include/SimpleEngine/Asset/AssetMetadata.h
@@ -1,9 +1,11 @@
 ﻿#pragma once
+
 #include "SimpleEngine/Core/Container/Array.h"
 #include "SimpleEngine/Core/Container/String.h"
 #include "SimpleEngine/Core/Reflection/Annotations.h"
 #include "SimpleEngine/Core/Reflection/TypeId.h"
 #include "SimpleEngine/Core/Types/Guid.h"
+#include "SimpleEngine/Core/Types/HashDigest.h"
 
 
 namespace se::asset
@@ -80,9 +82,9 @@ struct SE_ANNOTATION(=meta::SerializeOnly) AssetMetadata
     SE_ANNOTATION(=meta::Property)
     Guid guid;
 
-    /** 소스 파일의 SHA-256 해시 (변경 감지용, "sha256:..." 형태) */
+    /** 소스 파일의 SHA-256 해시 (변경 감지용) */
     SE_ANNOTATION(=meta::Property)
-    String source_hash;
+    ContentHash source_hash;
 
     /** 소스 파일의 마지막 수정 시간 */
     SE_ANNOTATION(=meta::Property)
@@ -96,9 +98,9 @@ struct SE_ANNOTATION(=meta::SerializeOnly) AssetMetadata
     SE_ANNOTATION(=meta::Property)
     uint32 cache_version = 0;
 
-    /** Import Settings의 SHA-256 해시 (설정 변경 감지용, "sha256:..." 형태) */
+    /** Import Settings의 SHA-256 해시 (설정 변경 감지용) */
     SE_ANNOTATION(=meta::Property)
-    String settings_hash;
+    ContentHash settings_hash;
 
     /** 이 소스 파일에서 생성된 Sub-Asset 목록 */
     SE_ANNOTATION(=meta::Property)

--- a/EngineCore/Include/SimpleEngine/Asset/DerivedDataCache.h
+++ b/EngineCore/Include/SimpleEngine/Asset/DerivedDataCache.h
@@ -2,8 +2,8 @@
 
 #include "SimpleEngine/Core/Container/Array.h"
 #include "SimpleEngine/Core/Container/ArrayView.h"
-#include "SimpleEngine/Core/Container/String.h"
 #include "SimpleEngine/Core/Types/Guid.h"
+#include "SimpleEngine/Core/Types/HashDigest.h"
 #include "SimpleEngine/Core/Types/Path.h"
 
 
@@ -17,8 +17,8 @@ namespace se::asset
  */
 struct CacheEntry
 {
-    /** 소스 파일의 해시 ("sha256:..." 형태) */
-    String source_hash;
+    /** 소스 파일의 해시 */
+    ContentHash source_hash;
 
     /** 캐시 스키마 버전 (Importer 출력 포맷 변경 시 증가) */
     uint32 cache_version = 0;
@@ -97,7 +97,7 @@ public:
      */
     [[nodiscard]] bool IsValid(
         const Guid& guid,
-        StringView source_hash,
+        const ContentHash& source_hash,
         uint32 cache_version
     ) const;
 

--- a/EngineCore/Include/SimpleEngine/Core/Types/HashDigest.h
+++ b/EngineCore/Include/SimpleEngine/Core/Types/HashDigest.h
@@ -80,6 +80,7 @@ public:
         const char* src = hex.Data();
         for (usize i = 0; i < N; ++i)
         {
+            SE_ASSERT(IsHexChar(src[i * 2]) && IsHexChar(src[(i * 2) + 1]), "FromHex: invalid hex character detected");
             result.data[i] = static_cast<uint8>(
                 (HexCharToNibble(src[i * 2]) << 4) | HexCharToNibble(src[(i * 2) + 1])
             );
@@ -118,7 +119,6 @@ public:
     [[nodiscard]] static constexpr usize Size() { return N; }
 
     [[nodiscard]] explicit constexpr operator bool() const { return !IsZero(); }
-
     [[nodiscard]] bool operator==(const HashDigest& other) const = default;
 
     /** HashDigest 직렬화 */
@@ -139,6 +139,11 @@ public:
     }
 
 private:
+    static constexpr bool IsHexChar(char c)
+    {
+        return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+    }
+
     static constexpr uint8 HexCharToNibble(char c)
     {
         if (c >= '0' && c <= '9') { return static_cast<uint8>(c - '0'); }

--- a/EngineCore/Include/SimpleEngine/Core/Types/HashDigest.h
+++ b/EngineCore/Include/SimpleEngine/Core/Types/HashDigest.h
@@ -116,25 +116,39 @@ public:
     }
 
     [[nodiscard]] const uint8* Data() const { return data.Data(); }
+    [[nodiscard]] uint8* Data() { return data.Data(); }
+
     [[nodiscard]] static constexpr usize Size() { return N; }
 
     [[nodiscard]] explicit constexpr operator bool() const { return !IsZero(); }
     [[nodiscard]] bool operator==(const HashDigest& other) const = default;
 
-    /** HashDigest 직렬화 */
+    /**
+     * HashDigest 직렬화
+     * Binary: raw bytes 직접 저장 (N bytes)
+     * Text: hex 문자열로 변환 (N*2 chars)
+     */
     friend void Serialize(Archive& ar, HashDigest& digest)
     {
-        String str;
-        if (ar.IsSaving())
+        if (ar.IsBinary())
         {
-            str = digest.ToHex();
+            ar << BinaryBlob::FromBytes(digest.data.Data(), N);
+            ar << digest.data;
         }
-
-        ar << str;
-
-        if (ar.IsLoading())
+        else
         {
-            digest = HashDigest::FromHex(str);
+            String str;
+            if (ar.IsSaving())
+            {
+                str = digest.ToHex();
+            }
+
+            ar << str;
+
+            if (ar.IsLoading())
+            {
+                digest = HashDigest::FromHex(str);
+            }
         }
     }
 

--- a/EngineCore/Include/SimpleEngine/Core/Types/HashDigest.h
+++ b/EngineCore/Include/SimpleEngine/Core/Types/HashDigest.h
@@ -1,0 +1,181 @@
+#pragma once
+
+#include "SimpleEngine/Core/Container/FixedArray.h"
+#include "SimpleEngine/Core/Container/String.h"
+#include "SimpleEngine/Core/HAL/PlatformTypes.h"
+#include "SimpleEngine/Core/Serialization/Archive.h"
+
+#include <algorithm>
+#include <cstring>
+
+
+namespace se
+{
+/**
+ * 고정 크기 Hash Digest
+ *
+ * SHA-256(32 bytes), xxHash128(16 bytes) 등의 해시 값을 인라인으로 저장합니다.
+ * 힙 할당 없이 값 비교가 가능하며, 직렬화 시 hex 문자열로 변환합니다.
+ *
+ * @tparam N 해시 바이트 수 (예: 32 for SHA-256, 16 for xxHash128)
+ */
+template <usize N>
+class HashDigest
+{
+    static_assert(N > 0 && N <= 64, "Hash digest size must be between 1 and 64 bytes");
+
+public:
+    static constexpr usize DIGEST_SIZE = N;
+
+    constexpr HashDigest() = default;
+
+public:
+    /** 원시 바이트 배열로부터 생성 */
+    static constexpr HashDigest FromRaw(const uint8 (&raw)[N])
+    {
+        HashDigest result;
+        if consteval
+        {
+            for (usize i = 0; i < N; ++i)
+            {
+                result.data[i] = raw[i];
+            }
+        }
+        else
+        {
+            std::memcpy(result.data.Data(), raw, N);
+        }
+        return result;
+    }
+
+    /** 원시 바이트 포인터로부터 생성 */
+    static constexpr HashDigest FromRaw(const uint8* raw)
+    {
+        HashDigest result;
+        if consteval
+        {
+            for (usize i = 0; i < N; ++i)
+            {
+                result.data[i] = raw[i];
+            }
+        }
+        else
+        {
+            std::memcpy(result.data.Data(), raw, N);
+        }
+        return result;
+    }
+
+    /** hex 문자열로부터 생성 (예: "db5c66474df3...") */
+    static constexpr HashDigest FromHex(StringView hex)
+    {
+        HashDigest result;
+
+        const usize expected_len = N * 2;
+        if (hex.ByteLen() != expected_len)
+        {
+            return result; // zero-initialized
+        }
+
+        const char* src = hex.Data();
+        for (usize i = 0; i < N; ++i)
+        {
+            result.data[i] = static_cast<uint8>(
+                (HexCharToNibble(src[i * 2]) << 4) | HexCharToNibble(src[(i * 2) + 1])
+            );
+        }
+        return result;
+    }
+
+    /** hex 문자열로 변환 */
+    [[nodiscard]] String ToHex() const
+    {
+        static constexpr char HEX_CHARS[] = "0123456789abcdef";
+
+        char buf[N * 2];
+        for (usize i = 0; i < N; ++i)
+        {
+            buf[i * 2] = HEX_CHARS[data[i] >> 4];
+            buf[(i * 2) + 1] = HEX_CHARS[data[i] & 0x0F];
+        }
+        return String{ buf, N * 2 };
+    }
+
+    /** Digest가 모두 0인지 확인 */
+    [[nodiscard]] constexpr bool IsZero() const
+    {
+        for (usize i = 0; i < N; ++i)
+        {
+            if (data[i] != 0)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    [[nodiscard]] const uint8* Data() const { return data.Data(); }
+    [[nodiscard]] static constexpr usize Size() { return N; }
+
+    [[nodiscard]] explicit constexpr operator bool() const { return !IsZero(); }
+
+    [[nodiscard]] bool operator==(const HashDigest& other) const = default;
+
+    /** HashDigest 직렬화 */
+    friend void Serialize(Archive& ar, HashDigest& digest)
+    {
+        String str;
+        if (ar.IsSaving())
+        {
+            str = digest.ToHex();
+        }
+
+        ar << str;
+
+        if (ar.IsLoading())
+        {
+            digest = HashDigest::FromHex(str);
+        }
+    }
+
+private:
+    static constexpr uint8 HexCharToNibble(char c)
+    {
+        if (c >= '0' && c <= '9') { return static_cast<uint8>(c - '0'); }
+        if (c >= 'a' && c <= 'f') { return static_cast<uint8>(c - 'a' + 10); }
+        if (c >= 'A' && c <= 'F') { return static_cast<uint8>(c - 'A' + 10); }
+        return 0;
+    }
+
+    FixedArray<uint8, N> data{};
+};
+
+/** SHA-256 Hash Digest (32 bytes) */
+using ContentHash = HashDigest<32>;
+} // namespace se
+
+namespace std
+{
+// NOLINTBEGIN(*-std-namespace-modification, *-dcl58-cpp)
+template <usize N>
+struct hash<se::HashDigest<N>>
+{
+    size_t operator()(const se::HashDigest<N>& digest) const noexcept
+    {
+        // Hash Digest는 이미 균일 분포이므로 앞 바이트를 그대로 사용
+        size_t result = 0;
+        std::memcpy(&result, digest.Data(), std::min(sizeof(size_t), N));
+        return result;
+    }
+};
+
+template <usize N>
+struct formatter<se::HashDigest<N>, char> : std::formatter<se::String>
+{
+    auto format(const se::HashDigest<N>& digest, std::format_context& ctx) const
+    {
+        return std::formatter<se::String>::format(digest.ToHex(), ctx);
+    }
+};
+// NOLINTEND(*-std-namespace-modification, *-dcl58-cpp)
+} // namespace std

--- a/EngineCore/Include/SimpleEngine/Core/Types/HashDigest.h
+++ b/EngineCore/Include/SimpleEngine/Core/Types/HashDigest.h
@@ -51,6 +51,8 @@ public:
     /** 원시 바이트 포인터로부터 생성 */
     static constexpr HashDigest FromRaw(const uint8* raw)
     {
+        SE_ASSERT(raw != nullptr);
+
         HashDigest result;
         if consteval
         {

--- a/EngineCore/Include/SimpleEngine/Utility/SHA256.h
+++ b/EngineCore/Include/SimpleEngine/Utility/SHA256.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "SimpleEngine/Core/Container/ArrayView.h"
-#include "SimpleEngine/Core/Container/String.h"
 #include "SimpleEngine/Core/HAL/PlatformTypes.h"
+#include "SimpleEngine/Core/Types/HashDigest.h"
 #include "SimpleEngine/Core/Types/Path.h"
 
 
@@ -21,22 +21,22 @@ struct SE_CORE_API SHA256
     /**
      * 파일의 SHA-256 해시를 계산합니다.
      * @param file_path 해시를 계산할 파일의 경로
-     * @return "sha256:<hex>" 형식의 해시 문자열. 실패 시 빈 문자열.
+     * @return SHA-256 digest. 실패 시 zero digest.
      */
-    [[nodiscard]] static String HashFile(const Path& file_path);
+    [[nodiscard]] static ContentHash HashFile(const Path& file_path);
 
     /**
      * 바이트 데이터의 SHA-256 해시를 계산합니다.
      * @param data 해시를 계산할 바이트 배열
-     * @return "sha256:<hex>" 형식의 해시 문자열
+     * @return SHA-256 digest
      */
-    [[nodiscard]] static String HashBytes(ArrayView<const uint8> data);
+    [[nodiscard]] static ContentHash HashBytes(ArrayView<const uint8> data);
 
     /**
      * 문자열 데이터의 SHA-256 해시를 계산합니다.
      * @param str 해시를 계산할 문자열
-     * @return "sha256:<hex>" 형식의 해시 문자열
+     * @return SHA-256 digest
      */
-    [[nodiscard]] static String HashString(StringView str);
+    [[nodiscard]] static ContentHash HashString(StringView str);
 };
 } // namespace se

--- a/EngineCore/Source/Asset/AssetSubsystem.cpp
+++ b/EngineCore/Source/Asset/AssetSubsystem.cpp
@@ -185,7 +185,7 @@ HandleData AssetSubsystem::LoadInternal(const TypeId& expected_type, const Asset
             }
 
             // DDC Hit 검사 및 로드 수행
-            String source_hash;
+            ContentHash source_hash;
             uint32 cache_version;
             const bool has_meta = registry->ReadRecord(current_id, [&source_hash, &cache_version](const AssetRecord& record)
             {
@@ -417,7 +417,7 @@ JobTask<HandleData> AssetSubsystem::LoadAsyncInternal(TypeId expected_type, Asse
     }
 
     // DDC validity 확인
-    String source_hash;
+    ContentHash source_hash;
     uint32 cache_version;
     const bool has_meta = registry->ReadRecord(asset_id, [&source_hash, &cache_version](const AssetRecord& record)
     {

--- a/EngineCore/Source/Asset/DerivedDataCache.cpp
+++ b/EngineCore/Source/Asset/DerivedDataCache.cpp
@@ -38,7 +38,7 @@ struct DDC_CacheEntryInternal
         uint32 magic = CACHE_MAGIC;
         uint32 format_version = CACHE_FORMAT_VERSION;
         uint32 cache_version = 0;
-        String source_hash;
+        ContentHash source_hash;
 
         friend void Serialize(Archive& ar, Header& ar_header)
         {
@@ -226,7 +226,7 @@ Optional<CacheEntry> DerivedDataCache::Load(const Guid& guid) const
 // source_hash와 cache_version이 모두 일치해야 유효한 것으로 판단.
 bool DerivedDataCache::IsValid(
     const Guid& guid,
-    StringView source_hash,
+    const ContentHash& source_hash,
     uint32 cache_version
 ) const
 {

--- a/EngineCore/Source/Utility/SHA256.cpp
+++ b/EngineCore/Source/Utility/SHA256.cpp
@@ -5,12 +5,24 @@
 
 #include "picosha2.h"
 
-#include <string>
-
 
 namespace se
 {
-String SHA256::HashFile(const Path& file_path)
+namespace
+{
+ContentHash DigestFromHasher(picosha2::hash256_one_by_one& hasher)
+{
+    static_assert(ContentHash::DIGEST_SIZE == 32, "SHA-256 produces 32 bytes; update hash library if ContentHash size changes");
+
+    hasher.finish();
+
+    uint8 raw[ContentHash::DIGEST_SIZE];
+    hasher.get_hash_bytes(raw, raw + ContentHash::DIGEST_SIZE);
+    return ContentHash::FromRaw(raw);
+}
+} // namespace
+
+ContentHash SHA256::HashFile(const Path& file_path)
 {
     picosha2::hash256_one_by_one hasher;
 
@@ -29,31 +41,20 @@ String SHA256::HashFile(const Path& file_path)
         hasher.process(chunk.begin(), chunk.end());
     }
 
-    hasher.finish();
-
-    std::string hex_str;
-    picosha2::get_hash_hex_string(hasher, hex_str);
-
-    return String::Format("sha256:{}", hex_str.c_str());
+    return DigestFromHasher(hasher);
 }
 
-String SHA256::HashBytes(ArrayView<const uint8> data)
+ContentHash SHA256::HashBytes(ArrayView<const uint8> data)
 {
-    std::string hex_str;
-    picosha2::hash256_hex_string(
-        data.begin(), data.end(),
-        hex_str
-    );
-    return String::Format("sha256:{}", hex_str.c_str());
+    picosha2::hash256_one_by_one hasher;
+    hasher.process(data.begin(), data.end());
+    return DigestFromHasher(hasher);
 }
 
-String SHA256::HashString(const StringView str)
+ContentHash SHA256::HashString(const StringView str)
 {
-    const uint8* begin = reinterpret_cast<const uint8*>(str.Data());
-    const uint8* end = begin + str.ByteLen();
-
-    std::string hex_str;
-    picosha2::hash256_hex_string(begin, end, hex_str);
-    return String::Format("sha256:{}", hex_str.c_str());
+    picosha2::hash256_one_by_one hasher;
+    hasher.process(str.begin(), str.end());
+    return DigestFromHasher(hasher);
 }
 }  // namespace se

--- a/EngineTest/Source/UnitTests/DerivedDataCacheTest.cpp
+++ b/EngineTest/Source/UnitTests/DerivedDataCacheTest.cpp
@@ -3,6 +3,7 @@
 #include "SimpleEngine/Asset/DerivedDataCache.h"
 #include "SimpleEngine/Core/Container/Array.h"
 #include "SimpleEngine/Core/FileSystem/FileSystem.h"
+#include "SimpleEngine/Core/Types/HashDigest.h"
 #include "SimpleEngine/Core/Types/Guid.h"
 
 #include "SDL3/SDL_filesystem.h"
@@ -35,6 +36,14 @@ public:
 private:
     Path root_path;
 };
+
+// 테스트용 ContentHash 생성 (라벨 바이트를 그대로 해시에 채워넣음)
+ContentHash MakeTestHash(StringView label)
+{
+    uint8 raw[ContentHash::DIGEST_SIZE] = {};
+    std::memcpy(raw, label.Data(), std::min(label.ByteLen(), usize{ ContentHash::DIGEST_SIZE }));
+    return ContentHash::FromRaw(raw);
+}
 
 // 테스트용 페이로드 생성
 Array<uint8> MakePayload(const std::initializer_list<uint8>& data)
@@ -70,7 +79,7 @@ protected:
 TEST_F(DDCTest, StoreAndLoad)
 {
     const Guid guid = Guid::NewGuid();
-    const String hash = "sha256:abcdef1234567890";
+    const ContentHash hash = MakeTestHash("abcdef1234567890");
     constexpr uint32 version = 1;
     const Array<uint8> payload = MakePayload({ 0x01, 0x02, 0x03, 0x04 });
 
@@ -105,7 +114,7 @@ TEST_F(DDCTest, Contains)
 
     const Array<uint8> payload = MakePayload({ 0xFF });
     ASSERT_TRUE(ddc.Store(guid, {
-        .source_hash = "sha256:test",
+        .source_hash = MakeTestHash("test"),
         .cache_version = 1,
         .payload = payload
     }));
@@ -121,7 +130,7 @@ TEST_F(DDCTest, Contains)
 TEST_F(DDCTest, IsValid_MatchingHashAndVersion)
 {
     const Guid guid = Guid::NewGuid();
-    const String hash = "sha256:matching_hash";
+    const ContentHash hash = MakeTestHash("matching_hash");
     constexpr uint32 version = 3;
     const Array<uint8> payload = MakePayload(16);
 
@@ -140,12 +149,12 @@ TEST_F(DDCTest, IsValid_MismatchHash)
     const Array<uint8> payload = MakePayload(16);
 
     ASSERT_TRUE(ddc.Store(guid, {
-        .source_hash = "sha256:original",
+        .source_hash = MakeTestHash("original"),
         .cache_version = 1,
         .payload = payload
     }));
 
-    EXPECT_FALSE(ddc.IsValid(guid, "sha256:different", 1));
+    EXPECT_FALSE(ddc.IsValid(guid, MakeTestHash("different"), 1));
 }
 
 TEST_F(DDCTest, IsValid_MismatchVersion)
@@ -154,18 +163,18 @@ TEST_F(DDCTest, IsValid_MismatchVersion)
     const Array<uint8> payload = MakePayload(16);
 
     ASSERT_TRUE(ddc.Store(guid, {
-        .source_hash = "sha256:same",
+        .source_hash = MakeTestHash("same"),
         .cache_version = 1,
         .payload = payload
     }));
 
-    EXPECT_FALSE(ddc.IsValid(guid, "sha256:same", 2));
+    EXPECT_FALSE(ddc.IsValid(guid, MakeTestHash("same"), 2));
 }
 
 TEST_F(DDCTest, IsValid_NonExistent)
 {
     const Guid guid = Guid::NewGuid();
-    EXPECT_FALSE(ddc.IsValid(guid, "sha256:any", 1));
+    EXPECT_FALSE(ddc.IsValid(guid, MakeTestHash("any"), 1));
 }
 
 
@@ -180,12 +189,12 @@ TEST_F(DDCTest, OverwriteExistingCache)
     const Array<uint8> payload2 = MakePayload({ 0xAA, 0xBB, 0xCC });
 
     ASSERT_TRUE(ddc.Store(guid, {
-        .source_hash = "sha256:v1",
+        .source_hash = MakeTestHash("v1"),
         .cache_version = 1,
         .payload = payload1
     }));
     ASSERT_TRUE(ddc.Store(guid, {
-        .source_hash = "sha256:v2",
+        .source_hash = MakeTestHash("v2"),
         .cache_version = 2,
         .payload = payload2
     }));
@@ -193,7 +202,7 @@ TEST_F(DDCTest, OverwriteExistingCache)
     const Optional result = ddc.Load(guid);
     ASSERT_TRUE(result.HasValue());
 
-    EXPECT_EQ(result->source_hash, "sha256:v2");
+    EXPECT_EQ(result->source_hash, MakeTestHash("v2"));
     EXPECT_EQ(result->cache_version, 2u);
     ASSERT_EQ(result->payload.Len(), payload2.Len());
     EXPECT_EQ(std::memcmp(result->payload.Data(), payload2.Data(), payload2.Len()), 0);
@@ -210,7 +219,7 @@ TEST_F(DDCTest, Remove)
     const Array<uint8> payload = MakePayload({ 0x01 });
 
     ASSERT_TRUE(ddc.Store(guid, {
-        .source_hash = "sha256:test",
+        .source_hash = MakeTestHash("test"),
         .cache_version = 1,
         .payload = payload
     }));
@@ -234,12 +243,12 @@ TEST_F(DDCTest, Clear)
     const Array<uint8> payload = MakePayload(8);
 
     ASSERT_TRUE(ddc.Store(guid1, {
-        .source_hash = "sha256:a",
+        .source_hash = MakeTestHash("a"),
         .cache_version = 1,
         .payload = payload
     }));
     ASSERT_TRUE(ddc.Store(guid2, {
-        .source_hash = "sha256:b",
+        .source_hash = MakeTestHash("b"),
         .cache_version = 1,
         .payload = payload
     }));
@@ -264,7 +273,7 @@ TEST_F(DDCTest, EmptyPayload)
     const Array<uint8> empty_payload;
 
     ASSERT_TRUE(ddc.Store(guid, {
-        .source_hash = "sha256:empty",
+        .source_hash = MakeTestHash("empty"),
         .cache_version = 1,
         .payload = empty_payload
     }));
@@ -272,7 +281,7 @@ TEST_F(DDCTest, EmptyPayload)
     const Optional result = ddc.Load(guid);
     ASSERT_TRUE(result.HasValue());
 
-    EXPECT_EQ(result->source_hash, "sha256:empty");
+    EXPECT_EQ(result->source_hash, MakeTestHash("empty"));
     EXPECT_EQ(result->payload.Len(), 0u);
 }
 
@@ -288,7 +297,7 @@ TEST_F(DDCTest, LargePayload)
     const Array<uint8> payload = MakePayload(large_size, 0xCD);
 
     ASSERT_TRUE(ddc.Store(guid, {
-        .source_hash = "sha256:large",
+        .source_hash = MakeTestHash("large"),
         .cache_version = 1,
         .payload = payload
     }));
@@ -314,12 +323,12 @@ TEST_F(DDCTest, MultipleGuidsIndependent)
     const Array<uint8> payload2 = MakePayload({ 0xAA, 0xBB, 0xCC });
 
     ASSERT_TRUE(ddc.Store(guid1, {
-        .source_hash = "sha256:hash1",
+        .source_hash = MakeTestHash("hash1"),
         .cache_version = 1,
         .payload = payload1
     }));
     ASSERT_TRUE(ddc.Store(guid2, {
-        .source_hash = "sha256:hash2",
+        .source_hash = MakeTestHash("hash2"),
         .cache_version = 2,
         .payload = payload2
     }));
@@ -330,11 +339,11 @@ TEST_F(DDCTest, MultipleGuidsIndependent)
     ASSERT_TRUE(r1.HasValue());
     ASSERT_TRUE(r2.HasValue());
 
-    EXPECT_EQ(r1->source_hash, "sha256:hash1");
+    EXPECT_EQ(r1->source_hash, MakeTestHash("hash1"));
     EXPECT_EQ(r1->cache_version, 1u);
     EXPECT_EQ(r1->payload.Len(), 2u);
 
-    EXPECT_EQ(r2->source_hash, "sha256:hash2");
+    EXPECT_EQ(r2->source_hash, MakeTestHash("hash2"));
     EXPECT_EQ(r2->cache_version, 2u);
     EXPECT_EQ(r2->payload.Len(), 3u);
 }


### PR DESCRIPTION
> 아래 PR 메시지는 Claude AI를 사용하여 작성되었습니다.

## Summary

에셋 시스템의 `source_hash`, `settings_hash` 필드를 `String`에서 `ContentHash`(`HashDigest<32>`)로 전환합니다.

## Motivation

프로파일링 결과, 2500 엔티티 렌더링 시 `EnsureMeshesResident`에서 해시 비교가 **4.05% CPU**를 차지.
원인: 72바이트 힙 할당 String 비교 (SHA-256 hex + "sha256:" 접두사) x 2500회/프레임.

## Changes

- **`HashDigest<N>`**: 고정 크기 바이너리 해시 타입 (`FixedArray<uint8, N>` 기반)
    - `using ContentHash = HashDigest<32>` (SHA-256 용)
    - constexpr 팩토리 메서드 (`FromRaw`, `FromHex`)
    - Archive 직렬화 (hex 문자열), `std::hash` (앞 8바이트 직접 사용), `std::formatter`
- **전체 에셋 파이프라인 적용**: SHA256, AssetMetadata, DDC, Registry, Import, MeshCookKey
- **접두사 API 제거**: `ToPrefixedString`/`FromPrefixedString` 완전 퇴출 (hex-only)
- **`HashUtils::FNV(const uint8*, usize)`**: 바이트 범위 FNV-1a 오버로드 추가

## Performance Impact

| 항목 | Before | After |
|------|--------|-------|
| 해시 비교 비용 | 72B String 비교 (힙) | 32B memcmp (스택) |
| HashMap 해시 함수 | FNV-1a 32바이트 루프 | 앞 8바이트 직접 읽기 (O(1)) |
| 해시 저장 크기 | ~80B (String) | 32B (고정) |

## Migration Note

기존 .meta 파일의 "sha256:..." 접두사 형식은 더 이상 지원하지 않음.
DDC 캐시는 자동 무효화됨 (직렬화 포맷 변경).
xxHash128 전환 시: `using ContentHash = HashDigest<16>` + 해시 라이브러리 교체
(`static_assert`가 컴파일 에러로 알려줌).