### PR TITLE
[Feature] World 직렬화 (Entity + Component)

### DIFF
--- a/Editor/Source/UI/EditorUISubsystem.cpp
+++ b/Editor/Source/UI/EditorUISubsystem.cpp
@@ -316,9 +316,6 @@ void EditorUISubsystem::DrawMainMenu()
                         const bool is_binary = data.Len() >= sizeof(uint32)
                             && std::memcmp(data.Data(), &World::FILE_MAGIC, sizeof(uint32)) == 0;
 
-                        // 불러오기 전 World 초기화
-                        world.Reset();
-
                         if (is_binary)
                         {
                             MemoryReader reader{ data };

--- a/Editor/Source/UI/EditorUISubsystem.cpp
+++ b/Editor/Source/UI/EditorUISubsystem.cpp
@@ -304,7 +304,7 @@ void EditorUISubsystem::DrawMainMenu()
 
                         World& world = entity_sub->GetMainWorld().GetWorld();
 
-                        // 포맷 자동 감지: magic bytes (0x44574553 = "SEWD") -> binary, 아니면 TOML
+                        // 포맷 자동 감지: magic bytes -> binary, 아니면 TOML
                         FileResult<Array<uint8>> bytes_result = FileSystem::ReadBytes(path);
                         if (bytes_result.HasError())
                         {
@@ -313,9 +313,8 @@ void EditorUISubsystem::DrawMainMenu()
                         }
 
                         const Array<uint8>& data = bytes_result.Value();
-                        constexpr uint32 WORLD_MAGIC = 0x44574553;
                         const bool is_binary = data.Len() >= sizeof(uint32)
-                            && std::memcmp(data.Data(), &WORLD_MAGIC, sizeof(uint32)) == 0;
+                            && std::memcmp(data.Data(), &World::FILE_MAGIC, sizeof(uint32)) == 0;
 
                         // 불러오기 전 World 초기화
                         world.Reset();

--- a/Editor/Source/UI/EditorUISubsystem.cpp
+++ b/Editor/Source/UI/EditorUISubsystem.cpp
@@ -15,19 +15,26 @@
 #include "SimpleEngine/App/Application.h"
 #include "SimpleEngine/Asset/AssetSubsystem.h"
 #include "SimpleEngine/Core/Config/ConfigFile.h"
+#include "SimpleEngine/Core/FileSystem/FileSystem.h"
 #include "SimpleEngine/Core/HAL/EventSubsystem.h"
+#include "SimpleEngine/Core/HAL/FileDialog.h"
 #include "SimpleEngine/Core/HAL/WindowSubsystem.h"
 #include "SimpleEngine/Core/Logging/Logging.h"
+#include "SimpleEngine/Core/Serialization/MemoryArchive.h"
+#include "SimpleEngine/Core/Serialization/TomlArchive.h"
 #include "SimpleEngine/Core/Subsystem/SubsystemRegistration.h"
 #include "SimpleEngine/Core/FileSystem/VFS.h"
 #include "SimpleEngine/Core/Types/VPath.h"
 #include "SimpleEngine/ECS/EntitySubsystem.h"
+#include "SimpleEngine/ECS/World.h"
 #include "SimpleEngine/Utility/SubsystemUtils.h"
 
 #include "imgui.h"
 #include "backends/imgui_impl_sdl3.h"
 #include "backends/imgui_impl_sdlgpu3.h"
 #include "Panels/WorldResourcePanel.h"
+
+#include <sstream>
 
 
 namespace se::editor
@@ -68,7 +75,7 @@ bool EditorUISubsystem::Initialize()
     EditorUISettings ui_settings;
     if (auto result = ConfigFile::Load("Config://EditorConfig.toml"))
     {
-        ui_settings = result.Value().GetSection<EditorUISettings>("ui");
+        ui_settings = result->GetSection<EditorUISettings>("ui");
     }
 
     // TODO: 나중에 다중모니터 지원하도록 변경
@@ -200,10 +207,153 @@ void EditorUISubsystem::SetupDockSpace() // NOLINT(*-convert-member-functions-to
 
 void EditorUISubsystem::DrawMainMenu()
 {
+    static constexpr FileFilter WORLD_FILTER = {
+        .name = "SimpleEngine World",
+        .pattern = "seworld"
+    };
+
     if (ImGui::BeginMainMenuBar())
     {
         if (ImGui::BeginMenu("File"))
         {
+            if (ImGui::MenuItem("New World", "Ctrl+N"))
+            {
+                if (EntitySubsystem* entity_sub = GetSubsystem<EntitySubsystem>())
+                {
+                    World& world = entity_sub->GetMainWorld().GetWorld();
+                    world.Reset();
+                    ConsoleLog(ELogLevel::Info, "World reset.");
+                }
+            }
+
+            ImGui::Separator();
+
+            if (ImGui::MenuItem("Save World (Binary)", "Ctrl+S"))
+            {
+                if (EntitySubsystem* entity_sub = GetSubsystem<EntitySubsystem>())
+                {
+                    // 다이얼로그 표시 전에 직렬화하여 현재 상태를 캡처
+                    Array<uint8> buffer;
+                    MemoryWriter writer{ buffer };
+                    writer << entity_sub->GetMainWorld().GetWorld();
+
+                    FileDialog::SaveFile(
+                        [buf = std::move(buffer)](const Path& path)
+                        {
+                            if (FileSystem::Write(path, buf))
+                            {
+                                ConsoleLog(ELogLevel::Info, "World saved (binary): {}", path);
+                            }
+                            else
+                            {
+                                ConsoleLog(ELogLevel::Error, "Failed to save world: {}", path);
+                            }
+                        },
+                        { WORLD_FILTER }
+                    );
+                }
+            }
+
+            if (ImGui::MenuItem("Save World (TOML)", "Ctrl+Shift+S"))
+            {
+                if (EntitySubsystem* entity_sub = GetSubsystem<EntitySubsystem>())
+                {
+                    String content = [&] -> String
+                    {
+                        // TOML 직렬화
+                        toml::table tbl;
+                        TomlWriter writer(tbl);
+                        writer << entity_sub->GetMainWorld().GetWorld();
+
+                        // TOML 문자열 생성
+                        std::ostringstream oss;
+                        oss << tbl;
+
+                        return { oss.view() };
+                    }();
+
+                    FileDialog::SaveFile(
+                        [con = std::move(content)](const Path& path)
+                        {
+                            if (FileSystem::WriteString(path, con))
+                            {
+                                ConsoleLog(ELogLevel::Info, "World saved (TOML): {}", path);
+                            }
+                            else
+                            {
+                                ConsoleLog(ELogLevel::Error, "Failed to save world: {}", path);
+                            }
+                        },
+                        { WORLD_FILTER }
+                    );
+                }
+            }
+
+            ImGui::Separator();
+
+            if (ImGui::MenuItem("Load World", "Ctrl+O"))
+            {
+                FileDialog::OpenFile(
+                    [](const Path& path)
+                    {
+                        EntitySubsystem* entity_sub = GetSubsystem<EntitySubsystem>();
+                        if (!entity_sub)
+                        {
+                            return;
+                        }
+
+                        World& world = entity_sub->GetMainWorld().GetWorld();
+
+                        // 포맷 자동 감지: magic bytes (0x44574553 = "SEWD") -> binary, 아니면 TOML
+                        FileResult<Array<uint8>> bytes_result = FileSystem::ReadBytes(path);
+                        if (bytes_result.HasError())
+                        {
+                            ConsoleLog(ELogLevel::Error, "Failed to read file: {}, Err: {}", path, bytes_result.Error().What());
+                            return;
+                        }
+
+                        const Array<uint8>& data = bytes_result.Value();
+                        constexpr uint32 WORLD_MAGIC = 0x44574553;
+                        const bool is_binary = data.Len() >= sizeof(uint32)
+                            && std::memcmp(data.Data(), &WORLD_MAGIC, sizeof(uint32)) == 0;
+
+                        // 불러오기 전 World 초기화
+                        world.Reset();
+
+                        if (is_binary)
+                        {
+                            MemoryReader reader{ data };
+                            reader << world;
+                        }
+                        else
+                        {
+                            FileResult<String> str_result = FileSystem::ReadToString(path);
+                            if (!str_result.HasValue())
+                            {
+                                ConsoleLog(ELogLevel::Error, "Failed to read TOML: {}", path);
+                                return;
+                            }
+
+                            toml::parse_result parsed = toml::parse(str_result->Bytes());
+                            if (!parsed)
+                            {
+                                ConsoleLog(ELogLevel::Error, "TOML parse error: {}", parsed.error().description());
+                                return;
+                            }
+
+                            toml::table tbl = std::move(parsed).table();
+                            TomlReader reader{ tbl };
+                            reader << world;
+                        }
+
+                        ConsoleLog(ELogLevel::Info, "World loaded: {}", path);
+                    },
+                    { WORLD_FILTER }
+                );
+            }
+
+            ImGui::Separator();
+
             if (ImGui::MenuItem("Exit"))
             {
                 Application::Get().RequestQuit();

--- a/Editor/Source/UI/EditorUISubsystem.cpp
+++ b/Editor/Source/UI/EditorUISubsystem.cpp
@@ -323,6 +323,11 @@ void EditorUISubsystem::DrawMainMenu()
                         {
                             MemoryReader reader{ data };
                             reader << world;
+                            if (reader.HasError())
+                            {
+                                ConsoleLog(ELogLevel::Error, "Failed to load world (binary): {}", reader.GetError());
+                                return;
+                            }
                         }
                         else
                         {
@@ -343,6 +348,11 @@ void EditorUISubsystem::DrawMainMenu()
                             toml::table tbl = std::move(parsed).table();
                             TomlReader reader{ tbl };
                             reader << world;
+                            if (reader.HasError())
+                            {
+                                ConsoleLog(ELogLevel::Error, "Failed to load world (TOML): {}", reader.GetError());
+                                return;
+                            }
                         }
 
                         ConsoleLog(ELogLevel::Info, "World loaded: {}", path);

--- a/EngineCore/Include/SimpleEngine/Core/Time/Time.h
+++ b/EngineCore/Include/SimpleEngine/Core/Time/Time.h
@@ -50,7 +50,7 @@ protected:
  * 실제 글로벌 시간입니다.
  * 게임 일시정지나 time scale의 영향을 받지 않습니다.
  */
-class RealTime final : public detail::TimeTick
+class SE_ANNOTATION(=meta::EditorOnly, =meta::Resource) RealTime final : public detail::TimeTick
 {
     friend class TimeManager;
     friend struct TimeResources_Registrar;
@@ -60,7 +60,7 @@ class RealTime final : public detail::TimeTick
  * 가상 게임 시간입니다. World별로 독립적으로 관리됩니다.
  * time_scale과 pause 상태에 따라 delta가 조절됩니다.
  */
-class GameTime final : public detail::TimeTick
+class SE_ANNOTATION(=meta::EditorOnly, =meta::Resource) GameTime final : public detail::TimeTick
 {
     friend class TimeManager;
     friend struct TimeResources_Registrar;
@@ -91,7 +91,7 @@ private:
  * 물리 시뮬레이션 등 일정한 간격의 업데이트가 필요한 곳에서 사용합니다.
  * accumulator가 fixed_step 이상이면 FixedUpdatePhase가 실행됩니다.
  */
-class FixedTime final : public detail::TimeTick
+class SE_ANNOTATION(=meta::EditorOnly, =meta::Resource) FixedTime final : public detail::TimeTick
 {
     friend class TimeManager;
     friend struct TimeResources_Registrar;

--- a/EngineCore/Include/SimpleEngine/ECS/Components/GlobalTransformComponent.h
+++ b/EngineCore/Include/SimpleEngine/ECS/Components/GlobalTransformComponent.h
@@ -10,7 +10,7 @@ namespace se
  * Entity의 최종 월드 공간 변환 행렬입니다.
  * TransformComponent(로컬)로부터 계층 구조를 따라 계산됩니다.
  */
-struct SE_CORE_API SE_ANNOTATION(=meta::Reflect, =meta::Component) GlobalTransformComponent
+struct SE_CORE_API SE_ANNOTATION(=meta::EditorOnly, =meta::Component) GlobalTransformComponent
 {
     SE_ANNOTATION(=meta::Property, =meta::ReadOnly)
     Matrix4x4 value = Matrix4x4::Identity();

--- a/EngineCore/Include/SimpleEngine/ECS/ECSRegistry.h
+++ b/EngineCore/Include/SimpleEngine/ECS/ECSRegistry.h
@@ -127,7 +127,7 @@ public:
         component_operators.Insert(type_id, ComponentOps{
             .ensure_storage = [](World& world) static -> IComponentStorage*
             {
-                return world.GetOrCreateRawStorage<T>();
+                return &world.GetOrCreateComponentStorage<T>();
             },
             .add_component = [](World& world, Entity entity) static
             {

--- a/EngineCore/Include/SimpleEngine/ECS/ECSRegistry.h
+++ b/EngineCore/Include/SimpleEngine/ECS/ECSRegistry.h
@@ -214,6 +214,9 @@ public:
     /** 등록된 모든 리소스 타입의 Ops 맵을 반환합니다. */
     [[nodiscard]] const HashMap<TypeId, ResourceOps>& GetResourceOpsMap() const { return resource_operators; }
 
+    /** Transient 플래그가 설정된 리소스 중, World에 없는 것을 기본값으로 삽입합니다. */
+    void InsertDefaultTransientResources(World& world) const;
+
 private:
     HashMap<TypeId, ComponentOps> component_operators;
     HashMap<TypeId, ResourceOps> resource_operators;

--- a/EngineCore/Include/SimpleEngine/ECS/EntityManager.h
+++ b/EngineCore/Include/SimpleEngine/ECS/EntityManager.h
@@ -3,6 +3,7 @@
 #include "SimpleEngine/Core/Container/Array.h"
 #include "SimpleEngine/Core/Container/Optional.h"
 #include "SimpleEngine/Core/HAL/PlatformTypes.h"
+#include "SimpleEngine/Core/Serialization/Archive.h"
 #include "SimpleEngine/ECS/Entity.h"
 
 #include <atomic>
@@ -31,6 +32,35 @@ public:
     [[nodiscard]] Optional<Entity> TryResolveEntity(uint32 id) const;
 
 private:
+    friend void Serialize(Archive& ar, EntityManager& em)
+    {
+        // generation + alive per record
+        uint64 record_count = em.entity_records.Len();
+        ar("record_count") << record_count;
+
+        if (ar.IsLoading())
+        {
+            em.entity_records.Resize(static_cast<usize>(record_count));
+        }
+
+        for (uint64 i = 0; i < record_count; ++i)
+        {
+            ar("generation") << em.entity_records[i].generation;
+            ar("alive") << em.entity_records[i].alive;
+        }
+
+        // free_ids
+        ar("free_ids") << em.free_ids;
+
+        // next_id
+        uint32 next = em.next_id.load(std::memory_order_relaxed);
+        ar("next_id") << next;
+        if (ar.IsLoading())
+        {
+            em.next_id.store(next, std::memory_order_relaxed);
+        }
+    }
+
     struct EntityRecord
     {
         uint32 generation = 0;

--- a/EngineCore/Include/SimpleEngine/ECS/EntityManager.h
+++ b/EngineCore/Include/SimpleEngine/ECS/EntityManager.h
@@ -31,6 +31,14 @@ public:
      */
     [[nodiscard]] Optional<Entity> TryResolveEntity(uint32 id) const;
 
+    /** 모든 상태를 초기화합니다. */
+    void Reset()
+    {
+        entity_records.Clear();
+        free_ids.Clear();
+        next_id.store(0, std::memory_order_relaxed);
+    }
+
 private:
     friend void Serialize(Archive& ar, EntityManager& em)
     {

--- a/EngineCore/Include/SimpleEngine/ECS/EntityManager.h
+++ b/EngineCore/Include/SimpleEngine/ECS/EntityManager.h
@@ -42,9 +42,10 @@ public:
 private:
     friend void Serialize(Archive& ar, EntityManager& em)
     {
-        // generation + alive per record
+        // entity records (array of {generation, alive})
         uint64 record_count = em.entity_records.Len();
-        ar("record_count") << record_count;
+        ar("records") ;
+        ar.BeginArray(record_count);
 
         if (ar.IsLoading())
         {
@@ -53,9 +54,13 @@ private:
 
         for (uint64 i = 0; i < record_count; ++i)
         {
+            ar.BeginObject();
             ar("generation") << em.entity_records[i].generation;
             ar("alive") << em.entity_records[i].alive;
+            ar.EndObject();
         }
+
+        ar.EndArray();
 
         // free_ids
         ar("free_ids") << em.free_ids;

--- a/EngineCore/Include/SimpleEngine/ECS/World.h
+++ b/EngineCore/Include/SimpleEngine/ECS/World.h
@@ -30,6 +30,8 @@ class Query;
  */
 class SE_CORE_API World final
 {
+    friend class ECSRegistry;
+
 public:
     class EntityChain;
 

--- a/EngineCore/Include/SimpleEngine/ECS/World.h
+++ b/EngineCore/Include/SimpleEngine/ECS/World.h
@@ -44,7 +44,7 @@ public:
     World& operator=(World&&) = delete;
 
 public:
-    /** 모든 엔티티, 컴포넌트, 리소스를 제거하고 초기 상태로 되돌립니다. */
+    /** 모든 엔티티, 컴포넌트를 제거하고 초기 상태로 되돌립니다. */
     void Reset();
 
 public:

--- a/EngineCore/Include/SimpleEngine/ECS/World.h
+++ b/EngineCore/Include/SimpleEngine/ECS/World.h
@@ -44,6 +44,10 @@ public:
     World& operator=(World&&) = delete;
 
 public:
+    /** 모든 엔티티, 컴포넌트, 리소스를 제거하고 초기 상태로 되돌립니다. */
+    void Reset();
+
+public:
     /** Entity를 생성합니다. */
     template <typename... Components>
     EntityChain SpawnEntity(Components&&... comps)

--- a/EngineCore/Include/SimpleEngine/ECS/World.h
+++ b/EngineCore/Include/SimpleEngine/ECS/World.h
@@ -203,6 +203,12 @@ public:
     }
 
 public:
+    /** Schedule에서 현재 활성 CommandBuffer를 설정합니다. */
+    void SetActiveCommandBuffer(CommandBuffer* buffer) { active_command_buffer = buffer; }
+
+    /** 현재 활성 CommandBuffer를 반환합니다. */
+    [[nodiscard]] CommandBuffer* GetActiveCommandBuffer() const { return active_command_buffer; }
+
     /**
      * 주어진 TypeId에 해당하는 IComponentStorage 포인터를 반환합니다.
      * @param type_id 검색할 타입의 TypeId
@@ -268,6 +274,8 @@ private:
         return GetOrCreateComponentStorage<ComponentType>().GetStorage();
     }
 
+    friend SE_CORE_API void Serialize(Archive& ar, World& world);
+
 public:
     class EntityChain
     {
@@ -299,13 +307,6 @@ public:
         World& world;
         Entity entity;
     };
-
-public:
-    /** Schedule에서 현재 활성 CommandBuffer를 설정합니다. */
-    void SetActiveCommandBuffer(CommandBuffer* buffer) { active_command_buffer = buffer; }
-
-    /** 현재 활성 CommandBuffer를 반환합니다. */
-    [[nodiscard]] CommandBuffer* GetActiveCommandBuffer() const { return active_command_buffer; }
 
 private:
     EntityManager entity_manager;

--- a/EngineCore/Include/SimpleEngine/ECS/World.h
+++ b/EngineCore/Include/SimpleEngine/ECS/World.h
@@ -33,6 +33,11 @@ class SE_CORE_API World final
     friend class ECSRegistry;
 
 public:
+    // 직렬화 파일 포맷 상수
+    static constexpr uint32 FILE_MAGIC = 0x44574553; // "SEWD" little-endian
+    static constexpr uint32 FILE_VERSION = 1;
+
+public:
     class EntityChain;
 
     World() = default;

--- a/EngineCore/Source/ECS/Components/GlobalTransformComponent.cpp
+++ b/EngineCore/Source/ECS/Components/GlobalTransformComponent.cpp
@@ -6,7 +6,7 @@
 
 namespace se
 {
-SE_BEGIN_REFLECT(GlobalTransformComponent, meta::Reflect, meta::Component)
+SE_BEGIN_REFLECT(GlobalTransformComponent, meta::EditorOnly, meta::Component)
     SE_REFLECT_PROPERTY(value, meta::Property, meta::ReadOnly)
 SE_END_REFLECT(GlobalTransformComponent)
 }

--- a/EngineCore/Source/ECS/ECSRegistry.cpp
+++ b/EngineCore/Source/ECS/ECSRegistry.cpp
@@ -1,4 +1,5 @@
 #include "SimpleEngine/ECS/ECSRegistry.h"
+#include "SimpleEngine/Core/Reflection/TypeRegistry.h"
 
 
 namespace se
@@ -17,5 +18,22 @@ Optional<const ComponentOps&> ECSRegistry::GetComponentOps(const TypeId& type_id
 Optional<const ResourceOps&> ECSRegistry::GetResourceOps(const TypeId& type_id) const
 {
     return resource_operators.Find(type_id);
+}
+
+// TODO: 한계점
+// 1. 기본 생성자(default-constructed) 값만 삽입 -- 커스텀 초기화가 필요한 Transient Resource는 별도 처리 필요
+// 2. ECSRegistry에 등록된 Resource만 대상 -- 미등록 Resource는 누락됨
+// 3. ETypeFlags::Transient 판별이 meta::EditorOnly에 의존 -- 네이밍이 의도와 불일치 (별도 개선 예정)
+void ECSRegistry::InsertDefaultTransientResources(World& world) const
+{
+    const auto& registry = TypeRegistry::Get();
+    for (const auto& [type_id, ops] : resource_operators)
+    {
+        if (auto info_opt = registry.Find(type_id);
+            info_opt.HasValue() && info_opt->flags.IsSet(ETypeFlags::Transient) && !ops.has_resource(world))
+        {
+            ops.insert_default(world);
+        }
+    }
 }
 } // namespace se

--- a/EngineCore/Source/ECS/EntitySubsystem.cpp
+++ b/EngineCore/Source/ECS/EntitySubsystem.cpp
@@ -1,7 +1,7 @@
 #include "SimpleEngine/ECS/EntitySubsystem.h"
 
 #include "SimpleEngine/Core/Subsystem/SubsystemRegistration.h"
-#include "SimpleEngine/Core/Time/Time.h"
+#include "SimpleEngine/ECS/ECSRegistry.h"
 #include "SimpleEngine/Utility/Debug.h"
 
 #include <ranges>
@@ -38,14 +38,8 @@ WorldContext& EntitySubsystem::GetOrCreateWorld(const StringName& name)
 {
     WorldContext& ctx = worlds.Entry(name).OrInsertWith([] { return WorldContext{}; });
 
-    // World 생성 시 시간 Resource를 최초 등록
-    World& world = ctx.GetWorld();
-    if (!world.HasResource<RealTime>())
-    {
-        world.InsertResource<RealTime>();
-        world.InsertResource<GameTime>();
-        world.InsertResource<FixedTime>();
-    }
+    // Transient 리소스 (시간 등)를 최초 등록
+    ECSRegistry::Get().InsertDefaultTransientResources(ctx.GetWorld());
 
     return ctx;
 }

--- a/EngineCore/Source/ECS/World.cpp
+++ b/EngineCore/Source/ECS/World.cpp
@@ -110,6 +110,9 @@ void Serialize(Archive& ar, World& world)
             ar.SetError("Unsupported world file version");
             return;
         }
+
+        // Entity/Component 초기화 (Resource는 유지)
+        world.Reset();
     }
 
     // --- EntityManager ---

--- a/EngineCore/Source/ECS/World.cpp
+++ b/EngineCore/Source/ECS/World.cpp
@@ -1,5 +1,8 @@
 #include "SimpleEngine/ECS/World.h"
 
+#include "SimpleEngine/Core/Logging/Logging.h"
+#include "SimpleEngine/Core/Reflection/Meta.h"
+#include "SimpleEngine/Core/Reflection/TypeRegistry.h"
 #include "SimpleEngine/ECS/ComponentStorage.h"
 #include "SimpleEngine/ECS/ECSRegistry.h"
 
@@ -8,6 +11,29 @@
 
 namespace se
 {
+namespace
+{
+constexpr uint32 WORLD_FILE_MAGIC = 0x44574553; // "SEWD" little-endian
+constexpr uint32 WORLD_FILE_VERSION = 1;
+
+/**
+ * 직렬화 대상 여부를 판정합니다.
+ * Transient이거나 serialize 콜백이 없으면 제외
+ */
+[[nodiscard]] bool ShouldSerializeType(const TypeInfo& info)
+{
+    if (info.flags.IsSet(ETypeFlags::Transient))
+    {
+        return false;
+    }
+    if (info.serialize == nullptr)
+    {
+        return false;
+    }
+    return true;
+}
+} // namespace
+
 void World::DestroyEntity(Entity entity)
 {
     for (const auto& storage : component_storages | std::views::values)
@@ -22,21 +48,6 @@ void World::DestroyEntity(Entity entity)
     }
 
     entity_manager.Destroy(entity);
-}
-
-IComponentStorage* World::GetOrCreateRawStorage(const TypeId& type_id)
-{
-    if (const auto storage = component_storages.Find(type_id))
-    {
-        return storage->get();
-    }
-
-    if (const auto ops = ECSRegistry::Get().GetComponentOps(type_id))
-    {
-        return ops->ensure_storage(*this);
-    }
-
-    return nullptr;
 }
 
 IComponentStorage* World::FindRawStorage(const TypeId& type_id)
@@ -57,5 +68,164 @@ const IComponentStorage* World::FindRawStorage(const TypeId& type_id) const
     }
 
     return nullptr;
+}
+
+IComponentStorage* World::GetOrCreateRawStorage(const TypeId& type_id)
+{
+    if (const auto storage = component_storages.Find(type_id))
+    {
+        return storage->get();
+    }
+
+    if (const auto ops = ECSRegistry::Get().GetComponentOps(type_id))
+    {
+        return ops->ensure_storage(*this);
+    }
+
+    return nullptr;
+}
+
+void Serialize(Archive& ar, World& world)
+{
+    // --- Header ---
+    uint32 magic = WORLD_FILE_MAGIC;
+    uint32 version = WORLD_FILE_VERSION;
+    ar("magic") << magic;
+    ar("version") << version;
+
+    if (ar.IsLoading())
+    {
+        SE_ASSERT(magic == WORLD_FILE_MAGIC, "Invalid world file magic: 0x{:08X}", magic);
+        SE_ASSERT(version == WORLD_FILE_VERSION, "Unsupported world file version: {}", version);
+    }
+
+    // --- EntityManager ---
+    ar("entity_manager") << world.entity_manager;
+
+    // --- Alive Entities ---
+    ar("alive_entities") << world.alive_entities;
+
+    // --- Components ---
+    const TypeRegistry& registry = TypeRegistry::Get();
+    const ECSRegistry& ecs_registry = ECSRegistry::Get();
+
+    if (ar.IsSaving())
+    {
+        // 직렬화 대상 storage 수 카운트
+        uint64 type_count = 0;
+        for (const auto& [type_id, storage] : world.component_storages)
+        {
+            if (storage->IsEmpty())
+            {
+                continue;
+            }
+
+            if (const auto info = registry.Find(type_id))
+            {
+                if (ShouldSerializeType(*info))
+                {
+                    ++type_count;
+                }
+            }
+        }
+
+        ar("components");
+        ar.BeginMap(type_count);
+        for (auto& [type_id, storage] : world.component_storages)
+        {
+            if (storage->IsEmpty())
+            {
+                continue;
+            }
+
+            auto info_opt = registry.Find(type_id);
+            if (!info_opt.HasValue() || !ShouldSerializeType(*info_opt))
+            {
+                continue;
+            }
+
+            ar.BeginMapKey();
+            ar << type_id;
+            ar.EndMapKey();
+
+            ar.BeginMapValue();
+            uint64 entity_count = storage->Len();
+            ar.BeginArray(entity_count);
+            for (uint64 i = 0; i < entity_count; ++i)
+            {
+                Entity entity = *storage->GetEntityByIndex(static_cast<usize>(i));
+                void* raw = storage->GetRaw(entity);
+
+                ar.BeginObject();
+                ar("entity") << entity;
+                ar("data");
+                info_opt->serialize(ar, raw);
+                ar.EndObject();
+            }
+            ar.EndArray();
+            ar.EndMapValue();
+        }
+        ar.EndMap();
+    }
+    else // Loading
+    {
+        uint64 type_count = 0;
+        ar("components");
+        ar.BeginMap(type_count);
+        for (uint64 t = 0; t < type_count; ++t)
+        {
+            ar.BeginMapKey();
+            TypeId type_id;
+            ar << type_id;
+            ar.EndMapKey();
+
+            ar.BeginMapValue();
+
+            const auto info_opt = registry.Find(type_id);
+            const auto ops_opt = ecs_registry.GetComponentOps(type_id);
+
+            if (!info_opt.HasValue() || !ops_opt.HasValue())
+            {
+                // 미등록 타입: binary에서는 skip 불가 -> 경고 후 배열만 소모
+                ConsoleLog(ELogLevel::Warning, "World deserialization: unknown component type '{}', skipping.", type_id.GetName());
+                uint64 entity_count = 0;
+                ar.BeginArray(entity_count);
+                for (uint64 i = 0; i < entity_count; ++i)
+                {
+                    ar.BeginObject();
+                    Entity dummy_entity;
+                    ar("entity") << dummy_entity;
+                    // data는 skip 불가 (binary) -> text에서만 안전
+                    ar.EndObject();
+                }
+                ar.EndArray();
+                ar.EndMapValue();
+                continue;
+            }
+
+            uint64 entity_count = 0;
+            IComponentStorage* storage = ops_opt->ensure_storage(world);
+
+            ar.BeginArray(entity_count);
+            for (uint64 i = 0; i < entity_count; ++i)
+            {
+                ar.BeginObject();
+
+                Entity entity;
+                ar("entity") << entity;
+
+                // 기본 생성한 뒤 raw ptr에 역직렬화로 덮어쓰기
+                storage->EmplaceDefault(entity);
+                void* raw = storage->GetRaw(entity);
+                ar("data");
+                info_opt->serialize(ar, raw);
+
+                ar.EndObject();
+            }
+            ar.EndArray();
+            ar.EndMapValue();
+        }
+        ar.EndMap();
+    }
 }
 } // namespace se

--- a/EngineCore/Source/ECS/World.cpp
+++ b/EngineCore/Source/ECS/World.cpp
@@ -13,9 +13,6 @@ namespace se
 {
 namespace
 {
-constexpr uint32 WORLD_FILE_MAGIC = 0x44574553; // "SEWD" little-endian
-constexpr uint32 WORLD_FILE_VERSION = 1;
-
 /**
  * 직렬화 대상 여부를 판정합니다.
  * Transient이거나 serialize 콜백이 없으면 제외
@@ -96,15 +93,15 @@ IComponentStorage* World::GetOrCreateRawStorage(const TypeId& type_id)
 void Serialize(Archive& ar, World& world)
 {
     // --- Header ---
-    uint32 magic = WORLD_FILE_MAGIC;
-    uint32 version = WORLD_FILE_VERSION;
+    uint32 magic = World::FILE_MAGIC;
+    uint32 version = World::FILE_VERSION;
     ar("magic") << magic;
     ar("version") << version;
 
     if (ar.IsLoading())
     {
-        SE_ASSERT(magic == WORLD_FILE_MAGIC, "Invalid world file magic: 0x{:08X}", magic);
-        SE_ASSERT(version == WORLD_FILE_VERSION, "Unsupported world file version: {}", version);
+        SE_ASSERT(magic == World::FILE_MAGIC, "Invalid world file magic: 0x{:08X}", magic);
+        SE_ASSERT(version == World::FILE_VERSION, "Unsupported world file version: {}", version);
     }
 
     // --- EntityManager ---

--- a/EngineCore/Source/ECS/World.cpp
+++ b/EngineCore/Source/ECS/World.cpp
@@ -34,6 +34,14 @@ constexpr uint32 WORLD_FILE_VERSION = 1;
 }
 } // namespace
 
+void World::Reset()
+{
+    component_storages.Clear();
+    alive_entities.Clear();
+    entity_manager.Reset();
+    active_command_buffer = nullptr;
+}
+
 void World::DestroyEntity(Entity entity)
 {
     for (const auto& storage : component_storages | std::views::values)

--- a/EngineCore/Source/ECS/World.cpp
+++ b/EngineCore/Source/ECS/World.cpp
@@ -100,8 +100,16 @@ void Serialize(Archive& ar, World& world)
 
     if (ar.IsLoading())
     {
-        SE_ASSERT(magic == World::FILE_MAGIC, "Invalid world file magic: 0x{:08X}", magic);
-        SE_ASSERT(version == World::FILE_VERSION, "Unsupported world file version: {}", version);
+        if (magic != World::FILE_MAGIC)
+        {
+            ar.SetError("Invalid world file magic");
+            return;
+        }
+        if (version != World::FILE_VERSION)
+        {
+            ar.SetError("Unsupported world file version");
+            return;
+        }
     }
 
     // --- EntityManager ---

--- a/EngineCore/Source/ECS/World.cpp
+++ b/EngineCore/Source/ECS/World.cpp
@@ -202,16 +202,21 @@ void Serialize(Archive& ar, World& world)
 
             if (!info_opt.HasValue() || !ops_opt.HasValue())
             {
-                // 미등록 타입: binary에서는 skip 불가 -> 경고 후 배열만 소모
+                if (ar.IsBinary())
+                {
+                    // TODO: 컴포넌트 블록에 byte_size를 저장하면 binary에서도 skip 가능
+                    // Binary: data block의 byte size를 모르므로 skip 불가 -> fatal
+                    ar.SetError("Unknown component type in binary archive (forward-skip not supported)");
+                    return;
+                }
+
+                // Text: key 기반이므로 미소비 데이터는 자동 무시됨
                 ConsoleLog(ELogLevel::Warning, "World deserialization: unknown component type '{}', skipping.", type_id.GetName());
                 uint64 entity_count = 0;
                 ar.BeginArray(entity_count);
                 for (uint64 i = 0; i < entity_count; ++i)
                 {
                     ar.BeginObject();
-                    Entity dummy_entity;
-                    ar("entity") << dummy_entity;
-                    // data는 skip 불가 (binary) -> text에서만 안전
                     ar.EndObject();
                 }
                 ar.EndArray();

--- a/EngineTest/Source/UnitTests/WorldSerializationTest.cpp
+++ b/EngineTest/Source/UnitTests/WorldSerializationTest.cpp
@@ -1,0 +1,225 @@
+#include "gtest/gtest.h"
+
+#include "SimpleEngine/Core/Serialization/MemoryArchive.h"
+#include "SimpleEngine/Core/Serialization/TomlArchive.h"
+#include "SimpleEngine/ECS/World.h"
+#include "SimpleEngine/ECS/Components/ChildrenComponent.h"
+#include "SimpleEngine/ECS/Components/GlobalTransformComponent.h"
+#include "SimpleEngine/ECS/Components/NameComponent.h"
+#include "SimpleEngine/ECS/Components/ParentComponent.h"
+#include "SimpleEngine/ECS/Components/TransformComponent.h"
+
+using namespace se;
+
+
+namespace
+{
+
+// --- Binary round-trip helper ---
+void BinaryRoundTrip(World& src, World& dst)
+{
+    Array<uint8> buffer;
+    {
+        MemoryWriter writer(buffer);
+        writer << src;
+    }
+    {
+        MemoryReader reader(buffer);
+        reader << dst;
+    }
+}
+
+// --- TOML round-trip helper ---
+void TomlRoundTrip(World& src, World& dst)
+{
+    toml::table tbl;
+    {
+        TomlWriter writer(tbl);
+        writer << src;
+    }
+    {
+        TomlReader reader(tbl);
+        reader << dst;
+    }
+}
+
+} // namespace
+
+
+class WorldSerializationTest : public ::testing::Test
+{
+};
+
+// 1) 빈 World 라운드트립
+TEST_F(WorldSerializationTest, EmptyWorld_Binary)
+{
+    World src;
+    World dst;
+    BinaryRoundTrip(src, dst);
+
+    EXPECT_TRUE(dst.GetAliveEntities().IsEmpty());
+}
+
+TEST_F(WorldSerializationTest, EmptyWorld_Toml)
+{
+    World src;
+    World dst;
+    TomlRoundTrip(src, dst);
+
+    EXPECT_TRUE(dst.GetAliveEntities().IsEmpty());
+}
+
+// 2) 엔티티 + 컴포넌트 기본 라운드트립 (Binary)
+TEST_F(WorldSerializationTest, BasicRoundTrip_Binary)
+{
+    World src;
+
+    Entity e1 = src.SpawnEntity(
+        NameComponent{ .name = "Entity_A" },
+        TransformComponent{
+            .position = Vector3(1.0, 2.0, 3.0),
+            .scale = Vector3(2.0, 2.0, 2.0),
+        }
+    );
+
+    Entity e2 = src.SpawnEntity(
+        NameComponent{ .name = "Entity_B" },
+        TransformComponent{
+            .position = Vector3(4.0, 5.0, 6.0),
+        }
+    );
+
+    World dst;
+    BinaryRoundTrip(src, dst);
+
+    // 엔티티 수 검증
+    EXPECT_EQ(dst.GetAliveEntities().Len(), 2u);
+    EXPECT_TRUE(dst.IsEntityAlive(e1));
+    EXPECT_TRUE(dst.IsEntityAlive(e2));
+
+    // 컴포넌트 값 검증
+    auto& name1 = dst.GetComponent<NameComponent>(e1);
+    EXPECT_EQ(name1.name, "Entity_A");
+
+    auto& t1 = dst.GetComponent<TransformComponent>(e1);
+    EXPECT_DOUBLE_EQ(t1.position.x, 1.0);
+    EXPECT_DOUBLE_EQ(t1.position.y, 2.0);
+    EXPECT_DOUBLE_EQ(t1.position.z, 3.0);
+    EXPECT_DOUBLE_EQ(t1.scale.x, 2.0);
+
+    auto& name2 = dst.GetComponent<NameComponent>(e2);
+    EXPECT_EQ(name2.name, "Entity_B");
+
+    auto& t2 = dst.GetComponent<TransformComponent>(e2);
+    EXPECT_DOUBLE_EQ(t2.position.x, 4.0);
+}
+
+// 3) 엔티티 + 컴포넌트 기본 라운드트립 (TOML)
+TEST_F(WorldSerializationTest, BasicRoundTrip_Toml)
+{
+    World src;
+
+    Entity e1 = src.SpawnEntity(
+        NameComponent{ .name = "Entity_A" },
+        TransformComponent{
+            .position = Vector3(1.0, 2.0, 3.0),
+        }
+    );
+
+    World dst;
+    TomlRoundTrip(src, dst);
+
+    EXPECT_EQ(dst.GetAliveEntities().Len(), 1u);
+    EXPECT_TRUE(dst.IsEntityAlive(e1));
+
+    auto& name = dst.GetComponent<NameComponent>(e1);
+    EXPECT_EQ(name.name, "Entity_A");
+
+    auto& t = dst.GetComponent<TransformComponent>(e1);
+    EXPECT_DOUBLE_EQ(t.position.x, 1.0);
+    EXPECT_DOUBLE_EQ(t.position.y, 2.0);
+    EXPECT_DOUBLE_EQ(t.position.z, 3.0);
+}
+
+// 4) EntityManager 상태 보존 (생성 -> 삭제 -> 재생성 후 generation/free_ids 검증)
+TEST_F(WorldSerializationTest, EntityManagerStatePreservation_Binary)
+{
+    World src;
+
+    Entity e1 = src.SpawnEntity(NameComponent{ .name = "first" });
+    Entity e2 = src.SpawnEntity(NameComponent{ .name = "second" });
+    Entity e3 = src.SpawnEntity(NameComponent{ .name = "third" });
+
+    // e2를 삭제 -> free_ids에 e2 슬롯 추가, generation 증가
+    src.DestroyEntity(e2);
+
+    // 새 엔티티 생성 -> e2의 슬롯을 재사용하되 generation이 다름
+    Entity e4 = src.SpawnEntity(NameComponent{ .name = "fourth" });
+    EXPECT_EQ(e4.GetId(), e2.GetId());            // 같은 슬롯
+    EXPECT_NE(e4.GetGeneration(), e2.GetGeneration()); // 다른 세대
+
+    World dst;
+    BinaryRoundTrip(src, dst);
+
+    // e1, e3, e4는 살아있고 e2는 죽어있어야 함
+    EXPECT_TRUE(dst.IsEntityAlive(e1));
+    EXPECT_FALSE(dst.IsEntityAlive(e2));
+    EXPECT_TRUE(dst.IsEntityAlive(e3));
+    EXPECT_TRUE(dst.IsEntityAlive(e4));
+
+    EXPECT_EQ(dst.GetComponent<NameComponent>(e4).name, "fourth");
+}
+
+// 5) 부모-자식 관계 (Entity 참조 무결성)
+TEST_F(WorldSerializationTest, ParentChildRelationship_Binary)
+{
+    World src;
+
+    Entity parent = src.SpawnEntity(NameComponent{ .name = "parent" });
+    Entity child1 = src.SpawnEntity(NameComponent{ .name = "child1" });
+    Entity child2 = src.SpawnEntity(NameComponent{ .name = "child2" });
+
+    // 부모-자식 관계 수동 설정
+    src.AddComponent<ParentComponent>(child1, ParentComponent{ .parent = parent });
+    src.AddComponent<ParentComponent>(child2, ParentComponent{ .parent = parent });
+    src.AddComponent<ChildrenComponent>(parent, ChildrenComponent{ .children = { child1, child2 } });
+
+    World dst;
+    BinaryRoundTrip(src, dst);
+
+    // Entity 참조가 ID 보존으로 그대로 유효한지 검증
+    auto& p1 = dst.GetComponent<ParentComponent>(child1);
+    EXPECT_EQ(p1.parent, parent);
+
+    auto& p2 = dst.GetComponent<ParentComponent>(child2);
+    EXPECT_EQ(p2.parent, parent);
+
+    auto& ch = dst.GetComponent<ChildrenComponent>(parent);
+    EXPECT_EQ(ch.children.Len(), 2u);
+    EXPECT_TRUE(ch.children.Contains(child1));
+    EXPECT_TRUE(ch.children.Contains(child2));
+}
+
+// 6) Transient 컴포넌트 필터링 (GlobalTransformComponent 제외 확인)
+TEST_F(WorldSerializationTest, TransientComponentFiltered_Binary)
+{
+    World src;
+
+    Entity e = src.SpawnEntity(
+        TransformComponent{ .position = Vector3(1.0, 0.0, 0.0) },
+        GlobalTransformComponent{ .value = Matrix4x4::Identity() }
+    );
+
+    // 직렬화 전에 GlobalTransformComponent이 있는지 확인
+    EXPECT_TRUE(src.HasComponent<GlobalTransformComponent>(e));
+
+    World dst;
+    BinaryRoundTrip(src, dst);
+
+    // TransformComponent은 복원되어야 함
+    EXPECT_TRUE(dst.HasComponent<TransformComponent>(e));
+    EXPECT_DOUBLE_EQ(dst.GetComponent<TransformComponent>(e).position.x, 1.0);
+
+    // GlobalTransformComponent은 Transient이므로 복원되지 않아야 함
+    EXPECT_FALSE(dst.HasComponent<GlobalTransformComponent>(e));
+}

--- a/EngineTest/Source/UnitTests/WorldSerializationTest.cpp
+++ b/EngineTest/Source/UnitTests/WorldSerializationTest.cpp
@@ -126,19 +126,93 @@ TEST_F(WorldSerializationTest, BasicRoundTrip_Toml)
         }
     );
 
+    Entity e2 = src.SpawnEntity(
+        NameComponent{ .name = "Entity_B" },
+        TransformComponent{
+            .position = Vector3(4.0, 5.0, 6.0),
+        }
+    );
+
     World dst;
     TomlRoundTrip(src, dst);
 
-    EXPECT_EQ(dst.GetAliveEntities().Len(), 1u);
+    EXPECT_EQ(dst.GetAliveEntities().Len(), 2u);
     EXPECT_TRUE(dst.IsEntityAlive(e1));
+    EXPECT_TRUE(dst.IsEntityAlive(e2));
 
-    auto& name = dst.GetComponent<NameComponent>(e1);
-    EXPECT_EQ(name.name, "Entity_A");
+    auto& name1 = dst.GetComponent<NameComponent>(e1);
+    EXPECT_EQ(name1.name, "Entity_A");
 
-    auto& t = dst.GetComponent<TransformComponent>(e1);
-    EXPECT_DOUBLE_EQ(t.position.x, 1.0);
-    EXPECT_DOUBLE_EQ(t.position.y, 2.0);
-    EXPECT_DOUBLE_EQ(t.position.z, 3.0);
+    auto& t1 = dst.GetComponent<TransformComponent>(e1);
+    EXPECT_DOUBLE_EQ(t1.position.x, 1.0);
+    EXPECT_DOUBLE_EQ(t1.position.y, 2.0);
+    EXPECT_DOUBLE_EQ(t1.position.z, 3.0);
+
+    auto& name2 = dst.GetComponent<NameComponent>(e2);
+    EXPECT_EQ(name2.name, "Entity_B");
+
+    auto& t2 = dst.GetComponent<TransformComponent>(e2);
+    EXPECT_DOUBLE_EQ(t2.position.x, 4.0);
+    EXPECT_DOUBLE_EQ(t2.position.y, 5.0);
+    EXPECT_DOUBLE_EQ(t2.position.z, 6.0);
+}
+
+// 3-1) TOML 다수 엔티티 + Destroy/재사용 (EntityManager 상태 보존)
+TEST_F(WorldSerializationTest, EntityManagerStatePreservation_Toml)
+{
+    World src;
+
+    Entity e1 = src.SpawnEntity(NameComponent{ .name = "first" });
+    Entity e2 = src.SpawnEntity(NameComponent{ .name = "second" });
+    Entity e3 = src.SpawnEntity(NameComponent{ .name = "third" });
+
+    // e2를 삭제 -> free_ids에 e2 슬롯 추가, generation 증가
+    src.DestroyEntity(e2);
+
+    // 새 엔티티 생성 -> e2의 슬롯을 재사용하되 generation이 다름
+    Entity e4 = src.SpawnEntity(NameComponent{ .name = "fourth" });
+    EXPECT_EQ(e4.GetId(), e2.GetId());
+    EXPECT_NE(e4.GetGeneration(), e2.GetGeneration());
+
+    World dst;
+    TomlRoundTrip(src, dst);
+
+    EXPECT_TRUE(dst.IsEntityAlive(e1));
+    EXPECT_FALSE(dst.IsEntityAlive(e2));
+    EXPECT_TRUE(dst.IsEntityAlive(e3));
+    EXPECT_TRUE(dst.IsEntityAlive(e4));
+
+    EXPECT_EQ(dst.GetComponent<NameComponent>(e1).name, "first");
+    EXPECT_EQ(dst.GetComponent<NameComponent>(e3).name, "third");
+    EXPECT_EQ(dst.GetComponent<NameComponent>(e4).name, "fourth");
+}
+
+// 3-2) TOML 부모-자식 참조 무결성 (다수 Entity 참조)
+TEST_F(WorldSerializationTest, ParentChildRelationship_Toml)
+{
+    World src;
+
+    Entity parent = src.SpawnEntity(NameComponent{ .name = "parent" });
+    Entity child1 = src.SpawnEntity(NameComponent{ .name = "child1" });
+    Entity child2 = src.SpawnEntity(NameComponent{ .name = "child2" });
+
+    src.AddComponent<ParentComponent>(child1, ParentComponent{ .parent = parent });
+    src.AddComponent<ParentComponent>(child2, ParentComponent{ .parent = parent });
+    src.AddComponent<ChildrenComponent>(parent, ChildrenComponent{ .children = { child1, child2 } });
+
+    World dst;
+    TomlRoundTrip(src, dst);
+
+    auto& p1 = dst.GetComponent<ParentComponent>(child1);
+    EXPECT_EQ(p1.parent, parent);
+
+    auto& p2 = dst.GetComponent<ParentComponent>(child2);
+    EXPECT_EQ(p2.parent, parent);
+
+    auto& ch = dst.GetComponent<ChildrenComponent>(parent);
+    EXPECT_EQ(ch.children.Len(), 2u);
+    EXPECT_TRUE(ch.children.Contains(child1));
+    EXPECT_TRUE(ch.children.Contains(child2));
 }
 
 // 4) EntityManager 상태 보존 (생성 -> 삭제 -> 재생성 후 generation/free_ids 검증)


### PR DESCRIPTION
> 아래 PR 메시지는 Claude Opus 4.6을 사용하여 작성하였습니다.

## 이 PR이 해결하는 문제

에디터에서 배치한 엔티티/컴포넌트를 파일로 저장하고 다시 불러올 수 없었음. Scene 전환, 에디터 작업 저장의 기반이 되는 기능.

## 핵심 아키텍처 결정과 그 이유

### 1. Resource는 직렬화하지 않는다

**라이프사이클이 Scene과 다름.** Resource(Time, Input State, Render Config 등)는 엔진 시작 시 생성되어 애플리케이션 종료까지 존재하는 인프라 데이터. Scene 전환으로 사라지면 안 됨. Entity/Component는 "씬의 콘텐츠"이고, Resource는 "씬을 실행하기 위한 환경". 이 둘의 수명이 다르므로 같은 직렬화 단위에 묶으면 안 됨.

**작성자(authored) vs 파생값(derived) 문제.** 디자이너가 에디터에서 "만드는" 것은 Entity와 Component(위치, 메시, 머티리얼 등). Resource는 디자이너가 값을 지정하지 않음 -- 매 프레임 갱신되거나(Time), 프로젝트 설정 파일에서 읽히거나(Render Config), 하드웨어에서 수집됨(Input State). 저장할 "작성 의도"가 없는 데이터를 Scene에 포함하면, 로드 시 현재 런타임 상태를 파일의 과거 스냅샷으로 덮어쓰게 됨 (예: 저장 시점의 Time 값으로 현재 Time을 덮어씀).

**Reset 의미론이 깔끔해짐.** Resource를 직렬화하면 `Reset()`이 Resource도 날려야 하고, 재초기화 책임 문제가 생김 ("누가 어떤 Resource를 다시 만들어야 하나?"). 제외하면 `Reset()`은 Entity/Component만 초기화하면 되고, Resource는 항상 존재 -- Scene 전환 시 인프라가 끊기지 않음.

**Scene별 설정이 필요해지면?** Singleton Entity + Component 패턴 사용. UE의 WorldSettings Actor와 동일. Resource가 아닌 Component로 만들면 Scene 저장에 자연스럽게 포함되고, 에디터에서 편집 가능.

(참고: UE/Unity/Bevy 모두 같은 결론 -- Resource 성격의 데이터를 Scene에 넣지 않음. 이유가 같기 때문.)

### 2. Entity ID를 보존한다 (리매핑 안 함)

EntityManager의 records/free_ids/next_id를 그대로 저장해서 Entity ID가 파일에 기록된 값 그대로 복원됨. 덕분에 ParentComponent의 `Optional<Entity> parent`, ChildrenComponent의 `Array<Entity> children` 등 모든 Entity 참조가 추가 처리 없이 유효.

리매핑을 하려면 모든 컴포넌트의 모든 프로퍼티를 재귀 순회하면서 Entity 타입 필드를 찾아야 하고, `HashMap<Entity, V>`의 키 변경(=Map 재건), `Optional<Entity>`, `Array<Entity>` 등 컨테이너별 엣지 케이스가 많음. 구현 비용 대비 v1에서 얻는 이점 없음. Prefab 인스턴싱에서 Merge가 필요해지면 그때 별도 시스템으로.

**트레이드오프**: "빈 World에만 로드 가능". 현재 사용 사례(에디터 씬 저장/로드 = 전체 교체)에서는 문제 없음.

### 3. Component-centric (column-major) 레이아웃

SparseSet의 dense 배열을 타입별로 순회. Entity-centric(행 단위)은 각 엔티티마다 "이 엔티티가 가진 컴포넌트 목록"을 구하려면 모든 storage를 탐색해야 함 -- O(엔티티 x 타입 수). 우리 ECS에는 "엔티티 -> 컴포넌트 목록" 인덱스가 없고, SparseSet이 타입별로 존재하므로 column-major가 자연스러움. 각 storage의 dense 배열을 순차 접근하면 O(전체 인스턴스 수)이고 캐시 친화적.

### 4. ADL friend Serialize 패턴

엔진 전체가 `friend void Serialize(Archive& ar, T& value)` + `ar << value` 디스패치 체인. World도 동일 패턴을 따라야 `ar << world;`가 자연스럽게 동작. 별도 Serializer 클래스를 만들면 `ar <<` 체인에서 이탈하고, stateless인데 클래스화할 이유 없음.

## 구현 중 부딪힌 함정

### ensure_storage 순환 참조 (스택 오버플로)

`GetOrCreateRawStorage(TypeId)` -> ECSRegistry의 `ensure_storage` 람다 -> `GetOrCreateRawStorage<T>()` -> 다시 non-template `GetOrCreateRawStorage(TypeId)` -> 무한 재귀.

원인: `ensure_storage` 람다가 storage를 실제로 생성하는 `GetOrCreateComponentStorage<T>()`가 아니라, non-template public wrapper를 호출했음. 이 wrapper가 다시 ensure_storage를 타면서 루프.

해결: `ECSRegistry`를 `World`의 friend로 추가, 람다가 `GetOrCreateComponentStorage<T>()`를 직접 호출.

### atomic 때문에 EntityManager 대입 불가

`std::atomic<uint32> next_id` -> copy/move assign 불가 -> `entity_manager = EntityManager{}` 컴파일 에러. `Reset()` 메서드를 만들어 멤버별 개별 초기화.

## Transient 필터링 체계

`meta::EditorOnly` -> `ETypeFlags::Transient`. 직렬화 시 3가지 조건으로 필터:
1. `ETypeFlags::Transient` 설정된 타입 (GlobalTransformComponent, Time 계열)
2. `TypeInfo::serialize == nullptr` (반영만 되고 직렬화 미지원)
3. 빈 storage (엔티티 0개)

**`meta::EditorOnly` 네이밍 문제**: 실제 의미는 "UI 표시 전용, 직렬화 제외"인데 "에디터에서만 존재"로 오해 가능. 별도 작업 예정.

## 포맷

Binary(MemoryArchive), TOML(TomlArchive) 동시 지원. Archive 추상화로 같은 코드가 양쪽에서 동작.

- **Binary**: 순서 의존, 빠름. 미등록 타입 시 forward-skip 불가 (v1 한계)
- **TOML**: 키 기반, 필드 추가/삭제에 자연 호환. 장기 저장/디버깅용

매직 넘버 `0x44574553` ("SEWD" little-endian)로 로드 시 포맷 자동 판별.

## InsertDefaultTransientResources의 존재 이유

이전: EntitySubsystem에서 `InsertResource<RealTime>()`, `InsertResource<GameTime>()`, `InsertResource<FixedTime>()` 수동 호출. 새 Transient Resource 추가 때마다 여기를 수정해야 하는 것은 잊기 쉬운 수동 작업. ECSRegistry에 등록된 Transient Resource를 일괄 삽입하도록 자동화.

**한계** (TODO 참고): 기본 생성자만 사용, 미등록 Resource 누락, EditorOnly 네이밍 혼란.

## 에디터 UI

- **New World** (Ctrl+N): `world.Reset()` -- Resource 유지, Entity/Component만 클리어
- **Save Binary/TOML** (Ctrl+S/Ctrl+Shift+S): 현재 상태 캡처 -> FileDialog -> 파일 쓰기
- **Load** (Ctrl+O): 파일 읽기 -> 매직으로 포맷 판별 -> Reset -> Deserialize

## 향후 확장 포인트

- **Binary forward-skip**: 컴포넌트 블록 앞에 byte_size 기록 -> 미등록 타입 스킵
- **Merge 모드 + ID 리매핑**: Prefab 인스턴싱 필요 시
- **Singleton Entity 패턴**: Scene별 설정 필요 시 Resource 대신 사용
- **Per-type 버전 + 마이그레이션 콜백**: 스키마 변경 대응    
