### PR TITLE
[Feature] 컨테이너 API 리팩토링 및 IterChain 추가

### DIFF
--- a/Editor/Include/SimpleEditor/Asset/Pipeline/AssetImporter.h
+++ b/Editor/Include/SimpleEditor/Asset/Pipeline/AssetImporter.h
@@ -113,7 +113,8 @@ void AssetImporter::RegisterTranslator(Args&&... args)
 
     for (const StringView& ext : instance->GetSupportedExtensions())
     {
-        extension_to_translator_indices[String(ext).ToLower()].Push(new_index);
+        String lower_ext = String{ ext }.ToLower();
+        extension_to_translator_indices.Entry(std::move(lower_ext)).OrDefault().Push(new_index);
     }
 
     translators.Push({

--- a/Editor/Source/Asset/Pipeline/AssetImporter.cpp
+++ b/Editor/Source/Asset/Pipeline/AssetImporter.cpp
@@ -207,7 +207,7 @@ Array<PipelineBaseNode*> AssetImporter::SortNodesByDependency(const PipelineNode
             if (container.Contains(dependency_id))
             {
                 // 역방향 그래프 구축: 의존성(부모) -> 의존자(자식) 관계 저장
-                dependents_map[dependency_id].Push(node_id);
+                dependents_map.Entry(dependency_id).OrDefault().Push(node_id);
                 ++current_in_degree;
             }
         }

--- a/Editor/Source/Asset/Pipeline/ImportResult.cpp
+++ b/Editor/Source/Asset/Pipeline/ImportResult.cpp
@@ -78,7 +78,7 @@ String ImportResult::Builder::MakeUniqueName(const String& base_name)
     }
 
     // 중복 시 suffix 추가: Name_1, Name_2, ...
-    u32& suffix = next_suffix_map[base_name];
+    u32& suffix = next_suffix_map.Entry(base_name).OrDefault();
     ++suffix;
 
     String candidate;

--- a/Editor/Source/UI/EditorViewportSubsystem.cpp
+++ b/Editor/Source/UI/EditorViewportSubsystem.cpp
@@ -201,10 +201,10 @@ void EditorViewportSubsystem::Update(f64 delta_time)
             {
                 switch (GetViewportGizmoMode(focused_viewport))
                 {
-                    case EGizmoMode::Translate: SetViewportGizmoMode(focused_viewport, EGizmoMode::Rotate); break;
-                    case EGizmoMode::Rotate:    SetViewportGizmoMode(focused_viewport, EGizmoMode::Scale); break;
-                    case EGizmoMode::Scale:     SetViewportGizmoMode(focused_viewport, EGizmoMode::Translate); break;
-                    default: SE_UNREACHABLE();
+                case EGizmoMode::Translate: SetViewportGizmoMode(focused_viewport, EGizmoMode::Rotate); break;
+                case EGizmoMode::Rotate:    SetViewportGizmoMode(focused_viewport, EGizmoMode::Scale); break;
+                case EGizmoMode::Scale:     SetViewportGizmoMode(focused_viewport, EGizmoMode::Translate); break;
+                default: SE_UNREACHABLE();
                 }
             }
             else if (
@@ -302,7 +302,7 @@ void EditorViewportSubsystem::UpdateViewportSize(const StringName& viewport_id, 
     }
 
     // 텍스처가 없거나, 크기가 변경된 경우 재생성
-    ViewportState& state = viewports[viewport_id];
+    ViewportState& state = viewports.Entry(viewport_id).OrDefault();
 
     // 최초 뷰포트 등록 시 기본 포커스 대상으로 설정
     if (focused_viewport == StringName::None)
@@ -425,6 +425,44 @@ ECoordinateSpace EditorViewportSubsystem::GetViewportCoordinateSpace(const Strin
     }).ValueOr(ECoordinateSpace::World);
 }
 
+void EditorViewportSubsystem::SetViewportViewMode(const StringName& viewport_id, EViewMode mode)
+{
+    if (const auto state = viewports.Find(viewport_id))
+    {
+        state->view_mode = mode;
+        if (mode != EViewMode::Perspective)
+        {
+            state->ortho_camera.velocity = Vector3::Zero(); // 관성 초기화
+            switch (mode)
+            {
+            case EViewMode::Top:    state->ortho_camera.rotation = Rotator{ -90.0_deg, 0.0_deg,   0.0_deg }; break;
+            case EViewMode::Bottom: state->ortho_camera.rotation = Rotator{  90.0_deg, 0.0_deg,   0.0_deg }; break;
+            case EViewMode::Front:  state->ortho_camera.rotation = Rotator{   0.0_deg, 0.0_deg, 180.0_deg }; break;
+            case EViewMode::Back:   state->ortho_camera.rotation = Rotator{   0.0_deg, 0.0_deg,   0.0_deg }; break;
+            case EViewMode::Right:  state->ortho_camera.rotation = Rotator{   0.0_deg, 0.0_deg,  90.0_deg }; break;
+            case EViewMode::Left:   state->ortho_camera.rotation = Rotator{   0.0_deg, 0.0_deg, -90.0_deg }; break;
+            default: break;
+            }
+        }
+    }
+}
+
+void EditorViewportSubsystem::SetViewportCursorPosition(const StringName& viewport_id, const Vector2f& pos)
+{
+    if (const auto state = viewports.Find(viewport_id))
+    {
+        state->cursor_viewport_pos = pos;
+    }
+}
+
+EViewMode EditorViewportSubsystem::GetViewportViewMode(const StringName& viewport_id) const
+{
+    return viewports.Find(viewport_id).Map([](const ViewportState& state)
+    {
+        return state.view_mode;
+    }).ValueOr(EViewMode::Perspective);
+}
+
 void* EditorViewportSubsystem::GetViewportTextureID(const StringName& viewport_id) const
 {
     if (const auto state = viewports.Find(viewport_id))
@@ -454,43 +492,5 @@ Optional<EditorCameraState&> EditorViewportSubsystem::GetViewportCamera(const St
     {
         return (state.view_mode == EViewMode::Perspective) ? state.persp_camera : state.ortho_camera;
     });
-}
-
-void EditorViewportSubsystem::SetViewportViewMode(const StringName& viewport_id, EViewMode mode)
-{
-    if (const auto state = viewports.Find(viewport_id))
-    {
-        state->view_mode = mode;
-        if (mode != EViewMode::Perspective)
-        {
-            state->ortho_camera.velocity = Vector3::Zero(); // 관성 초기화
-            switch (mode)
-            {
-            case EViewMode::Top:    state->ortho_camera.rotation = Rotator{ -90.0_deg, 0.0_deg,   0.0_deg }; break;
-            case EViewMode::Bottom: state->ortho_camera.rotation = Rotator{  90.0_deg, 0.0_deg,   0.0_deg }; break;
-            case EViewMode::Front:  state->ortho_camera.rotation = Rotator{   0.0_deg, 0.0_deg, 180.0_deg }; break;
-            case EViewMode::Back:   state->ortho_camera.rotation = Rotator{   0.0_deg, 0.0_deg,   0.0_deg }; break;
-            case EViewMode::Right:  state->ortho_camera.rotation = Rotator{   0.0_deg, 0.0_deg,  90.0_deg }; break;
-            case EViewMode::Left:   state->ortho_camera.rotation = Rotator{   0.0_deg, 0.0_deg, -90.0_deg }; break;
-            default: break;
-            }
-        }
-    }
-}
-
-EViewMode EditorViewportSubsystem::GetViewportViewMode(const StringName& viewport_id) const
-{
-    return viewports.Find(viewport_id).Map([](const ViewportState& state)
-    {
-        return state.view_mode;
-    }).ValueOr(EViewMode::Perspective);
-}
-
-void EditorViewportSubsystem::SetViewportCursorPosition(const StringName& viewport_id, const Vector2f& pos)
-{
-    if (const auto state = viewports.Find(viewport_id))
-    {
-        state->cursor_viewport_pos = pos;
-    }
 }
 } // namespace se::editor

--- a/Editor/Source/UI/ImGui/ImGuiString.cpp
+++ b/Editor/Source/UI/ImGui/ImGuiString.cpp
@@ -18,7 +18,7 @@ int InputTextCallback(ImGuiInputTextCallbackData* data)
         // 입력에 맞게 문자열 크기 조절
         se::String* str = user_data->string;
         IM_ASSERT(data->Buf == str->Data());
-        str->ResizeForOverwrite(data->BufTextLen);
+        str->ResizeUninitialized(data->BufTextLen);
         data->Buf = str->Data();
     }
     else if (user_data->chain_callback)

--- a/Editor/Source/UI/Panels/DetailPanel.cpp
+++ b/Editor/Source/UI/Panels/DetailPanel.cpp
@@ -169,7 +169,7 @@ void DetailPanel::DrawContent()
                 );
 
                 // 편집 중이 아닐 때만 외부 변경을 감지해 Quat -> Euler 재계산
-                CachedRotator& cached = rotator_cache[entity];
+                CachedRotator& cached = rotator_cache.Entry(entity).OrDefault();
                 if (!cached.is_editing && !cached.source_quat.IsNearlyEqual(transform_component->rotation))
                 {
                     cached.euler = transform_component->rotation.ToRotator();

--- a/EngineCore/Include/SimpleEngine/Core/Container/Array.h
+++ b/EngineCore/Include/SimpleEngine/Core/Container/Array.h
@@ -243,6 +243,16 @@ public:
     /** 배열의 요소 순서를 뒤집습니다. */
     void Reverse();
 
+    /**
+     * 조건을 통과한 요소와 그렇지 않은 요소를 각각 새 Array로 분리하여 반환합니다.
+     * @tparam Predicate 요소를 인자로 받아 bool을 반환하는 함수
+     * @param pred 조건자
+     * @return first: 조건자를 통과한 요소들, second: 그렇지 않은 요소들
+     */
+    template <typename Predicate>
+        requires std::predicate<Predicate, const T&>
+    [[nodiscard]] std::pair<Array, Array> Partition(Predicate&& pred) const;
+
     /** 배열의 요소를 교환합니다. */
     void Swap(Array& other) noexcept;
 

--- a/EngineCore/Include/SimpleEngine/Core/Container/Array.h
+++ b/EngineCore/Include/SimpleEngine/Core/Container/Array.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "SimpleEngine/Core/Container/IterChain.h"
 #include "SimpleEngine/Core/Container/Optional.h"
 #include "SimpleEngine/Core/HAL/PlatformTypes.h"
 #include "SimpleEngine/Core/Memory/Allocators.h"
@@ -274,6 +275,20 @@ public:
     [[nodiscard]] ReverseIteratorType rend() noexcept;
     [[nodiscard]] ConstReverseIteratorType rbegin() const noexcept;
     [[nodiscard]] ConstReverseIteratorType rend() const noexcept;
+
+    /** 요소를 순회하는 IterChain을 반환합니다. rvalue에서 호출하면 배열을 소유합니다. */
+    template <typename Self>
+    [[nodiscard]] auto Iter(this Self&& self)
+    {
+        if constexpr (!std::is_reference_v<Self>)
+        {
+            return IterChain{ std::ranges::owning_view<std::remove_cvref_t<Self>>{ std::forward<Self>(self) } };
+        }
+        else
+        {
+            return IterChain{ std::views::all(self) };
+        }
+    }
 
     friend void swap(Array& lhs, Array& rhs) noexcept { lhs.Swap(rhs); }
 

--- a/EngineCore/Include/SimpleEngine/Core/Container/Array.inl
+++ b/EngineCore/Include/SimpleEngine/Core/Container/Array.inl
@@ -701,6 +701,29 @@ void Array<T, Allocator>::Reverse()
 }
 
 template <typename T, typename Allocator>
+template <typename Predicate>
+    requires std::predicate<Predicate, const T&>
+std::pair<Array<T, Allocator>, Array<T, Allocator>> Array<T, Allocator>::Partition(Predicate&& pred) const
+{
+    Array pass;
+    Array fail;
+    pass.Reserve(Len());
+    fail.Reserve(Len());
+    for (const T& value : *this)
+    {
+        if (pred(value))
+        {
+            pass.Push(value);
+        }
+        else
+        {
+            fail.Push(value);
+        }
+    }
+    return { std::move(pass), std::move(fail) };
+}
+
+template <typename T, typename Allocator>
 void Array<T, Allocator>::Swap(Array& other) noexcept
 {
     std::swap(data, other.data);

--- a/EngineCore/Include/SimpleEngine/Core/Container/Deque.h
+++ b/EngineCore/Include/SimpleEngine/Core/Container/Deque.h
@@ -144,6 +144,16 @@ public:
         requires std::predicate<Predicate, const T&>
     [[nodiscard]] Optional<const T&> FindBy(Predicate&& pred) const;
 
+    /**
+     * 조건자를 통과한 요소와 그렇지 않은 요소를 각각 새 Deque로 분리하여 반환합니다.
+     * @tparam Predicate 요소를 인자로 받아 bool을 반환하는 함수
+     * @param pred 조건자
+     * @return first: 조건자를 통과한 요소들, second: 그렇지 않은 요소들
+     */
+    template <typename Predicate>
+        requires std::predicate<Predicate, const T&>
+    [[nodiscard]] std::pair<Deque, Deque> Partition(Predicate&& pred) const;
+
     /** Deque의 요소를 교환합니다. */
     void Swap(Deque& other) noexcept;
 

--- a/EngineCore/Include/SimpleEngine/Core/Container/Deque.h
+++ b/EngineCore/Include/SimpleEngine/Core/Container/Deque.h
@@ -1,5 +1,6 @@
 ﻿#pragma once
 
+#include "SimpleEngine/Core/Container/IterChain.h"
 #include "SimpleEngine/Core/Container/Optional.h"
 #include "SimpleEngine/Core/HAL/PlatformTypes.h"
 #include "SimpleEngine/Core/Memory/Allocators.h"
@@ -173,6 +174,20 @@ public:
     [[nodiscard]] ReverseIteratorType rend() noexcept;
     [[nodiscard]] ConstReverseIteratorType rbegin() const noexcept;
     [[nodiscard]] ConstReverseIteratorType rend() const noexcept;
+
+    /** 요소를 순회하는 IterChain을 반환합니다. rvalue에서 호출하면 컨테이너를 소유합니다. */
+    template <typename Self>
+    [[nodiscard]] auto Iter(this Self&& self)
+    {
+        if constexpr (!std::is_reference_v<Self>)
+        {
+            return IterChain{ std::ranges::owning_view<std::remove_cvref_t<Self>>{ std::forward<Self>(self) } };
+        }
+        else
+        {
+            return IterChain{ std::views::all(self) };
+        }
+    }
 
     friend void swap(Deque& lhs, Deque& rhs) noexcept { lhs.Swap(rhs); }
 

--- a/EngineCore/Include/SimpleEngine/Core/Container/Deque.inl
+++ b/EngineCore/Include/SimpleEngine/Core/Container/Deque.inl
@@ -288,6 +288,27 @@ Optional<const T&> Deque<T, Allocator>::FindBy(Predicate&& pred) const
 }
 
 template <typename T, typename Allocator>
+template <typename Predicate>
+    requires std::predicate<Predicate, const T&>
+std::pair<Deque<T, Allocator>, Deque<T, Allocator>> Deque<T, Allocator>::Partition(Predicate&& pred) const
+{
+    Deque pass;
+    Deque fail;
+    for (const T& value : *this)
+    {
+        if (pred(value))
+        {
+            pass.PushBack(value);
+        }
+        else
+        {
+            fail.PushBack(value);
+        }
+    }
+    return { std::move(pass), std::move(fail) };
+}
+
+template <typename T, typename Allocator>
 void Deque<T, Allocator>::Swap(Deque& other) noexcept
 {
     std::swap(internal_deque, other.internal_deque);

--- a/EngineCore/Include/SimpleEngine/Core/Container/FixedString.h
+++ b/EngineCore/Include/SimpleEngine/Core/Container/FixedString.h
@@ -46,6 +46,30 @@ public:
     /** 개별 문자에 직접 접근합니다. */
     [[nodiscard]] constexpr const char& operator[](usize index) const { return data[index]; }
 
+    /** 부분 문자열이 포함되어 있는지 확인합니다. */
+    [[nodiscard]] constexpr bool Contains(StringView view) const
+    {
+        return StringView{ *this }.Contains(view);
+    }
+
+    /** 부분 문자열의 위치를 찾습니다. */
+    [[nodiscard]] constexpr Optional<usize> Find(StringView view, usize pos = 0) const
+    {
+        return StringView{ *this }.Find(view, pos);
+    }
+
+    /** 특정 접두사로 시작하는지 확인합니다. */
+    [[nodiscard]] constexpr bool StartsWith(StringView view) const
+    {
+        return StringView{ *this }.StartsWith(view);
+    }
+
+    /** 특정 접미사로 끝나는지 확인합니다. */
+    [[nodiscard]] constexpr bool EndsWith(StringView view) const
+    {
+        return StringView{ *this }.EndsWith(view);
+    }
+
 public:
     [[nodiscard]] constexpr IteratorType begin() { return data.begin(); }
     [[nodiscard]] constexpr IteratorType end() { return data.end(); }

--- a/EngineCore/Include/SimpleEngine/Core/Container/FlatMap.h
+++ b/EngineCore/Include/SimpleEngine/Core/Container/FlatMap.h
@@ -28,16 +28,22 @@ class FlatMap
 private:
     friend class FlatMapEntry<FlatMap>;
 
+    /**
+     * 내부 배열 저장 타입
+     * 삽입/정렬 시 이동 대입이 필요하므로 Key를 mutable로 유지합니다.
+     */
+    using MutablePairType = std::pair<Key, Value>;
+
 public:
     using KeyType = Key;
     using ValueType = Value;
-    using PairType = std::pair<Key, Value>;
+    using PairType = std::pair<const Key, Value>;
     using SizeType = usize;
 
-    using IteratorType = Array<PairType, Allocator>::IteratorType;
-    using ConstIteratorType = Array<PairType, Allocator>::ConstIteratorType;
-    using ReverseIteratorType = Array<PairType, Allocator>::ReverseIteratorType;
-    using ConstReverseIteratorType = Array<PairType, Allocator>::ConstReverseIteratorType;
+    using IteratorType = Array<MutablePairType, Allocator>::IteratorType;
+    using ConstIteratorType = Array<MutablePairType, Allocator>::ConstIteratorType;
+    using ReverseIteratorType = Array<MutablePairType, Allocator>::ReverseIteratorType;
+    using ConstReverseIteratorType = Array<MutablePairType, Allocator>::ConstReverseIteratorType;
 
     using EntryType = FlatMapEntry<FlatMap>;
 
@@ -258,12 +264,18 @@ private:
     struct PairCompare
     {
         NO_UNIQUE_ADDRESS Pred compare;
-        bool operator()(const PairType& lhs, const KeyType& rhs) const { return compare(lhs.first, rhs); }
-        bool operator()(const KeyType& lhs, const PairType& rhs) const { return compare(lhs, rhs.first); }
-        bool operator()(const PairType& lhs, const PairType& rhs) const { return compare(lhs.first, rhs.first); }
+        bool operator()(const MutablePairType& lhs, const KeyType& rhs) const { return compare(lhs.first, rhs); }
+        bool operator()(const KeyType& lhs, const MutablePairType& rhs) const { return compare(lhs, rhs.first); }
+        bool operator()(const MutablePairType& lhs, const MutablePairType& rhs) const { return compare(lhs.first, rhs.first); }
     };
 
-    Array<PairType, Allocator> internal_array;
+    /** 내부 저장 타입(MutablePairType)을 공개 API 타입(PairType)으로 변환합니다. */
+    static PairType& AsPairType(MutablePairType& p) noexcept
+    {
+        return reinterpret_cast<PairType&>(p);
+    }
+
+    Array<MutablePairType, Allocator> internal_array;
     NO_UNIQUE_ADDRESS PairCompare pair_compare;
 };
 } // namespace se

--- a/EngineCore/Include/SimpleEngine/Core/Container/FlatMap.h
+++ b/EngineCore/Include/SimpleEngine/Core/Container/FlatMap.h
@@ -208,10 +208,18 @@ public:
 
 public:
     /**
-     * 키에 해당하는 값에 접근합니다. 키가 없으면 기본 생성된 값을 삽입 후 반환합니다.
+     * 키가 존재하면 해당 값의 참조를 반환합니다. (FindChecked()와 동일)
+     * @warning std::flat_map의 operator[]와 달리 키가 없으면 SE_ASSERT_RELEASE로 프로그램이 종료됩니다.
+     * @note 키의 존재가 보장되지 않는다면 Find() 또는 Entry()를 사용하세요.
+     *       삽입이 필요하다면 Insert() / Emplace() / Entry()를 사용하세요.
      * @param key 접근할 키
+     * @return 키에 대응하는 값의 참조
      */
-    [[nodiscard]] ValueType& operator[](const KeyType& key);
+    template <typename Self>
+    [[nodiscard]] auto&& operator[](this Self&& self, const KeyType& key)
+    {
+        return std::forward_like<Self>(self.FindChecked(key));
+    }
 
     [[nodiscard]] bool operator==(const FlatMap&) const = default;
     [[nodiscard]] auto operator<=>(const FlatMap&) const = default;
@@ -226,6 +234,20 @@ public:
     [[nodiscard]] ReverseIteratorType rend() noexcept;
     [[nodiscard]] ConstReverseIteratorType rbegin() const noexcept;
     [[nodiscard]] ConstReverseIteratorType rend() const noexcept;
+
+    /** 요소를 순회하는 IterChain을 반환합니다. rvalue에서 호출하면 컨테이너를 소유합니다. */
+    template <typename Self>
+    [[nodiscard]] auto Iter(this Self&& self)
+    {
+        if constexpr (!std::is_reference_v<Self>)
+        {
+            return IterChain{ std::ranges::owning_view<std::remove_cvref_t<Self>>{ std::forward<Self>(self) } };
+        }
+        else
+        {
+            return IterChain{ std::views::all(self) };
+        }
+    }
 
     friend void swap(FlatMap& lhs, FlatMap& rhs) noexcept
     {

--- a/EngineCore/Include/SimpleEngine/Core/Container/FlatMap.h
+++ b/EngineCore/Include/SimpleEngine/Core/Container/FlatMap.h
@@ -36,6 +36,8 @@ public:
 
     using IteratorType = Array<PairType, Allocator>::IteratorType;
     using ConstIteratorType = Array<PairType, Allocator>::ConstIteratorType;
+    using ReverseIteratorType = Array<PairType, Allocator>::ReverseIteratorType;
+    using ConstReverseIteratorType = Array<PairType, Allocator>::ConstReverseIteratorType;
 
     using EntryType = FlatMapEntry<FlatMap>;
 
@@ -62,6 +64,9 @@ public:
 
     /** FlatMap이 비어있는지 확인합니다. */
     [[nodiscard]] bool IsEmpty() const noexcept;
+
+    /** 재할당 없이 FlatMap이 담을 수 있는 요소의 수를 반환합니다. */
+    [[nodiscard]] SizeType Capacity() const noexcept;
 
     /** FlatMap의 모든 요소를 제거합니다. */
     void Clear() noexcept;
@@ -198,6 +203,11 @@ public:
     [[nodiscard]] IteratorType end() noexcept;
     [[nodiscard]] ConstIteratorType begin() const noexcept;
     [[nodiscard]] ConstIteratorType end() const noexcept;
+
+    [[nodiscard]] ReverseIteratorType rbegin() noexcept;
+    [[nodiscard]] ReverseIteratorType rend() noexcept;
+    [[nodiscard]] ConstReverseIteratorType rbegin() const noexcept;
+    [[nodiscard]] ConstReverseIteratorType rend() const noexcept;
 
     friend void swap(FlatMap& lhs, FlatMap& rhs) noexcept
     {

--- a/EngineCore/Include/SimpleEngine/Core/Container/FlatMap.h
+++ b/EngineCore/Include/SimpleEngine/Core/Container/FlatMap.h
@@ -40,10 +40,10 @@ public:
     using PairType = std::pair<const Key, Value>;
     using SizeType = usize;
 
-    using IteratorType = Array<MutablePairType, Allocator>::IteratorType;
-    using ConstIteratorType = Array<MutablePairType, Allocator>::ConstIteratorType;
-    using ReverseIteratorType = Array<MutablePairType, Allocator>::ReverseIteratorType;
-    using ConstReverseIteratorType = Array<MutablePairType, Allocator>::ConstReverseIteratorType;
+    using IteratorType = PairType*;
+    using ConstIteratorType = const PairType*;
+    using ReverseIteratorType = std::reverse_iterator<PairType*>;
+    using ConstReverseIteratorType = std::reverse_iterator<const PairType*>;
 
     using EntryType = FlatMapEntry<FlatMap>;
 
@@ -150,10 +150,10 @@ public:
     [[nodiscard]] Optional<const PairType&> Back() const noexcept;
 
     /** 가장 작은 키를 가진 요소를 제거하고 반환합니다. */
-    [[nodiscard]] Optional<PairType> PopFront();
+    Optional<PairType> PopFront();
 
     /** 가장 큰 키를 가진 요소를 제거하고 반환합니다. */
-    [[nodiscard]] Optional<PairType> PopBack();
+    Optional<PairType> PopBack();
 
     /**
      * 주어진 키보다 크거나 같은 첫 번째 요소를 찾습니다.

--- a/EngineCore/Include/SimpleEngine/Core/Container/FlatMap.h
+++ b/EngineCore/Include/SimpleEngine/Core/Container/FlatMap.h
@@ -126,13 +126,28 @@ public:
     [[nodiscard]] ValueType& FindChecked(const KeyType& key);
     [[nodiscard]] const ValueType& FindChecked(const KeyType& key) const;
 
+    /** 조건자를 만족하는 첫 번째 키-값 쌍에 대한 Optional 참조를 반환합니다. O(N) 선형 탐색입니다. */
+    template <typename Predicate>
+        requires std::predicate<Predicate, const Key&, const Value&>
+    [[nodiscard]] Optional<PairType&> FindBy(Predicate&& pred);
+
+    template <typename Predicate>
+        requires std::predicate<Predicate, const Key&, const Value&>
+    [[nodiscard]] Optional<const PairType&> FindBy(Predicate&& pred) const;
+
     /** 가장 작은 키를 가진 요소의 참조를 Optional로 반환합니다. */
-    [[nodiscard]] Optional<PairType&> First() noexcept;
-    [[nodiscard]] Optional<const PairType&> First() const noexcept;
+    [[nodiscard]] Optional<PairType&> Front() noexcept;
+    [[nodiscard]] Optional<const PairType&> Front() const noexcept;
 
     /** 가장 큰 키를 가진 요소의 참조를 Optional로 반환합니다. */
-    [[nodiscard]] Optional<PairType&> Last() noexcept;
-    [[nodiscard]] Optional<const PairType&> Last() const noexcept;
+    [[nodiscard]] Optional<PairType&> Back() noexcept;
+    [[nodiscard]] Optional<const PairType&> Back() const noexcept;
+
+    /** 가장 작은 키를 가진 요소를 제거하고 반환합니다. */
+    [[nodiscard]] Optional<PairType> PopFront();
+
+    /** 가장 큰 키를 가진 요소를 제거하고 반환합니다. */
+    [[nodiscard]] Optional<PairType> PopBack();
 
     /**
      * 주어진 키보다 크거나 같은 첫 번째 요소를 찾습니다.
@@ -173,12 +188,15 @@ public:
     /** FlatMap의 모든 키를 담은 Array를 생성하여 반환합니다. */
     template <typename T = KeyType>
         requires std::constructible_from<T, const Key&>
-    [[nodiscard]] Array<KeyType> Keys() const;
+    [[nodiscard]] Array<T> Keys() const;
 
     /** FlatMap의 모든 값을 담은 Array를 생성하여 반환합니다. */
     template <typename T = ValueType>
         requires std::constructible_from<T, const Value&>
-    [[nodiscard]] Array<ValueType> Values() const;
+    [[nodiscard]] Array<T> Values() const;
+
+    /** FlatMap의 모든 키-값 쌍을 담은 Array를 생성하여 반환합니다. */
+    [[nodiscard]] Array<PairType> ToArray() const;
 
     /** 최소 new_capacity 만큼의 요소를 저장할 수 있도록 용량을 예약합니다. */
     void Reserve(SizeType new_capacity);

--- a/EngineCore/Include/SimpleEngine/Core/Container/FlatMap.inl
+++ b/EngineCore/Include/SimpleEngine/Core/Container/FlatMap.inl
@@ -185,22 +185,16 @@ template <typename Key, typename Value, typename Pred, typename Allocator>
 typename FlatMap<Key, Value, Pred, Allocator>::ValueType& FlatMap<Key, Value, Pred, Allocator>::FindChecked(const KeyType& key)
 {
     auto it = std::lower_bound(internal_array.begin(), internal_array.end(), key, pair_compare);
-    if (it != internal_array.end() && !pair_compare.compare(key, it->first))
-    {
-        return it->second;
-    }
-    SE_UNREACHABLE();
+    SE_ASSERT_RELEASE(it != internal_array.end() && !pair_compare.compare(key, it->first));
+    return it->second;
 }
 
 template <typename Key, typename Value, typename Pred, typename Allocator>
 const typename FlatMap<Key, Value, Pred, Allocator>::ValueType& FlatMap<Key, Value, Pred, Allocator>::FindChecked(const KeyType& key) const
 {
     auto it = std::lower_bound(internal_array.begin(), internal_array.end(), key, pair_compare);
-    if (it != internal_array.end() && !pair_compare.compare(key, it->first))
-    {
-        return it->second;
-    }
-    SE_UNREACHABLE();
+    SE_ASSERT_RELEASE(it != internal_array.end() && !pair_compare.compare(key, it->first));
+    return it->second;
 }
 
 template <typename Key, typename Value, typename Pred, typename Allocator>
@@ -404,19 +398,6 @@ void FlatMap<Key, Value, Pred, Allocator>::Swap(FlatMap& other) noexcept
     internal_array.Swap(other.internal_array);
 }
 
-template <typename Key, typename Value, typename Pred, typename Allocator>
-typename FlatMap<Key, Value, Pred, Allocator>::ValueType& FlatMap<Key, Value, Pred, Allocator>::operator[](const KeyType& key)
-{
-    auto it = std::lower_bound(internal_array.begin(), internal_array.end(), key, pair_compare);
-    if (it != internal_array.end() && !pair_compare.compare(key, it->first))
-    {
-        return it->second;
-    }
-
-    auto index = std::distance(internal_array.begin(), it);
-    internal_array.Insert(index, std::make_pair(key, Value()));
-    return internal_array[index].second;
-}
 
 template <typename Key, typename Value, typename Pred, typename Allocator>
 typename FlatMap<Key, Value, Pred, Allocator>::IteratorType FlatMap<Key, Value, Pred, Allocator>::begin() noexcept

--- a/EngineCore/Include/SimpleEngine/Core/Container/FlatMap.inl
+++ b/EngineCore/Include/SimpleEngine/Core/Container/FlatMap.inl
@@ -14,11 +14,16 @@ namespace se
 {
 template <typename Key, typename Value, typename Pred, typename Allocator>
 FlatMap<Key, Value, Pred, Allocator>::FlatMap(std::initializer_list<PairType> init_list)
-    : internal_array(init_list)
 {
+    internal_array.Reserve(init_list.size());
+    for (const PairType& p : init_list)
+    {
+        internal_array.Push(MutablePairType{ p.first, p.second });
+    }
+
     std::sort(internal_array.begin(), internal_array.end(), pair_compare);
     // 중복 키 제거
-    auto unique_end = std::unique(internal_array.begin(), internal_array.end(), [this](const PairType& lhs, const PairType& rhs)
+    auto unique_end = std::unique(internal_array.begin(), internal_array.end(), [this](const MutablePairType& lhs, const MutablePairType& rhs)
     {
         return !pair_compare.compare(lhs.first, rhs.first) && !pair_compare.compare(rhs.first, lhs.first);
     });
@@ -31,7 +36,7 @@ FlatMap<Key, Value, Pred, Allocator>::FlatMap(It first, Sent last)
     : internal_array(first, last)
 {
     std::sort(internal_array.begin(), internal_array.end(), pair_compare);
-    auto unique_end = std::unique(internal_array.begin(), internal_array.end(), [this](const PairType& lhs, const PairType& rhs)
+    auto unique_end = std::unique(internal_array.begin(), internal_array.end(), [this](const MutablePairType& lhs, const MutablePairType& rhs)
     {
         return !pair_compare.compare(lhs.first, rhs.first) && !pair_compare.compare(rhs.first, lhs.first);
     });
@@ -206,7 +211,7 @@ Optional<typename FlatMap<Key, Value, Pred, Allocator>::PairType&> FlatMap<Key, 
     {
         if (pred(pair.first, pair.second))
         {
-            return pair;
+            return AsPairType(pair);
         }
     }
     return NullOpt;
@@ -221,7 +226,7 @@ Optional<const typename FlatMap<Key, Value, Pred, Allocator>::PairType&> FlatMap
     {
         if (pred(pair.first, pair.second))
         {
-            return pair;
+            return reinterpret_cast<const PairType&>(pair);
         }
     }
     return NullOpt;
@@ -230,25 +235,37 @@ Optional<const typename FlatMap<Key, Value, Pred, Allocator>::PairType&> FlatMap
 template <typename Key, typename Value, typename Pred, typename Allocator>
 Optional<typename FlatMap<Key, Value, Pred, Allocator>::PairType&> FlatMap<Key, Value, Pred, Allocator>::Front() noexcept
 {
-    return internal_array.Front();
+    return internal_array.Front().Map([](MutablePairType& pair) -> PairType&
+    {
+        return AsPairType(pair);
+    });
 }
 
 template <typename Key, typename Value, typename Pred, typename Allocator>
 Optional<const typename FlatMap<Key, Value, Pred, Allocator>::PairType&> FlatMap<Key, Value, Pred, Allocator>::Front() const noexcept
 {
-    return internal_array.Front();
+    return internal_array.Front().Map([](const MutablePairType& pair) -> const PairType&
+    {
+        return reinterpret_cast<const PairType&>(pair);
+    });
 }
 
 template <typename Key, typename Value, typename Pred, typename Allocator>
 Optional<typename FlatMap<Key, Value, Pred, Allocator>::PairType&> FlatMap<Key, Value, Pred, Allocator>::Back() noexcept
 {
-    return internal_array.Back();
+    return internal_array.Back().Map([](MutablePairType& pair) -> PairType&
+    {
+        return AsPairType(pair);
+    });
 }
 
 template <typename Key, typename Value, typename Pred, typename Allocator>
 Optional<const typename FlatMap<Key, Value, Pred, Allocator>::PairType&> FlatMap<Key, Value, Pred, Allocator>::Back() const noexcept
 {
-    return internal_array.Back();
+    return internal_array.Back().Map([](const MutablePairType& pair) -> const PairType&
+    {
+        return reinterpret_cast<const PairType&>(pair);
+    });
 }
 
 template <typename Key, typename Value, typename Pred, typename Allocator>
@@ -279,7 +296,7 @@ Optional<typename FlatMap<Key, Value, Pred, Allocator>::PairType&> FlatMap<Key, 
     auto it = std::lower_bound(internal_array.begin(), internal_array.end(), key, pair_compare);
     if (it != internal_array.end())
     {
-        return *it;
+        return AsPairType(*it);
     }
     return NullOpt;
 }
@@ -290,7 +307,7 @@ Optional<const typename FlatMap<Key, Value, Pred, Allocator>::PairType&> FlatMap
     auto it = std::lower_bound(internal_array.begin(), internal_array.end(), key, pair_compare);
     if (it != internal_array.end())
     {
-        return *it;
+        return reinterpret_cast<const PairType&>(*it);
     }
     return NullOpt;
 }
@@ -301,7 +318,7 @@ Optional<typename FlatMap<Key, Value, Pred, Allocator>::PairType&> FlatMap<Key, 
     auto it = std::upper_bound(internal_array.begin(), internal_array.end(), key, pair_compare);
     if (it != internal_array.end())
     {
-        return *it;
+        return AsPairType(*it);
     }
     return NullOpt;
 }
@@ -312,7 +329,7 @@ Optional<const typename FlatMap<Key, Value, Pred, Allocator>::PairType&> FlatMap
     auto it = std::upper_bound(internal_array.begin(), internal_array.end(), key, pair_compare);
     if (it != internal_array.end())
     {
-        return *it;
+        return reinterpret_cast<const PairType&>(*it);
     }
     return NullOpt;
 }
@@ -340,7 +357,7 @@ template <typename Predicate>
     requires std::predicate<Predicate, const Key&, const Value&>
 typename FlatMap<Key, Value, Pred, Allocator>::SizeType FlatMap<Key, Value, Pred, Allocator>::RemoveIf(Predicate&& pred)
 {
-    return internal_array.RemoveIf([&pred](const PairType& pair)
+    return internal_array.RemoveIf([&pred](const MutablePairType& pair)
     {
         return std::forward<Predicate>(pred)(pair.first, pair.second);
     });
@@ -377,7 +394,13 @@ Array<T> FlatMap<Key, Value, Pred, Allocator>::Values() const
 template <typename Key, typename Value, typename Pred, typename Allocator>
 Array<typename FlatMap<Key, Value, Pred, Allocator>::PairType> FlatMap<Key, Value, Pred, Allocator>::ToArray() const
 {
-    return internal_array;
+    Array<PairType> result;
+    result.Reserve(Len());
+    for (const auto& pair : internal_array)
+    {
+        result.Push(pair);
+    }
+    return result;
 }
 
 template <typename Key, typename Value, typename Pred, typename Allocator>

--- a/EngineCore/Include/SimpleEngine/Core/Container/FlatMap.inl
+++ b/EngineCore/Include/SimpleEngine/Core/Container/FlatMap.inl
@@ -204,27 +204,79 @@ const typename FlatMap<Key, Value, Pred, Allocator>::ValueType& FlatMap<Key, Val
 }
 
 template <typename Key, typename Value, typename Pred, typename Allocator>
-Optional<typename FlatMap<Key, Value, Pred, Allocator>::PairType&> FlatMap<Key, Value, Pred, Allocator>::First() noexcept
+template <typename Predicate>
+    requires std::predicate<Predicate, const Key&, const Value&>
+Optional<typename FlatMap<Key, Value, Pred, Allocator>::PairType&> FlatMap<Key, Value, Pred, Allocator>::FindBy(Predicate&& pred)
+{
+    for (auto& pair : internal_array)
+    {
+        if (pred(pair.first, pair.second))
+        {
+            return pair;
+        }
+    }
+    return NullOpt;
+}
+
+template <typename Key, typename Value, typename Pred, typename Allocator>
+template <typename Predicate>
+    requires std::predicate<Predicate, const Key&, const Value&>
+Optional<const typename FlatMap<Key, Value, Pred, Allocator>::PairType&> FlatMap<Key, Value, Pred, Allocator>::FindBy(Predicate&& pred) const
+{
+    for (const auto& pair : internal_array)
+    {
+        if (pred(pair.first, pair.second))
+        {
+            return pair;
+        }
+    }
+    return NullOpt;
+}
+
+template <typename Key, typename Value, typename Pred, typename Allocator>
+Optional<typename FlatMap<Key, Value, Pred, Allocator>::PairType&> FlatMap<Key, Value, Pred, Allocator>::Front() noexcept
 {
     return internal_array.Front();
 }
 
 template <typename Key, typename Value, typename Pred, typename Allocator>
-Optional<const typename FlatMap<Key, Value, Pred, Allocator>::PairType&> FlatMap<Key, Value, Pred, Allocator>::First() const noexcept
+Optional<const typename FlatMap<Key, Value, Pred, Allocator>::PairType&> FlatMap<Key, Value, Pred, Allocator>::Front() const noexcept
 {
     return internal_array.Front();
 }
 
 template <typename Key, typename Value, typename Pred, typename Allocator>
-Optional<typename FlatMap<Key, Value, Pred, Allocator>::PairType&> FlatMap<Key, Value, Pred, Allocator>::Last() noexcept
+Optional<typename FlatMap<Key, Value, Pred, Allocator>::PairType&> FlatMap<Key, Value, Pred, Allocator>::Back() noexcept
 {
     return internal_array.Back();
 }
 
 template <typename Key, typename Value, typename Pred, typename Allocator>
-Optional<const typename FlatMap<Key, Value, Pred, Allocator>::PairType&> FlatMap<Key, Value, Pred, Allocator>::Last() const noexcept
+Optional<const typename FlatMap<Key, Value, Pred, Allocator>::PairType&> FlatMap<Key, Value, Pred, Allocator>::Back() const noexcept
 {
     return internal_array.Back();
+}
+
+template <typename Key, typename Value, typename Pred, typename Allocator>
+Optional<typename FlatMap<Key, Value, Pred, Allocator>::PairType> FlatMap<Key, Value, Pred, Allocator>::PopFront()
+{
+    if (IsEmpty())
+    {
+        return NullOpt;
+    }
+    PairType pair = std::move(internal_array[0]);
+    internal_array.RemoveAt(0);
+    return pair;
+}
+
+template <typename Key, typename Value, typename Pred, typename Allocator>
+Optional<typename FlatMap<Key, Value, Pred, Allocator>::PairType> FlatMap<Key, Value, Pred, Allocator>::PopBack()
+{
+    if (IsEmpty())
+    {
+        return NullOpt;
+    }
+    return internal_array.Pop();
 }
 
 template <typename Key, typename Value, typename Pred, typename Allocator>
@@ -303,13 +355,13 @@ typename FlatMap<Key, Value, Pred, Allocator>::SizeType FlatMap<Key, Value, Pred
 template <typename Key, typename Value, typename Pred, typename Allocator>
 template <typename T>
     requires std::constructible_from<T, const Key&>
-Array<typename FlatMap<Key, Value, Pred, Allocator>::KeyType> FlatMap<Key, Value, Pred, Allocator>::Keys() const
+Array<T> FlatMap<Key, Value, Pred, Allocator>::Keys() const
 {
-    Array<KeyType> keys;
+    Array<T> keys;
     keys.Reserve(Len());
     for (const auto& pair : internal_array)
     {
-        keys.Push(pair.first);
+        keys.Emplace(pair.first);
     }
     return keys;
 }
@@ -317,15 +369,21 @@ Array<typename FlatMap<Key, Value, Pred, Allocator>::KeyType> FlatMap<Key, Value
 template <typename Key, typename Value, typename Pred, typename Allocator>
 template <typename T>
     requires std::constructible_from<T, const Value&>
-Array<typename FlatMap<Key, Value, Pred, Allocator>::ValueType> FlatMap<Key, Value, Pred, Allocator>::Values() const
+Array<T> FlatMap<Key, Value, Pred, Allocator>::Values() const
 {
-    Array<ValueType> values;
+    Array<T> values;
     values.Reserve(Len());
     for (const auto& pair : internal_array)
     {
-        values.Push(pair.second);
+        values.Emplace(pair.second);
     }
     return values;
+}
+
+template <typename Key, typename Value, typename Pred, typename Allocator>
+Array<typename FlatMap<Key, Value, Pred, Allocator>::PairType> FlatMap<Key, Value, Pred, Allocator>::ToArray() const
+{
+    return internal_array;
 }
 
 template <typename Key, typename Value, typename Pred, typename Allocator>

--- a/EngineCore/Include/SimpleEngine/Core/Container/FlatMap.inl
+++ b/EngineCore/Include/SimpleEngine/Core/Container/FlatMap.inl
@@ -148,7 +148,7 @@ typename FlatMap<Key, Value, Pred, Allocator>::EntryType FlatMap<Key, Value, Pre
     auto it = std::lower_bound(internal_array.begin(), internal_array.end(), key, pair_compare);
     if (it != internal_array.end() && !pair_compare.compare(key, it->first))
     {
-        return EntryType(typename EntryType::OccupiedEntry(it, this));
+        return EntryType(typename EntryType::OccupiedEntry(reinterpret_cast<IteratorType>(it), this));
     }
     return EntryType(typename EntryType::VacantEntry(key, this));
 }
@@ -159,7 +159,7 @@ typename FlatMap<Key, Value, Pred, Allocator>::EntryType FlatMap<Key, Value, Pre
     auto it = std::lower_bound(internal_array.begin(), internal_array.end(), key, pair_compare);
     if (it != internal_array.end() && !pair_compare.compare(key, it->first))
     {
-        return EntryType(typename EntryType::OccupiedEntry(it, this));
+        return EntryType(typename EntryType::OccupiedEntry(reinterpret_cast<IteratorType>(it), this));
     }
     return EntryType(typename EntryType::VacantEntry(std::move(key), this));
 }
@@ -425,48 +425,48 @@ void FlatMap<Key, Value, Pred, Allocator>::Swap(FlatMap& other) noexcept
 template <typename Key, typename Value, typename Pred, typename Allocator>
 typename FlatMap<Key, Value, Pred, Allocator>::IteratorType FlatMap<Key, Value, Pred, Allocator>::begin() noexcept
 {
-    return internal_array.begin();
+    return reinterpret_cast<IteratorType>(internal_array.begin());
 }
 
 template <typename Key, typename Value, typename Pred, typename Allocator>
 typename FlatMap<Key, Value, Pred, Allocator>::IteratorType FlatMap<Key, Value, Pred, Allocator>::end() noexcept
 {
-    return internal_array.end();
+    return reinterpret_cast<IteratorType>(internal_array.end());
 }
 
 template <typename Key, typename Value, typename Pred, typename Allocator>
 typename FlatMap<Key, Value, Pred, Allocator>::ConstIteratorType FlatMap<Key, Value, Pred, Allocator>::begin() const noexcept
 {
-    return internal_array.begin();
+    return reinterpret_cast<ConstIteratorType>(internal_array.begin());
 }
 
 template <typename Key, typename Value, typename Pred, typename Allocator>
 typename FlatMap<Key, Value, Pred, Allocator>::ConstIteratorType FlatMap<Key, Value, Pred, Allocator>::end() const noexcept
 {
-    return internal_array.end();
+    return reinterpret_cast<ConstIteratorType>(internal_array.end());
 }
 
 template <typename Key, typename Value, typename Pred, typename Allocator>
 typename FlatMap<Key, Value, Pred, Allocator>::ReverseIteratorType FlatMap<Key, Value, Pred, Allocator>::rbegin() noexcept
 {
-    return internal_array.rbegin();
+    return std::make_reverse_iterator(end());
 }
 
 template <typename Key, typename Value, typename Pred, typename Allocator>
 typename FlatMap<Key, Value, Pred, Allocator>::ReverseIteratorType FlatMap<Key, Value, Pred, Allocator>::rend() noexcept
 {
-    return internal_array.rend();
+    return std::make_reverse_iterator(begin());
 }
 
 template <typename Key, typename Value, typename Pred, typename Allocator>
 typename FlatMap<Key, Value, Pred, Allocator>::ConstReverseIteratorType FlatMap<Key, Value, Pred, Allocator>::rbegin() const noexcept
 {
-    return internal_array.rbegin();
+    return std::make_reverse_iterator(end());
 }
 
 template <typename Key, typename Value, typename Pred, typename Allocator>
 typename FlatMap<Key, Value, Pred, Allocator>::ConstReverseIteratorType FlatMap<Key, Value, Pred, Allocator>::rend() const noexcept
 {
-    return internal_array.rend();
+    return std::make_reverse_iterator(begin());
 }
 } // namespace se

--- a/EngineCore/Include/SimpleEngine/Core/Container/FlatMap.inl
+++ b/EngineCore/Include/SimpleEngine/Core/Container/FlatMap.inl
@@ -58,6 +58,12 @@ bool FlatMap<Key, Value, Pred, Allocator>::IsEmpty() const noexcept
 }
 
 template <typename Key, typename Value, typename Pred, typename Allocator>
+typename FlatMap<Key, Value, Pred, Allocator>::SizeType FlatMap<Key, Value, Pred, Allocator>::Capacity() const noexcept
+{
+    return internal_array.Capacity();
+}
+
+template <typename Key, typename Value, typename Pred, typename Allocator>
 void FlatMap<Key, Value, Pred, Allocator>::Clear() noexcept
 {
     internal_array.Clear();
@@ -376,5 +382,29 @@ template <typename Key, typename Value, typename Pred, typename Allocator>
 typename FlatMap<Key, Value, Pred, Allocator>::ConstIteratorType FlatMap<Key, Value, Pred, Allocator>::end() const noexcept
 {
     return internal_array.end();
+}
+
+template <typename Key, typename Value, typename Pred, typename Allocator>
+typename FlatMap<Key, Value, Pred, Allocator>::ReverseIteratorType FlatMap<Key, Value, Pred, Allocator>::rbegin() noexcept
+{
+    return internal_array.rbegin();
+}
+
+template <typename Key, typename Value, typename Pred, typename Allocator>
+typename FlatMap<Key, Value, Pred, Allocator>::ReverseIteratorType FlatMap<Key, Value, Pred, Allocator>::rend() noexcept
+{
+    return internal_array.rend();
+}
+
+template <typename Key, typename Value, typename Pred, typename Allocator>
+typename FlatMap<Key, Value, Pred, Allocator>::ConstReverseIteratorType FlatMap<Key, Value, Pred, Allocator>::rbegin() const noexcept
+{
+    return internal_array.rbegin();
+}
+
+template <typename Key, typename Value, typename Pred, typename Allocator>
+typename FlatMap<Key, Value, Pred, Allocator>::ConstReverseIteratorType FlatMap<Key, Value, Pred, Allocator>::rend() const noexcept
+{
+    return internal_array.rend();
 }
 } // namespace se

--- a/EngineCore/Include/SimpleEngine/Core/Container/FlatMapEntry.h
+++ b/EngineCore/Include/SimpleEngine/Core/Container/FlatMapEntry.h
@@ -56,7 +56,7 @@ public:
         [[nodiscard]] ValueType Remove()
         {
             ValueType value = std::move(iter->second);
-            map_ptr->internal_array.RemoveAt(std::distance(map_ptr->internal_array.begin(), iter));
+            map_ptr->internal_array.RemoveAt(iter - map_ptr->begin());
             return value;
         }
 

--- a/EngineCore/Include/SimpleEngine/Core/Container/FlatSet.h
+++ b/EngineCore/Include/SimpleEngine/Core/Container/FlatSet.h
@@ -26,6 +26,8 @@ public:
 
     using IteratorType = Array<T, Allocator>::IteratorType;
     using ConstIteratorType = Array<T, Allocator>::ConstIteratorType;
+    using ReverseIteratorType = Array<T, Allocator>::ReverseIteratorType;
+    using ConstReverseIteratorType = Array<T, Allocator>::ConstReverseIteratorType;
 
 public:
     FlatSet() = default;
@@ -52,6 +54,9 @@ public:
 
     /** FlatSet이 비어있는지 확인합니다. */
     [[nodiscard]] bool IsEmpty() const noexcept;
+
+    /** 재할당 없이 FlatSet이 담을 수 있는 요소의 수를 반환합니다. */
+    [[nodiscard]] SizeType Capacity() const noexcept;
 
     /** FlatSet의 모든 요소를 제거하여 비웁니다. */
     void Clear() noexcept;
@@ -127,6 +132,11 @@ public:
     [[nodiscard]] IteratorType end() noexcept;
     [[nodiscard]] ConstIteratorType begin() const noexcept;
     [[nodiscard]] ConstIteratorType end() const noexcept;
+
+    [[nodiscard]] ReverseIteratorType rbegin() noexcept;
+    [[nodiscard]] ReverseIteratorType rend() noexcept;
+    [[nodiscard]] ConstReverseIteratorType rbegin() const noexcept;
+    [[nodiscard]] ConstReverseIteratorType rend() const noexcept;
 
     friend void swap(FlatSet& lhs, FlatSet& rhs) noexcept
     {

--- a/EngineCore/Include/SimpleEngine/Core/Container/FlatSet.h
+++ b/EngineCore/Include/SimpleEngine/Core/Container/FlatSet.h
@@ -138,6 +138,20 @@ public:
     [[nodiscard]] ConstReverseIteratorType rbegin() const noexcept;
     [[nodiscard]] ConstReverseIteratorType rend() const noexcept;
 
+    /** 요소를 순회하는 IterChain을 반환합니다. rvalue에서 호출하면 컨테이너를 소유합니다. */
+    template <typename Self>
+    [[nodiscard]] auto Iter(this Self&& self)
+    {
+        if constexpr (!std::is_reference_v<Self>)
+        {
+            return IterChain{ std::ranges::owning_view<std::remove_cvref_t<Self>>{ std::forward<Self>(self) } };
+        }
+        else
+        {
+            return IterChain{ std::views::all(self) };
+        }
+    }
+
     friend void swap(FlatSet& lhs, FlatSet& rhs) noexcept
     {
         lhs.Swap(rhs);

--- a/EngineCore/Include/SimpleEngine/Core/Container/FlatSet.inl
+++ b/EngineCore/Include/SimpleEngine/Core/Container/FlatSet.inl
@@ -51,6 +51,12 @@ bool FlatSet<T, Pred, Allocator>::IsEmpty() const noexcept
 }
 
 template <typename T, typename Pred, typename Allocator>
+typename FlatSet<T, Pred, Allocator>::SizeType FlatSet<T, Pred, Allocator>::Capacity() const noexcept
+{
+    return internal_array.Capacity();
+}
+
+template <typename T, typename Pred, typename Allocator>
 void FlatSet<T, Pred, Allocator>::Clear() noexcept
 {
     internal_array.Clear();
@@ -168,5 +174,29 @@ template <typename T, typename Pred, typename Allocator>
 typename FlatSet<T, Pred, Allocator>::ConstIteratorType FlatSet<T, Pred, Allocator>::end() const noexcept
 {
     return internal_array.end();
+}
+
+template <typename T, typename Pred, typename Allocator>
+typename FlatSet<T, Pred, Allocator>::ReverseIteratorType FlatSet<T, Pred, Allocator>::rbegin() noexcept
+{
+    return internal_array.rbegin();
+}
+
+template <typename T, typename Pred, typename Allocator>
+typename FlatSet<T, Pred, Allocator>::ReverseIteratorType FlatSet<T, Pred, Allocator>::rend() noexcept
+{
+    return internal_array.rend();
+}
+
+template <typename T, typename Pred, typename Allocator>
+typename FlatSet<T, Pred, Allocator>::ConstReverseIteratorType FlatSet<T, Pred, Allocator>::rbegin() const noexcept
+{
+    return internal_array.rbegin();
+}
+
+template <typename T, typename Pred, typename Allocator>
+typename FlatSet<T, Pred, Allocator>::ConstReverseIteratorType FlatSet<T, Pred, Allocator>::rend() const noexcept
+{
+    return internal_array.rend();
 }
 } // namespace se

--- a/EngineCore/Include/SimpleEngine/Core/Container/HashMap.h
+++ b/EngineCore/Include/SimpleEngine/Core/Container/HashMap.h
@@ -187,10 +187,18 @@ public:
 
 public:
     /**
-     * 키에 해당하는 값에 접근합니다. 키가 없으면 기본 생성된 값을 삽입 후 반환합니다.
+     * 키가 존재하면 해당 값의 참조를 반환합니다. (FindChecked()와 동일)
+     * @warning std::unordered_map의 operator[]와 달리 키가 없으면 SE_ASSERT_RELEASE로 프로그램이 종료됩니다.
+     * @note 키의 존재가 보장되지 않는다면 Find() 또는 Entry()를 사용하세요.
+     *       삽입이 필요하다면 Insert() / Emplace() / Entry()를 사용하세요.
      * @param key 접근할 키
+     * @return 키에 대응하는 값의 참조
      */
-    [[nodiscard]] ValueType& operator[](const KeyType& key);
+    template <typename Self>
+    [[nodiscard]] auto&& operator[](this Self&& self, const KeyType& key)
+    {
+        return std::forward_like<Self>(self.FindChecked(key));
+    }
 
     [[nodiscard]] bool operator==(const HashMap&) const = default;
 
@@ -199,6 +207,20 @@ public:
     [[nodiscard]] IteratorType end() noexcept;
     [[nodiscard]] ConstIteratorType begin() const noexcept;
     [[nodiscard]] ConstIteratorType end() const noexcept;
+
+    /** 요소를 순회하는 IterChain을 반환합니다. rvalue에서 호출하면 컨테이너를 소유합니다. */
+    template <typename Self>
+    [[nodiscard]] auto Iter(this Self&& self)
+    {
+        if constexpr (!std::is_reference_v<Self>)
+        {
+            return IterChain{ std::ranges::owning_view<std::remove_cvref_t<Self>>{ std::forward<Self>(self) } };
+        }
+        else
+        {
+            return IterChain{ std::views::all(self) };
+        }
+    }
 
     friend void swap(HashMap& lhs, HashMap& rhs) noexcept
     {

--- a/EngineCore/Include/SimpleEngine/Core/Container/HashMap.h
+++ b/EngineCore/Include/SimpleEngine/Core/Container/HashMap.h
@@ -38,11 +38,11 @@ private:
     friend class MapEntry<HashMap>;
 
     using InternalMapType = std::unordered_map<Key, Value, Hasher, KeyEq, Allocator>;
-    using PairType = std::pair<const Key, Value>;
 
 public:
     using KeyType = Key;
     using ValueType = Value;
+    using PairType = std::pair<const Key, Value>;
     using SizeType = usize;
 
     using IteratorType = InternalMapType::iterator;
@@ -139,6 +139,15 @@ public:
     [[nodiscard]] ValueType& FindChecked(const KeyType& key);
     [[nodiscard]] const ValueType& FindChecked(const KeyType& key) const;
 
+    /** 조건자를 만족하는 첫 번째 키-값 쌍에 대한 Optional 참조를 반환합니다. */
+    template <typename Predicate>
+        requires std::predicate<Predicate, const Key&, const Value&>
+    [[nodiscard]] Optional<PairType&> FindBy(Predicate&& pred);
+
+    template <typename Predicate>
+        requires std::predicate<Predicate, const Key&, const Value&>
+    [[nodiscard]] Optional<const PairType&> FindBy(Predicate&& pred) const;
+
     /**
      * 특정 Key가 Map에 포함되어 있는지 확인합니다
      * @param key 확인할 Key
@@ -170,6 +179,9 @@ public:
     template <typename T = ValueType>
         requires std::constructible_from<T, const Value&>
     [[nodiscard]] Array<T> Values() const;
+
+    /** HashMap의 모든 키-값 쌍을 담은 Array를 생성하여 반환합니다. */
+    [[nodiscard]] Array<PairType> ToArray() const;
 
     void Swap(HashMap& other) noexcept;
 

--- a/EngineCore/Include/SimpleEngine/Core/Container/HashMap.inl
+++ b/EngineCore/Include/SimpleEngine/Core/Container/HashMap.inl
@@ -159,11 +159,9 @@ Optional<const typename HashMap<Key, Value, Hasher, KeyEq, Allocator>::ValueType
 template <typename Key, typename Value, typename Hasher, typename KeyEq, typename Allocator>
 typename HashMap<Key, Value, Hasher, KeyEq, Allocator>::ValueType& HashMap<Key, Value, Hasher, KeyEq, Allocator>::FindChecked(const KeyType& key)
 {
-    if (auto it = internal_map.find(key); it != internal_map.end())
-    {
-        return it->second;
-    }
-    SE_UNREACHABLE();
+    auto it = internal_map.find(key);
+    SE_ASSERT_RELEASE(it != internal_map.end());
+    return it->second;
 }
 
 template <typename Key, typename Value, typename Hasher, typename KeyEq, typename Allocator>
@@ -171,11 +169,9 @@ const typename HashMap<Key, Value, Hasher, KeyEq, Allocator>::ValueType& HashMap
     const KeyType& key
 ) const
 {
-    if (auto it = internal_map.find(key); it != internal_map.end())
-    {
-        return it->second;
-    }
-    SE_UNREACHABLE();
+    auto it = internal_map.find(key);
+    SE_ASSERT_RELEASE(it != internal_map.end());
+    return it->second;
 }
 
 template <typename Key, typename Value, typename Hasher, typename KeyEq, typename Allocator>
@@ -279,11 +275,6 @@ void HashMap<Key, Value, Hasher, KeyEq, Allocator>::Swap(HashMap& other) noexcep
     std::swap(internal_map, other.internal_map);
 }
 
-template <typename Key, typename Value, typename Hasher, typename KeyEq, typename Allocator>
-HashMap<Key, Value, Hasher, KeyEq, Allocator>::ValueType& HashMap<Key, Value, Hasher, KeyEq, Allocator>::operator[](const KeyType& key)
-{
-    return internal_map[key];
-}
 
 template <typename Key, typename Value, typename Hasher, typename KeyEq, typename Allocator>
 HashMap<Key, Value, Hasher, KeyEq, Allocator>::IteratorType HashMap<Key, Value, Hasher, KeyEq, Allocator>::begin() noexcept

--- a/EngineCore/Include/SimpleEngine/Core/Container/HashMap.inl
+++ b/EngineCore/Include/SimpleEngine/Core/Container/HashMap.inl
@@ -179,6 +179,36 @@ const typename HashMap<Key, Value, Hasher, KeyEq, Allocator>::ValueType& HashMap
 }
 
 template <typename Key, typename Value, typename Hasher, typename KeyEq, typename Allocator>
+template <typename Predicate>
+    requires std::predicate<Predicate, const Key&, const Value&>
+Optional<typename HashMap<Key, Value, Hasher, KeyEq, Allocator>::PairType&> HashMap<Key, Value, Hasher, KeyEq, Allocator>::FindBy(Predicate&& pred)
+{
+    for (auto& pair : internal_map)
+    {
+        if (pred(pair.first, pair.second))
+        {
+            return pair;
+        }
+    }
+    return NullOpt;
+}
+
+template <typename Key, typename Value, typename Hasher, typename KeyEq, typename Allocator>
+template <typename Predicate>
+    requires std::predicate<Predicate, const Key&, const Value&>
+Optional<const typename HashMap<Key, Value, Hasher, KeyEq, Allocator>::PairType&> HashMap<Key, Value, Hasher, KeyEq, Allocator>::FindBy(Predicate&& pred) const
+{
+    for (const auto& pair : internal_map)
+    {
+        if (pred(pair.first, pair.second))
+        {
+            return pair;
+        }
+    }
+    return NullOpt;
+}
+
+template <typename Key, typename Value, typename Hasher, typename KeyEq, typename Allocator>
 bool HashMap<Key, Value, Hasher, KeyEq, Allocator>::Contains(const KeyType& key) const
 {
     return internal_map.contains(key);
@@ -229,6 +259,18 @@ Array<T> HashMap<Key, Value, Hasher, KeyEq, Allocator>::Values() const
         values.Emplace(value);
     }
     return values;
+}
+
+template <typename Key, typename Value, typename Hasher, typename KeyEq, typename Allocator>
+Array<typename HashMap<Key, Value, Hasher, KeyEq, Allocator>::PairType> HashMap<Key, Value, Hasher, KeyEq, Allocator>::ToArray() const
+{
+    Array<PairType> result;
+    result.Reserve(Len());
+    for (const auto& pair : internal_map)
+    {
+        result.Push(pair);
+    }
+    return result;
 }
 
 template <typename Key, typename Value, typename Hasher, typename KeyEq, typename Allocator>

--- a/EngineCore/Include/SimpleEngine/Core/Container/HashSet.h
+++ b/EngineCore/Include/SimpleEngine/Core/Container/HashSet.h
@@ -131,6 +131,20 @@ public:
     [[nodiscard]] ConstIteratorType begin() const noexcept;
     [[nodiscard]] ConstIteratorType end() const noexcept;
 
+    /** 요소를 순회하는 IterChain을 반환합니다. rvalue에서 호출하면 컨테이너를 소유합니다. */
+    template <typename Self>
+    [[nodiscard]] auto Iter(this Self&& self)
+    {
+        if constexpr (!std::is_reference_v<Self>)
+        {
+            return IterChain{ std::ranges::owning_view<std::remove_cvref_t<Self>>{ std::forward<Self>(self) } };
+        }
+        else
+        {
+            return IterChain{ std::views::all(self) };
+        }
+    }
+
     friend void swap(HashSet& lhs, HashSet& rhs) noexcept
     {
         lhs.Swap(rhs);

--- a/EngineCore/Include/SimpleEngine/Core/Container/IterChain.h
+++ b/EngineCore/Include/SimpleEngine/Core/Container/IterChain.h
@@ -1,0 +1,281 @@
+#pragma once
+
+#include "SimpleEngine/Core/Container/Optional.h"
+#include "SimpleEngine/Core/HAL/PlatformTypes.h"
+#include "SimpleEngine/Traits/TypeTraits.h"
+
+#include <algorithm>
+#include <concepts>
+#include <functional>
+#include <ranges>
+#include <type_traits>
+
+
+namespace se
+{
+/**
+ * std::ranges::view를 감싸는 Rust 스타일 메서드 체인 래퍼
+ * @tparam V 내부 view 타입 (std::ranges::view를 만족해야 합니다)
+ *
+ * 컨테이너의 Iter() 메서드로 생성하며, 두 가지 사용 방식을 지원합니다.
+ * @code
+ * // 방식 1: IterChain (Rust 친화)
+ * arr.Iter().Filter(pred).Map(fn).Collect<Array<int>>();
+ *
+ * // 방식 2: ranges 직접 사용 (C++ 표준)
+ * arr | std::views::filter(pred) | std::views::transform(fn) | std::ranges::to<std::vector>();
+ * @endcode
+ */
+template <std::ranges::view V>
+class IterChain
+{
+    template <std::ranges::view OtherV>
+    friend class IterChain;
+
+public:
+    using ValueType = std::ranges::range_value_t<V>;
+
+    constexpr explicit IterChain(V v) noexcept(std::is_nothrow_move_constructible_v<V>)
+        : ranges_view(std::move(v))
+    {
+    }
+
+public:
+    // --- 지연 평가되는 함수 ---
+
+    /**
+     * 각 요소를 fn으로 변환합니다. (std::views::transform)
+     * @param fn 변환 함수
+     */
+    template <typename Self, typename Fn>
+        requires std::invocable<Fn, std::ranges::range_reference_t<V>>
+    [[nodiscard]] auto Map(this Self&& self, Fn&& fn)
+    {
+        auto v = std::forward<Self>(self).ranges_view | std::views::transform(std::forward<Fn>(fn));
+        return IterChain<decltype(v)>{ std::move(v) };
+    }
+
+    /**
+     * 조건을 만족하는 요소만 통과시킵니다. (std::views::filter)
+     * @param pred 조건자
+     */
+    template <typename Self, typename Pred>
+        requires std::predicate<Pred, std::ranges::range_reference_t<V>>
+    [[nodiscard]] auto Filter(this Self&& self, Pred&& pred)
+    {
+        auto v = std::forward<Self>(self).ranges_view | std::views::filter(std::forward<Pred>(pred));
+        return IterChain<decltype(v)>{ std::move(v) };
+    }
+
+    /**
+     * 각 요소를 range로 변환한 뒤 한 단계 평탄화합니다. (views::transform | views::join)
+     * @param fn 요소를 range로 변환하는 함수
+     */
+    template <typename Self, typename Fn>
+        requires std::invocable<Fn, std::ranges::range_reference_t<V>>
+        && std::ranges::input_range<std::invoke_result_t<Fn, std::ranges::range_reference_t<V>>>
+    [[nodiscard]] auto FlatMap(this Self&& self, Fn&& fn)
+    {
+        auto v = std::forward<Self>(self).ranges_view
+            | std::views::transform(std::forward<Fn>(fn))
+            | std::views::join;
+        return IterChain<decltype(v)>{ std::move(v) };
+    }
+
+    /** 앞에서 n개만 가져옵니다. (std::views::take) */
+    template <typename Self>
+    [[nodiscard]] auto Take(this Self&& self, usize n)
+    {
+        auto v = std::forward<Self>(self).ranges_view | std::views::take(static_cast<isize>(n));
+        return IterChain<decltype(v)>{ std::move(v) };
+    }
+
+    /** 앞에서 n개를 건너뜁니다. (std::views::drop) */
+    template <typename Self>
+    [[nodiscard]] auto Skip(this Self&& self, usize n)
+    {
+        auto v = std::forward<Self>(self).ranges_view | std::views::drop(static_cast<isize>(n));
+        return IterChain<decltype(v)>{ std::move(v) };
+    }
+
+    /**
+     * 각 요소에 0-based 인덱스를 붙입니다. (std::views::enumerate)
+     * @return std::tuple<index, value> 쌍의 IterChain
+     */
+    template <typename Self>
+    [[nodiscard]] auto Enumerate(this Self&& self)
+    {
+        auto v = std::forward<Self>(self).ranges_view | std::views::enumerate;
+        return IterChain<decltype(v)>{ std::move(v) };
+    }
+
+    /**
+     * 역방향으로 순회합니다. (std::views::reverse)
+     * @note bidirectional_range에서만 사용 가능합니다.
+     */
+    template <typename Self>
+        requires std::ranges::bidirectional_range<V>
+    [[nodiscard]] auto Reverse(this Self&& self)
+    {
+        auto v = std::forward<Self>(self).ranges_view | std::views::reverse;
+        return IterChain<decltype(v)>{ std::move(v) };
+    }
+
+    /**
+     * 두 IterChain을 요소별로 묶습니다. (std::views::zip)
+     * @return std::tuple<left, right> 쌍의 IterChain
+     */
+    template <typename Self, std::ranges::view OtherV>
+    [[nodiscard]] auto Zip(this Self&& self, IterChain<OtherV> other)
+    {
+        auto v = std::views::zip(std::forward<Self>(self).ranges_view, std::move(other).ranges_view);
+        return IterChain<decltype(v)>{ std::move(v) };
+    }
+
+public:
+    // --- 즉시 실행되는 함수 ---
+
+    /**
+     * 모든 요소를 Container로 변환합니다.
+     * @tparam Container 목표 컨테이너 타입. 항상 명시해야 합니다.
+     * @code
+     * arr.Iter().Filter(pred).Collect<Array<int>>();
+     * arr.Iter().Collect<std::vector<int>>();
+     * @endcode
+     */
+    template <typename Container, typename Self>
+    [[nodiscard]] Container Collect(this Self&& self)
+    {
+        auto&& v = std::forward<Self>(self).ranges_view;
+        if constexpr (requires { Container::FromRange(std::forward<decltype(v)>(v)); })
+        {
+            return Container::FromRange(std::forward<decltype(v)>(v));
+        }
+        else
+        {
+            return std::ranges::to<Container>(std::forward<decltype(v)>(v));
+        }
+    }
+
+    /** 모든 요소에 fn을 적용합니다. */
+    template <typename Self, typename Fn>
+        requires std::invocable<Fn, std::ranges::range_reference_t<V>>
+    void ForEach(this Self&& self, Fn&& fn)
+    {
+        std::ranges::for_each(std::forward<Self>(self).ranges_view, std::forward<Fn>(fn));
+    }
+
+    /**
+     * 조건을 만족하는 첫 번째 요소의 값(복사본)을 반환합니다.
+     * @return 조건을 만족하는 요소가 없으면 NullOpt를 반환합니다.
+     */
+    template <typename Self, typename Pred>
+        requires std::predicate<Pred, std::ranges::range_reference_t<V>>
+    [[nodiscard]] Optional<ValueType> Find(this Self&& self, Pred&& pred)
+    {
+        auto&& v = std::forward<Self>(self).ranges_view;
+        const auto it = std::ranges::find_if(v, std::forward<Pred>(pred));
+        if (it == std::ranges::end(v))
+        {
+            return NullOpt;
+        }
+        return *it;
+    }
+
+    /** 조건을 만족하는 요소가 하나라도 있으면 true를 반환합니다. */
+    template <typename Self, typename Pred>
+        requires std::predicate<Pred, std::ranges::range_reference_t<V>>
+    [[nodiscard]] bool Any(this Self&& self, Pred&& pred)
+    {
+        return std::ranges::any_of(std::forward<Self>(self).ranges_view, std::forward<Pred>(pred));
+    }
+
+    /** 모든 요소가 조건을 만족하면 true를 반환합니다. */
+    template <typename Self, typename Pred>
+        requires std::predicate<Pred, std::ranges::range_reference_t<V>>
+    [[nodiscard]] bool All(this Self&& self, Pred&& pred)
+    {
+        return std::ranges::all_of(std::forward<Self>(self).ranges_view, std::forward<Pred>(pred));
+    }
+
+    /** 요소의 수를 반환합니다. */
+    template <typename Self>
+    [[nodiscard]] usize Count(this Self&& self)
+    {
+        return static_cast<usize>(std::ranges::distance(std::forward<Self>(self).ranges_view));
+    }
+
+    /**
+     * 초기값 init에서 시작해 fn을 왼쪽부터 누적 적용합니다.
+     * @param init 초기 누산값
+     * @param fn (accumulator, element) -> new_accumulator
+     */
+    template <typename Self, typename Init, typename Fn>
+        requires std::invocable<Fn, Init, std::ranges::range_reference_t<V>>
+    [[nodiscard]] Init Fold(this Self&& self, Init init, Fn&& fn)
+    {
+        return std::ranges::fold_left(std::forward<Self>(self).ranges_view, std::move(init), std::forward<Fn>(fn));
+    }
+
+    /** 모든 요소의 합을 반환합니다. (초기값 ValueType{}) */
+    template <typename Self>
+    [[nodiscard]] ValueType Sum(this Self&& self)
+        requires traits::NumberType<ValueType>
+    {
+        return std::ranges::fold_left(std::forward<Self>(self).ranges_view, ValueType{}, std::plus<ValueType>{});
+    }
+
+    /** 모든 요소의 곱을 반환합니다. (초기값 ValueType{1}) */
+    template <typename Self>
+    [[nodiscard]] ValueType Product(this Self&& self)
+        requires traits::NumberType<ValueType>
+    {
+        return std::ranges::fold_left(std::forward<Self>(self).ranges_view, ValueType{ 1 }, std::multiplies<ValueType>{});
+    }
+
+    /**
+     * 최솟값을 반환합니다.
+     * @return 비어있으면 NullOpt를 반환합니다.
+     */
+    template <typename Self>
+    [[nodiscard]] Optional<ValueType> Min(this Self&& self)
+        requires std::totally_ordered<ValueType>
+    {
+        auto&& v = std::forward<Self>(self).ranges_view;
+        const auto it = std::ranges::min_element(v);
+        if (it == std::ranges::end(v))
+        {
+            return NullOpt;
+        }
+        return *it;
+    }
+
+    /**
+     * 최댓값을 반환합니다.
+     * @return 비어있으면 NullOpt를 반환합니다.
+     */
+    template <typename Self>
+    [[nodiscard]] Optional<ValueType> Max(this Self&& self)
+        requires std::totally_ordered<ValueType>
+    {
+        auto&& v = std::forward<Self>(self).ranges_view;
+        const auto it = std::ranges::max_element(v);
+        if (it == std::ranges::end(v))
+        {
+            return NullOpt;
+        }
+        return *it;
+    }
+
+    [[nodiscard]] auto begin() { return std::ranges::begin(ranges_view); }
+    [[nodiscard]] auto end() { return std::ranges::end(ranges_view); }
+    [[nodiscard]] auto begin() const requires std::ranges::range<const V> { return std::ranges::begin(ranges_view); }
+    [[nodiscard]] auto end() const requires std::ranges::range<const V> { return std::ranges::end(ranges_view); }
+
+private:
+    V ranges_view;
+};
+
+template <std::ranges::view V>
+IterChain(V) -> IterChain<V>;
+} // namespace se

--- a/EngineCore/Include/SimpleEngine/Core/Container/Map.h
+++ b/EngineCore/Include/SimpleEngine/Core/Container/Map.h
@@ -44,6 +44,8 @@ public:
 
     using IteratorType = InternalMapType::iterator;
     using ConstIteratorType = InternalMapType::const_iterator;
+    using ReverseIteratorType = InternalMapType::reverse_iterator;
+    using ConstReverseIteratorType = InternalMapType::const_reverse_iterator;
 
     using EntryType = MapEntry<Map>;
 
@@ -200,6 +202,11 @@ public:
     [[nodiscard]] IteratorType end() noexcept;
     [[nodiscard]] ConstIteratorType begin() const noexcept;
     [[nodiscard]] ConstIteratorType end() const noexcept;
+
+    [[nodiscard]] ReverseIteratorType rbegin() noexcept;
+    [[nodiscard]] ReverseIteratorType rend() noexcept;
+    [[nodiscard]] ConstReverseIteratorType rbegin() const noexcept;
+    [[nodiscard]] ConstReverseIteratorType rend() const noexcept;
 
     friend void swap(Map& lhs, Map& rhs) noexcept
     {

--- a/EngineCore/Include/SimpleEngine/Core/Container/Map.h
+++ b/EngineCore/Include/SimpleEngine/Core/Container/Map.h
@@ -35,11 +35,11 @@ private:
     friend class MapEntry<Map>;
 
     using InternalMapType = std::map<Key, Value, Pred, Allocator>;
-    using PairType = std::pair<const Key, Value>;
 
 public:
     using KeyType = Key;
     using ValueType = Value;
+    using PairType = std::pair<const Key, Value>;
     using SizeType = usize;
 
     using IteratorType = InternalMapType::iterator;
@@ -131,13 +131,28 @@ public:
     [[nodiscard]] ValueType& FindChecked(const KeyType& key);
     [[nodiscard]] const ValueType& FindChecked(const KeyType& key) const;
 
+    /** 조건자를 만족하는 첫 번째 키-값 쌍에 대한 Optional 참조를 반환합니다. */
+    template <typename Predicate>
+        requires std::predicate<Predicate, const Key&, const Value&>
+    [[nodiscard]] Optional<PairType&> FindBy(Predicate&& pred);
+
+    template <typename Predicate>
+        requires std::predicate<Predicate, const Key&, const Value&>
+    [[nodiscard]] Optional<const PairType&> FindBy(Predicate&& pred) const;
+
     /** 가장 작은 키를 가진 요소의 참조를 Optional로 반환합니다. */
-    [[nodiscard]] Optional<PairType&> First() noexcept;
-    [[nodiscard]] Optional<const PairType&> First() const noexcept;
+    [[nodiscard]] Optional<PairType&> Front() noexcept;
+    [[nodiscard]] Optional<const PairType&> Front() const noexcept;
 
     /** 가장 큰 키를 가진 요소의 참조를 Optional로 반환합니다. */
-    [[nodiscard]] Optional<PairType&> Last() noexcept;
-    [[nodiscard]] Optional<const PairType&> Last() const noexcept;
+    [[nodiscard]] Optional<PairType&> Back() noexcept;
+    [[nodiscard]] Optional<const PairType&> Back() const noexcept;
+
+    /** 가장 작은 키를 가진 요소를 제거하고 반환합니다. */
+    [[nodiscard]] Optional<PairType> PopFront();
+
+    /** 가장 큰 키를 가진 요소를 제거하고 반환합니다. */
+    [[nodiscard]] Optional<PairType> PopBack();
 
     /**
      * 주어진 키보다 크거나 같은 첫 번째 요소를 찾습니다.
@@ -178,12 +193,15 @@ public:
     /** Map의 모든 키를 담은 Array를 생성하여 반환합니다. */
     template <typename T = KeyType>
         requires std::constructible_from<T, const Key&>
-    [[nodiscard]] Array<KeyType> Keys() const;
+    [[nodiscard]] Array<T> Keys() const;
 
     /** Map의 모든 값을 담은 Array를 생성하여 반환합니다. */
     template <typename T = ValueType>
         requires std::constructible_from<T, const Value&>
-    [[nodiscard]] Array<ValueType> Values() const;
+    [[nodiscard]] Array<T> Values() const;
+
+    /** Map의 모든 키-값 쌍을 담은 Array를 생성하여 반환합니다. */
+    [[nodiscard]] Array<PairType> ToArray() const;
 
     void Swap(Map& other) noexcept;
 

--- a/EngineCore/Include/SimpleEngine/Core/Container/Map.h
+++ b/EngineCore/Include/SimpleEngine/Core/Container/Map.h
@@ -207,10 +207,18 @@ public:
 
 public:
     /**
-     * 키에 해당하는 값에 접근합니다. 키가 없으면 기본 생성된 값을 삽입 후 반환합니다.
+     * 키가 존재하면 해당 값의 참조를 반환합니다. (FindChecked()와 동일)
+     * @warning std::map의 operator[]와 달리 키가 없으면 SE_ASSERT_RELEASE로 프로그램이 종료됩니다.
+     * @note 키의 존재가 보장되지 않는다면 Find() 또는 Entry()를 사용하세요.
+     *       삽입이 필요하다면 Insert() / Emplace() / Entry()를 사용하세요.
      * @param key 접근할 키
+     * @return 키에 대응하는 값의 참조
      */
-    [[nodiscard]] ValueType& operator[](const KeyType& key);
+    template <typename Self>
+    [[nodiscard]] auto&& operator[](this Self&& self, const KeyType& key)
+    {
+        return std::forward_like<Self>(self.FindChecked(key));
+    }
 
     [[nodiscard]] bool operator==(const Map&) const = default;
     [[nodiscard]] auto operator<=>(const Map&) const = default;
@@ -225,6 +233,20 @@ public:
     [[nodiscard]] ReverseIteratorType rend() noexcept;
     [[nodiscard]] ConstReverseIteratorType rbegin() const noexcept;
     [[nodiscard]] ConstReverseIteratorType rend() const noexcept;
+
+    /** 요소를 순회하는 IterChain을 반환합니다. rvalue에서 호출하면 컨테이너를 소유합니다. */
+    template <typename Self>
+    [[nodiscard]] auto Iter(this Self&& self)
+    {
+        if constexpr (!std::is_reference_v<Self>)
+        {
+            return IterChain{ std::ranges::owning_view<std::remove_cvref_t<Self>>{ std::forward<Self>(self) } };
+        }
+        else
+        {
+            return IterChain{ std::views::all(self) };
+        }
+    }
 
     friend void swap(Map& lhs, Map& rhs) noexcept
     {

--- a/EngineCore/Include/SimpleEngine/Core/Container/Map.inl
+++ b/EngineCore/Include/SimpleEngine/Core/Container/Map.inl
@@ -317,4 +317,28 @@ Map<Key, Value, Pred, Allocator>::ConstIteratorType Map<Key, Value, Pred, Alloca
 {
     return internal_map.end();
 }
+
+template <typename Key, typename Value, typename Pred, typename Allocator>
+Map<Key, Value, Pred, Allocator>::ReverseIteratorType Map<Key, Value, Pred, Allocator>::rbegin() noexcept
+{
+    return internal_map.rbegin();
+}
+
+template <typename Key, typename Value, typename Pred, typename Allocator>
+Map<Key, Value, Pred, Allocator>::ReverseIteratorType Map<Key, Value, Pred, Allocator>::rend() noexcept
+{
+    return internal_map.rend();
+}
+
+template <typename Key, typename Value, typename Pred, typename Allocator>
+Map<Key, Value, Pred, Allocator>::ConstReverseIteratorType Map<Key, Value, Pred, Allocator>::rbegin() const noexcept
+{
+    return internal_map.rbegin();
+}
+
+template <typename Key, typename Value, typename Pred, typename Allocator>
+Map<Key, Value, Pred, Allocator>::ConstReverseIteratorType Map<Key, Value, Pred, Allocator>::rend() const noexcept
+{
+    return internal_map.rend();
+}
 } // namespace se

--- a/EngineCore/Include/SimpleEngine/Core/Container/Map.inl
+++ b/EngineCore/Include/SimpleEngine/Core/Container/Map.inl
@@ -150,7 +150,37 @@ const typename Map<Key, Value, Pred, Allocator>::ValueType& Map<Key, Value, Pred
 }
 
 template <typename Key, typename Value, typename Pred, typename Allocator>
-Optional<typename Map<Key, Value, Pred, Allocator>::PairType&> Map<Key, Value, Pred, Allocator>::First() noexcept
+template <typename Predicate>
+    requires std::predicate<Predicate, const Key&, const Value&>
+Optional<typename Map<Key, Value, Pred, Allocator>::PairType&> Map<Key, Value, Pred, Allocator>::FindBy(Predicate&& pred)
+{
+    for (auto& pair : internal_map)
+    {
+        if (pred(pair.first, pair.second))
+        {
+            return pair;
+        }
+    }
+    return NullOpt;
+}
+
+template <typename Key, typename Value, typename Pred, typename Allocator>
+template <typename Predicate>
+    requires std::predicate<Predicate, const Key&, const Value&>
+Optional<const typename Map<Key, Value, Pred, Allocator>::PairType&> Map<Key, Value, Pred, Allocator>::FindBy(Predicate&& pred) const
+{
+    for (const auto& pair : internal_map)
+    {
+        if (pred(pair.first, pair.second))
+        {
+            return pair;
+        }
+    }
+    return NullOpt;
+}
+
+template <typename Key, typename Value, typename Pred, typename Allocator>
+Optional<typename Map<Key, Value, Pred, Allocator>::PairType&> Map<Key, Value, Pred, Allocator>::Front() noexcept
 {
     if (IsEmpty())
     {
@@ -160,7 +190,7 @@ Optional<typename Map<Key, Value, Pred, Allocator>::PairType&> Map<Key, Value, P
 }
 
 template <typename Key, typename Value, typename Pred, typename Allocator>
-Optional<const typename Map<Key, Value, Pred, Allocator>::PairType&> Map<Key, Value, Pred, Allocator>::First() const noexcept
+Optional<const typename Map<Key, Value, Pred, Allocator>::PairType&> Map<Key, Value, Pred, Allocator>::Front() const noexcept
 {
     if (IsEmpty())
     {
@@ -170,7 +200,7 @@ Optional<const typename Map<Key, Value, Pred, Allocator>::PairType&> Map<Key, Va
 }
 
 template <typename Key, typename Value, typename Pred, typename Allocator>
-Optional<typename Map<Key, Value, Pred, Allocator>::PairType&> Map<Key, Value, Pred, Allocator>::Last() noexcept
+Optional<typename Map<Key, Value, Pred, Allocator>::PairType&> Map<Key, Value, Pred, Allocator>::Back() noexcept
 {
     if (IsEmpty())
     {
@@ -180,13 +210,35 @@ Optional<typename Map<Key, Value, Pred, Allocator>::PairType&> Map<Key, Value, P
 }
 
 template <typename Key, typename Value, typename Pred, typename Allocator>
-Optional<const typename Map<Key, Value, Pred, Allocator>::PairType&> Map<Key, Value, Pred, Allocator>::Last() const noexcept
+Optional<const typename Map<Key, Value, Pred, Allocator>::PairType&> Map<Key, Value, Pred, Allocator>::Back() const noexcept
 {
     if (IsEmpty())
     {
         return NullOpt;
     }
     return *(--internal_map.end());
+}
+
+template <typename Key, typename Value, typename Pred, typename Allocator>
+Optional<typename Map<Key, Value, Pred, Allocator>::PairType> Map<Key, Value, Pred, Allocator>::PopFront()
+{
+    if (IsEmpty())
+    {
+        return NullOpt;
+    }
+    auto node = internal_map.extract(internal_map.begin());
+    return PairType{ std::move(node.key()), std::move(node.mapped()) };
+}
+
+template <typename Key, typename Value, typename Pred, typename Allocator>
+Optional<typename Map<Key, Value, Pred, Allocator>::PairType> Map<Key, Value, Pred, Allocator>::PopBack()
+{
+    if (IsEmpty())
+    {
+        return NullOpt;
+    }
+    auto node = internal_map.extract(--internal_map.end());
+    return PairType{ std::move(node.key()), std::move(node.mapped()) };
 }
 
 template <typename Key, typename Value, typename Pred, typename Allocator>
@@ -255,7 +307,7 @@ Map<Key, Value, Pred, Allocator>::SizeType Map<Key, Value, Pred, Allocator>::Rem
 template <typename Key, typename Value, typename Pred, typename Allocator>
 template <typename T>
     requires std::constructible_from<T, const Key&>
-Array<typename Map<Key, Value, Pred, Allocator>::KeyType> Map<Key, Value, Pred, Allocator>::Keys() const
+Array<T> Map<Key, Value, Pred, Allocator>::Keys() const
 {
     Array<T> keys;
 
@@ -270,7 +322,7 @@ Array<typename Map<Key, Value, Pred, Allocator>::KeyType> Map<Key, Value, Pred, 
 template <typename Key, typename Value, typename Pred, typename Allocator>
 template <typename T>
     requires std::constructible_from<T, const Value&>
-Array<typename Map<Key, Value, Pred, Allocator>::ValueType> Map<Key, Value, Pred, Allocator>::Values() const
+Array<T> Map<Key, Value, Pred, Allocator>::Values() const
 {
     Array<T> values;
 
@@ -280,6 +332,18 @@ Array<typename Map<Key, Value, Pred, Allocator>::ValueType> Map<Key, Value, Pred
         values.Emplace(value);
     }
     return values;
+}
+
+template <typename Key, typename Value, typename Pred, typename Allocator>
+Array<typename Map<Key, Value, Pred, Allocator>::PairType> Map<Key, Value, Pred, Allocator>::ToArray() const
+{
+    Array<PairType> result;
+    result.Reserve(Len());
+    for (const auto& pair : internal_map)
+    {
+        result.Push(pair);
+    }
+    return result;
 }
 
 template <typename Key, typename Value, typename Pred, typename Allocator>

--- a/EngineCore/Include/SimpleEngine/Core/Container/Map.inl
+++ b/EngineCore/Include/SimpleEngine/Core/Container/Map.inl
@@ -132,21 +132,17 @@ Optional<const typename Map<Key, Value, Pred, Allocator>::ValueType&> Map<Key, V
 template <typename Key, typename Value, typename Pred, typename Allocator>
 typename Map<Key, Value, Pred, Allocator>::ValueType& Map<Key, Value, Pred, Allocator>::FindChecked(const KeyType& key)
 {
-    if (auto it = internal_map.find(key); it != internal_map.end())
-    {
-        return it->second;
-    }
-    SE_UNREACHABLE();
+    auto it = internal_map.find(key);
+    SE_ASSERT_RELEASE(it != internal_map.end());
+    return it->second;
 }
 
 template <typename Key, typename Value, typename Pred, typename Allocator>
 const typename Map<Key, Value, Pred, Allocator>::ValueType& Map<Key, Value, Pred, Allocator>::FindChecked(const KeyType& key) const
 {
-    if (auto it = internal_map.find(key); it != internal_map.end())
-    {
-        return it->second;
-    }
-    SE_UNREACHABLE();
+    auto it = internal_map.find(key);
+    SE_ASSERT_RELEASE(it != internal_map.end());
+    return it->second;
 }
 
 template <typename Key, typename Value, typename Pred, typename Allocator>
@@ -352,11 +348,6 @@ void Map<Key, Value, Pred, Allocator>::Swap(Map& other) noexcept
     std::swap(internal_map, other.internal_map);
 }
 
-template <typename Key, typename Value, typename Pred, typename Allocator>
-Map<Key, Value, Pred, Allocator>::ValueType& Map<Key, Value, Pred, Allocator>::operator[](const KeyType& key)
-{
-    return internal_map[key];
-}
 
 template <typename Key, typename Value, typename Pred, typename Allocator>
 Map<Key, Value, Pred, Allocator>::IteratorType Map<Key, Value, Pred, Allocator>::begin() noexcept

--- a/EngineCore/Include/SimpleEngine/Core/Container/Optional.h
+++ b/EngineCore/Include/SimpleEngine/Core/Container/Optional.h
@@ -266,6 +266,18 @@ public:
         return std::invoke(std::forward<Fn>(func));
     }
 
+    /** 값이 존재할 때, fn(const T&)을 호출해 부수 효과를 실행하고 자기 자신을 그대로 반환합니다. */
+    template <typename Self, typename Fn>
+        requires std::invocable<Fn, const T&>
+    constexpr auto&& Inspect(this Self&& self, Fn&& func)
+    {
+        if (self.HasValue())
+        {
+            std::invoke(std::forward<Fn>(func), *std::as_const(self));
+        }
+        return std::forward<Self>(self);
+    }
+
 public:
     [[nodiscard]] constexpr explicit operator bool() const
     {
@@ -476,6 +488,18 @@ public:
         return std::invoke(std::forward<Fn>(func));
     }
 
+    /** 값이 존재할 때, fn(const T*)을 호출해 부수 효과를 실행하고 자기 자신을 그대로 반환합니다. */
+    template <typename Fn>
+        requires std::invocable<Fn, const T*>
+    [[nodiscard]] constexpr const Optional& Inspect(Fn&& func) const
+    {
+        if (HasValue())
+        {
+            std::invoke(std::forward<Fn>(func), static_cast<const T*>(value_ptr));
+        }
+        return *this;
+    }
+
 public:
     [[nodiscard]] constexpr explicit operator bool() const { return HasValue(); }
 
@@ -651,6 +675,18 @@ public:
             return *this;
         }
         return std::invoke(std::forward<Fn>(func));
+    }
+
+    /** 값이 존재할 때, fn(const T&)을 호출해 부수 효과를 실행하고 자기 자신을 그대로 반환합니다. */
+    template <typename Fn>
+        requires std::invocable<Fn, const T&>
+    [[nodiscard]] constexpr const Optional& Inspect(Fn&& func) const
+    {
+        if (HasValue())
+        {
+            std::invoke(std::forward<Fn>(func), std::as_const(*value_ptr));
+        }
+        return *this;
     }
 
 public:

--- a/EngineCore/Include/SimpleEngine/Core/Container/PriorityQueue.h
+++ b/EngineCore/Include/SimpleEngine/Core/Container/PriorityQueue.h
@@ -88,12 +88,6 @@ public:
      */
     Optional<ValueType> Pop();
 
-    /**
-     * 내부 컨테이너를 복사하여 반환합니다.
-     * @note 반환된 Array는 힙 속성을 가지지만 정렬되어 있지는 않습니다.
-     */
-    [[nodiscard]] ContainerType ToUnderlyingContainer() const;
-
     void Swap(PriorityQueue& other) noexcept;
 
 public:

--- a/EngineCore/Include/SimpleEngine/Core/Container/PriorityQueue.h
+++ b/EngineCore/Include/SimpleEngine/Core/Container/PriorityQueue.h
@@ -1,11 +1,13 @@
 // ReSharper disable CppRedundantTypenameKeyword
 #pragma once
-#include <algorithm>
-#include <functional>
-#include <initializer_list>
 
 #include "SimpleEngine/Core/Container/Array.h"
 #include "SimpleEngine/Core/Container/Optional.h"
+
+#include <functional>
+#include <initializer_list>
+#include <iterator>
+#include <ranges>
 
 
 namespace se
@@ -104,101 +106,6 @@ private:
     ContainerType container; // 내부 컨테이너
     CompareType comp;        // 비교 함수 객체
 };
-
-template <typename T, typename Container, typename Compare>
-PriorityQueue<T, Container, Compare>::PriorityQueue(std::initializer_list<ValueType> init_list)
-    : container(init_list)
-    , comp{}
-{
-    std::ranges::make_heap(container, comp);
-}
-
-template <typename T, typename Container, typename Compare>
-template <std::input_iterator It, std::sentinel_for<It> Sent>
-    requires std::same_as<std::iter_value_t<It>, T>
-PriorityQueue<T, Container, Compare>::PriorityQueue(It first, Sent last)
-    : container(first, last)
-    , comp{}
-{
-    std::ranges::make_heap(container, comp);
-}
-
-template <typename T, typename Container, typename Compare>
-bool PriorityQueue<T, Container, Compare>::IsEmpty() const noexcept
-{
-    return container.IsEmpty();
-}
-
-template <typename T, typename Container, typename Compare>
-PriorityQueue<T, Container, Compare>::SizeType PriorityQueue<T, Container, Compare>::Len() const noexcept
-{
-    return container.Len();
-}
-
-template <typename T, typename Container, typename Compare>
-void PriorityQueue<T, Container, Compare>::Clear() noexcept
-{
-    container.Clear();
-}
-
-template <typename T, typename Container, typename Compare>
-void PriorityQueue<T, Container, Compare>::Push(const ValueType& value)
-{
-    container.Push(value);
-    std::ranges::push_heap(container, comp);
-}
-
-template <typename T, typename Container, typename Compare>
-void PriorityQueue<T, Container, Compare>::Push(ValueType&& value)
-{
-    container.Push(std::move(value));
-    std::ranges::push_heap(container, comp);
-}
-
-template <typename T, typename Container, typename Compare>
-template <std::ranges::input_range Rng>
-    requires std::same_as<std::ranges::range_value_t<Rng>, T>
-void PriorityQueue<T, Container, Compare>::PushRange(Rng&& range)
-{
-    container.PushRange(std::forward<Rng>(range));
-    std::ranges::make_heap(container, comp);
-}
-
-template <typename T, typename Container, typename Compare>
-template <typename... Args>
-void PriorityQueue<T, Container, Compare>::Emplace(Args&&... args)
-{
-    container.Emplace(std::forward<Args>(args)...);
-    std::ranges::push_heap(container, comp);
-}
-
-template <typename T, typename Container, typename Compare>
-Optional<const typename PriorityQueue<T, Container, Compare>::ValueType&> PriorityQueue<T, Container, Compare>::Peek() const
-{
-    return container.Front();
-}
-
-template <typename T, typename Container, typename Compare>
-Optional<typename PriorityQueue<T, Container, Compare>::ValueType> PriorityQueue<T, Container, Compare>::Pop()
-{
-    if (IsEmpty())
-    {
-        return NullOpt;
-    }
-    std::ranges::pop_heap(container, comp);
-    return container.Pop();
-}
-
-template <typename T, typename Container, typename Compare>
-PriorityQueue<T, Container, Compare>::ContainerType PriorityQueue<T, Container, Compare>::ToUnderlyingContainer() const
-{
-    return container;
-}
-
-template <typename T, typename Container, typename Compare>
-void PriorityQueue<T, Container, Compare>::Swap(PriorityQueue& other) noexcept
-{
-    container.Swap(other.container);
-    std::swap(comp, other.comp);
-}
 } // namespace se
+
+#include "SimpleEngine/Core/Container/PriorityQueue.inl"

--- a/EngineCore/Include/SimpleEngine/Core/Container/PriorityQueue.inl
+++ b/EngineCore/Include/SimpleEngine/Core/Container/PriorityQueue.inl
@@ -1,0 +1,106 @@
+// ReSharper disable CppRedundantTypenameKeyword
+#pragma once
+
+#include <algorithm>
+#include <utility>
+
+
+namespace se
+{
+template <typename T, typename Container, typename Compare>
+PriorityQueue<T, Container, Compare>::PriorityQueue(std::initializer_list<ValueType> init_list)
+    : container(init_list)
+    , comp{}
+{
+    std::ranges::make_heap(container, comp);
+}
+
+template <typename T, typename Container, typename Compare>
+template <std::input_iterator It, std::sentinel_for<It> Sent>
+    requires std::same_as<std::iter_value_t<It>, T>
+PriorityQueue<T, Container, Compare>::PriorityQueue(It first, Sent last)
+    : container(first, last)
+    , comp{}
+{
+    std::ranges::make_heap(container, comp);
+}
+
+template <typename T, typename Container, typename Compare>
+bool PriorityQueue<T, Container, Compare>::IsEmpty() const noexcept
+{
+    return container.IsEmpty();
+}
+
+template <typename T, typename Container, typename Compare>
+PriorityQueue<T, Container, Compare>::SizeType PriorityQueue<T, Container, Compare>::Len() const noexcept
+{
+    return container.Len();
+}
+
+template <typename T, typename Container, typename Compare>
+void PriorityQueue<T, Container, Compare>::Clear() noexcept
+{
+    container.Clear();
+}
+
+template <typename T, typename Container, typename Compare>
+void PriorityQueue<T, Container, Compare>::Push(const ValueType& value)
+{
+    container.Push(value);
+    std::ranges::push_heap(container, comp);
+}
+
+template <typename T, typename Container, typename Compare>
+void PriorityQueue<T, Container, Compare>::Push(ValueType&& value)
+{
+    container.Push(std::move(value));
+    std::ranges::push_heap(container, comp);
+}
+
+template <typename T, typename Container, typename Compare>
+template <std::ranges::input_range Rng>
+    requires std::same_as<std::ranges::range_value_t<Rng>, T>
+void PriorityQueue<T, Container, Compare>::PushRange(Rng&& range)
+{
+    container.PushRange(std::forward<Rng>(range));
+    std::ranges::make_heap(container, comp);
+}
+
+template <typename T, typename Container, typename Compare>
+template <typename... Args>
+void PriorityQueue<T, Container, Compare>::Emplace(Args&&... args)
+{
+    container.Emplace(std::forward<Args>(args)...);
+    std::ranges::push_heap(container, comp);
+}
+
+template <typename T, typename Container, typename Compare>
+Optional<const typename PriorityQueue<T, Container, Compare>::ValueType&> PriorityQueue<T, Container, Compare>::Peek() const
+{
+    return container.Front();
+}
+
+template <typename T, typename Container, typename Compare>
+Optional<typename PriorityQueue<T, Container, Compare>::ValueType> PriorityQueue<T, Container, Compare>::Pop()
+{
+    if (IsEmpty())
+    {
+        return NullOpt;
+    }
+    std::ranges::pop_heap(container, comp);
+    return container.Pop();
+}
+
+template <typename T, typename Container, typename Compare>
+PriorityQueue<T, Container, Compare>::ContainerType PriorityQueue<T, Container, Compare>::ToUnderlyingContainer() const
+{
+    return container;
+}
+
+template <typename T, typename Container, typename Compare>
+void PriorityQueue<T, Container, Compare>::Swap(PriorityQueue& other) noexcept
+{
+    container.Swap(other.container);
+    std::swap(comp, other.comp);
+}
+} // namespace se

--- a/EngineCore/Include/SimpleEngine/Core/Container/PriorityQueue.inl
+++ b/EngineCore/Include/SimpleEngine/Core/Container/PriorityQueue.inl
@@ -92,12 +92,6 @@ Optional<typename PriorityQueue<T, Container, Compare>::ValueType> PriorityQueue
 }
 
 template <typename T, typename Container, typename Compare>
-PriorityQueue<T, Container, Compare>::ContainerType PriorityQueue<T, Container, Compare>::ToUnderlyingContainer() const
-{
-    return container;
-}
-
-template <typename T, typename Container, typename Compare>
 void PriorityQueue<T, Container, Compare>::Swap(PriorityQueue& other) noexcept
 {
     container.Swap(other.container);

--- a/EngineCore/Include/SimpleEngine/Core/Container/Queue.h
+++ b/EngineCore/Include/SimpleEngine/Core/Container/Queue.h
@@ -36,12 +36,12 @@ public:
     void Clear() noexcept;
 
     /** Queue의 맨 앞에 있는 요소(가장 먼저 나갈 요소)에 대한 Optional 참조를 반환합니다. */
-    [[nodiscard]] Optional<ValueType&> Front();
-    [[nodiscard]] Optional<const ValueType&> Front() const;
+    [[nodiscard]] Optional<ValueType&> PeekFront();
+    [[nodiscard]] Optional<const ValueType&> PeekFront() const;
 
     /** Queue의 맨 뒤에 있는 요소(가장 마지막에 들어온 요소)에 대한 Optional 참조를 반환합니다. */
-    [[nodiscard]] Optional<ValueType&> Back();
-    [[nodiscard]] Optional<const ValueType&> Back() const;
+    [[nodiscard]] Optional<ValueType&> PeekBack();
+    [[nodiscard]] Optional<const ValueType&> PeekBack() const;
 
     /**
      * Queue의 맨 뒤에 새 요소를 추가합니다.
@@ -105,25 +105,25 @@ void Queue<T, Container>::Clear() noexcept
 }
 
 template <typename T, typename Container>
-Optional<typename Queue<T, Container>::ValueType&> Queue<T, Container>::Front()
+Optional<typename Queue<T, Container>::ValueType&> Queue<T, Container>::PeekFront()
 {
     return container.Front();
 }
 
 template <typename T, typename Container>
-Optional<const typename Queue<T, Container>::ValueType&> Queue<T, Container>::Front() const
+Optional<const typename Queue<T, Container>::ValueType&> Queue<T, Container>::PeekFront() const
 {
     return container.Front();
 }
 
 template <typename T, typename Container>
-Optional<typename Queue<T, Container>::ValueType&> Queue<T, Container>::Back()
+Optional<typename Queue<T, Container>::ValueType&> Queue<T, Container>::PeekBack()
 {
     return container.Back();
 }
 
 template <typename T, typename Container>
-Optional<const typename Queue<T, Container>::ValueType&> Queue<T, Container>::Back() const
+Optional<const typename Queue<T, Container>::ValueType&> Queue<T, Container>::PeekBack() const
 {
     return container.Back();
 }

--- a/EngineCore/Include/SimpleEngine/Core/Container/Set.h
+++ b/EngineCore/Include/SimpleEngine/Core/Container/Set.h
@@ -130,6 +130,20 @@ public:
     [[nodiscard]] ConstReverseIteratorType rbegin() const noexcept;
     [[nodiscard]] ConstReverseIteratorType rend() const noexcept;
 
+    /** 요소를 순회하는 IterChain을 반환합니다. rvalue에서 호출하면 컨테이너를 소유합니다. */
+    template <typename Self>
+    [[nodiscard]] auto Iter(this Self&& self)
+    {
+        if constexpr (!std::is_reference_v<Self>)
+        {
+            return IterChain{ std::ranges::owning_view<std::remove_cvref_t<Self>>{ std::forward<Self>(self) } };
+        }
+        else
+        {
+            return IterChain{ std::views::all(self) };
+        }
+    }
+
     friend void swap(Set& lhs, Set& rhs) noexcept
     {
         lhs.Swap(rhs);

--- a/EngineCore/Include/SimpleEngine/Core/Container/Set.h
+++ b/EngineCore/Include/SimpleEngine/Core/Container/Set.h
@@ -33,6 +33,8 @@ public:
 
     using IteratorType = InternalSetType::iterator;
     using ConstIteratorType = InternalSetType::const_iterator;
+    using ReverseIteratorType = InternalSetType::reverse_iterator;
+    using ConstReverseIteratorType = InternalSetType::const_reverse_iterator;
 
 public:
     Set() = default;
@@ -122,6 +124,11 @@ public:
     [[nodiscard]] IteratorType end() noexcept;
     [[nodiscard]] ConstIteratorType begin() const noexcept;
     [[nodiscard]] ConstIteratorType end() const noexcept;
+
+    [[nodiscard]] ReverseIteratorType rbegin() noexcept;
+    [[nodiscard]] ReverseIteratorType rend() noexcept;
+    [[nodiscard]] ConstReverseIteratorType rbegin() const noexcept;
+    [[nodiscard]] ConstReverseIteratorType rend() const noexcept;
 
     friend void swap(Set& lhs, Set& rhs) noexcept
     {

--- a/EngineCore/Include/SimpleEngine/Core/Container/Set.inl
+++ b/EngineCore/Include/SimpleEngine/Core/Container/Set.inl
@@ -119,4 +119,28 @@ Set<T, Pred, Allocator>::ConstIteratorType Set<T, Pred, Allocator>::end() const 
 {
     return internal_set.end();
 }
+
+template <typename T, typename Pred, typename Allocator>
+Set<T, Pred, Allocator>::ReverseIteratorType Set<T, Pred, Allocator>::rbegin() noexcept
+{
+    return internal_set.rbegin();
+}
+
+template <typename T, typename Pred, typename Allocator>
+Set<T, Pred, Allocator>::ReverseIteratorType Set<T, Pred, Allocator>::rend() noexcept
+{
+    return internal_set.rend();
+}
+
+template <typename T, typename Pred, typename Allocator>
+Set<T, Pred, Allocator>::ConstReverseIteratorType Set<T, Pred, Allocator>::rbegin() const noexcept
+{
+    return internal_set.rbegin();
+}
+
+template <typename T, typename Pred, typename Allocator>
+Set<T, Pred, Allocator>::ConstReverseIteratorType Set<T, Pred, Allocator>::rend() const noexcept
+{
+    return internal_set.rend();
+}
 } // namespace se

--- a/EngineCore/Include/SimpleEngine/Core/Container/Stack.h
+++ b/EngineCore/Include/SimpleEngine/Core/Container/Stack.h
@@ -36,8 +36,8 @@ public:
     void Clear() noexcept;
 
     /** Stack의 맨 위에 있는 요소(가장 마지막에 들어온 요소)에 대한 Optional 참조를 반환합니다. */
-    [[nodiscard]] Optional<ValueType&> Top();
-    [[nodiscard]] Optional<const ValueType&> Top() const;
+    [[nodiscard]] Optional<ValueType&> Peek();
+    [[nodiscard]] Optional<const ValueType&> Peek() const;
 
     /**
      * Stack의 스택의 맨 위에 새 요소를 추가합니다.
@@ -101,13 +101,13 @@ void Stack<T, Container>::Clear() noexcept
 }
 
 template <typename T, typename Container>
-Optional<typename Stack<T, Container>::ValueType&> Stack<T, Container>::Top()
+Optional<typename Stack<T, Container>::ValueType&> Stack<T, Container>::Peek()
 {
     return container.Back();
 }
 
 template <typename T, typename Container>
-Optional<const typename Stack<T, Container>::ValueType&> Stack<T, Container>::Top() const
+Optional<const typename Stack<T, Container>::ValueType&> Stack<T, Container>::Peek() const
 {
     return container.Back();
 }

--- a/EngineCore/Include/SimpleEngine/Core/Container/Stack.h
+++ b/EngineCore/Include/SimpleEngine/Core/Container/Stack.h
@@ -47,7 +47,7 @@ public:
     void Push(ValueType&& value);
 
     /**
-     * @brief Stack의 맨 위에 새 요소를 내부 생성(emplace)합니다.
+     * Stack의 맨 위에 새 요소를 내부 생성(emplace)합니다.
      * @return 생성된 요소의 참조
      */
     template <typename... Args>

--- a/EngineCore/Include/SimpleEngine/Core/Container/String.h
+++ b/EngineCore/Include/SimpleEngine/Core/Container/String.h
@@ -194,7 +194,7 @@ public:
      * 문자열의 크기를 new_size로 변경합니다. 추가된 메모리 공간은 초기화되지 않습니다.
      * @param new_size 변경할 문자열의 길이 (Null 문자 제외)
      */
-    void ResizeForOverwrite(SizeType new_size);
+    void ResizeUninitialized(SizeType new_size);
 
     /** 메모리 용량을 실제 크기에 맞게 줄입니다. */
     void ShrinkToFit();

--- a/EngineCore/Include/SimpleEngine/Core/Container/String.inl
+++ b/EngineCore/Include/SimpleEngine/Core/Container/String.inl
@@ -176,7 +176,7 @@ void BaseString<Allocator>::Reserve(SizeType new_capacity)
 }
 
 template <typename Allocator>
-void BaseString<Allocator>::ResizeForOverwrite(SizeType new_size)
+void BaseString<Allocator>::ResizeUninitialized(SizeType new_size)
 {
     data.ResizeUninitialized(new_size + 1); // null terminator 공간 추가
     data[new_size] = '\0';

--- a/EngineCore/Include/SimpleEngine/Core/Error/Expected.h
+++ b/EngineCore/Include/SimpleEngine/Core/Error/Expected.h
@@ -278,6 +278,30 @@ public:
         return ResultT{ std::forward<Self>(self).Value() };
     }
 
+    /** Ok 상태일 때, fn(const T&)을 호출해 부수 효과를 실행하고 자기 자신을 그대로 반환합니다. */
+    template <typename Self, typename Fn>
+        requires std::invocable<Fn, const T&>
+    [[nodiscard]] constexpr auto&& Inspect(this Self&& self, Fn&& func)
+    {
+        if (self.has_value)
+        {
+            std::invoke(std::forward<Fn>(func), *std::as_const(self));
+        }
+        return std::forward<Self>(self);
+    }
+
+    /** Err 상태일 때, fn(const E&)을 호출해 부수 효과를 실행하고 자기 자신을 그대로 반환합니다. */
+    template <typename Self, typename Fn>
+        requires std::invocable<Fn, const E&>
+    [[nodiscard]] constexpr auto&& InspectError(this Self&& self, Fn&& func)
+    {
+        if (!self.has_value)
+        {
+            std::invoke(std::forward<Fn>(func), static_cast<const E&>(self.Error()));
+        }
+        return std::forward<Self>(self);
+    }
+
 public:
     [[nodiscard]] constexpr explicit operator bool() const noexcept { return has_value; }
 
@@ -533,6 +557,30 @@ public:
             return ResultT{ Unexpected(std::invoke(std::forward<Fn>(func), std::forward<Self>(self).Error())) };
         }
         return ResultT{};
+    }
+
+    /** Ok 상태일 때, fn()을 호출해 부수 효과를 실행하고 자기 자신을 그대로 반환합니다. */
+    template <typename Self, typename Fn>
+        requires std::invocable<Fn>
+    [[nodiscard]] constexpr auto&& Inspect(this Self&& self, Fn&& func)
+    {
+        if (self.has_value)
+        {
+            std::invoke(std::forward<Fn>(func));
+        }
+        return std::forward<Self>(self);
+    }
+
+    /** Err 상태일 때, fn(const E&)을 호출해 부수 효과를 실행하고 자기 자신을 그대로 반환합니다. */
+    template <typename Self, typename Fn>
+        requires std::invocable<Fn, const E&>
+    [[nodiscard]] constexpr auto&& InspectError(this Self&& self, Fn&& func)
+    {
+        if (!self.has_value)
+        {
+            std::invoke(std::forward<Fn>(func), static_cast<const E&>(self.Error()));
+        }
+        return std::forward<Self>(self);
     }
 
 private:

--- a/EngineCore/Source/Core/Config/ConfigFile.cpp
+++ b/EngineCore/Source/Core/Config/ConfigFile.cpp
@@ -39,7 +39,7 @@ Expected<ConfigFile, String> ConfigFile::Load(const VPath& config_file_path)
     toml::table parsed = std::move(result).table();
 
     // 캐시에 저장 (복사본)
-    table_cache[path_key] = parsed;
+    table_cache.Insert(path_key, parsed);
 
     return ConfigFile{ std::move(parsed) };
 }
@@ -75,7 +75,7 @@ bool ConfigFile::Save(const VPath& config_file_path) const
     }
 
     // 저장 성공 시 캐시 갱신
-    table_cache[physical_path_str] = root_table;
+    table_cache.Insert(physical_path_str, root_table);
 
     rollback.Discard();
     return true;

--- a/EngineCore/Source/Core/Engine/Engine.cpp
+++ b/EngineCore/Source/Core/Engine/Engine.cpp
@@ -44,8 +44,8 @@ Array<TypeId> TopologicalSort(const Array<TypeId>& nodes, DepsFn&& get_dependenc
 
     for (const TypeId& id : nodes)
     {
-        in_degree[id] = 0;
-        adj_list[id] = {};
+        in_degree.Insert(id, 0);
+        adj_list.Insert(id, Array<TypeId>{});
     }
 
     for (const TypeId& id : nodes)

--- a/EngineCore/Source/Core/FileSystem/VFS.cpp
+++ b/EngineCore/Source/Core/FileSystem/VFS.cpp
@@ -40,7 +40,7 @@ void VFS::Mount(StringView scheme, const Path& physical_path, i32 priority)
     std::unique_lock lock(mutex);
 
     const StringName scheme_name{ scheme };
-    Array<MountPoint>& points = mount_points[scheme_name];
+    Array<MountPoint>& points = mount_points.Entry(scheme_name).OrDefault();
 
     // 이미 존재하는지 확인
     const MountPoint* it = std::ranges::find_if(points, [&](const MountPoint& point)

--- a/EngineCore/Source/Core/Reflection/TypeRegistry.cpp
+++ b/EngineCore/Source/Core/Reflection/TypeRegistry.cpp
@@ -28,7 +28,7 @@ void TypeRegistry::Resolve()
         // info가 구현하는 모든 인터페이스를 순회
         for (const TypeId& interface_id : info.interfaces | std::views::keys)
         {
-            interface_implementations_map[interface_id].Push(&info);
+            interface_implementations_map.Entry(interface_id).OrDefault().Push(&info);
         }
     }
 

--- a/EngineCore/Source/Core/Serialization/MemoryArchive.cpp
+++ b/EngineCore/Source/Core/Serialization/MemoryArchive.cpp
@@ -77,7 +77,7 @@ void MemoryReader::SerializeString(String& value)
 {
     u64 length = 0;
     ReadPrimitive(length);
-    value.ResizeForOverwrite(length);
+    value.ResizeUninitialized(length);
     ReadBytes(value.Data(), length);
 }
 

--- a/EngineCore/Source/Core/Types/Path.cpp
+++ b/EngineCore/Source/Core/Types/Path.cpp
@@ -472,7 +472,7 @@ String Path::NormalizePath(StringView input)
 
     // 작업 버퍼 할당 (최악의 경우 원본과 동일 길이)
     String buffer;
-    buffer.ResizeForOverwrite(len);
+    buffer.ResizeUninitialized(len);
     char* buf = buffer.Data();
 
     // Step 1: 복사하면서 '\' -> '/'

--- a/EngineCore/Source/Core/Types/VPath.cpp
+++ b/EngineCore/Source/Core/Types/VPath.cpp
@@ -143,7 +143,7 @@ void VPath::ParseAndNormalize(StringView path)
         return;
     }
 
-    full_path.ResizeForOverwrite(path.ByteLen());
+    full_path.ResizeUninitialized(path.ByteLen());
 
     // 경로 정규화 (\ -> /) 및 복사
     char* dest = full_path.Data();

--- a/EngineCore/Source/Graphics/Manager/PSOManager.cpp
+++ b/EngineCore/Source/Graphics/Manager/PSOManager.cpp
@@ -89,11 +89,11 @@ SDL_GPUGraphicsPipeline* PSOManager::GetOrCreateGraphicsPipeline(const GraphicsP
         return nullptr;
     }
 
-    cached_graphics_pipelines[create_info] = pipeline;
+    cached_graphics_pipelines.Insert(create_info, pipeline);
 
     // 역추적 인덱스 등록
-    graphics_shader_to_pipeline_map[create_info.vertex_shader].Push(create_info);
-    graphics_shader_to_pipeline_map[create_info.fragment_shader].Push(create_info);
+    graphics_shader_to_pipeline_map.Entry(create_info.vertex_shader).OrDefault().Push(create_info);
+    graphics_shader_to_pipeline_map.Entry(create_info.fragment_shader).OrDefault().Push(create_info);
 
     return pipeline;
 }
@@ -119,10 +119,10 @@ SDL_GPUComputePipeline* PSOManager::GetOrCreateComputePipeline(const ComputePipe
         return nullptr;
     }
 
-    cached_compute_pipelines[create_info] = pipeline;
+    cached_compute_pipelines.Insert(create_info, pipeline);
 
     // 역추적 인덱스 등록
-    compute_shader_to_pipeline_map[create_info.compute_shader].Push(create_info);
+    compute_shader_to_pipeline_map.Entry(create_info.compute_shader).OrDefault().Push(create_info);
 
     return pipeline;
 }

--- a/EngineCore/Source/Graphics/Manager/ShaderCache.cpp
+++ b/EngineCore/Source/Graphics/Manager/ShaderCache.cpp
@@ -41,8 +41,8 @@ SDL_GPUShader* ShaderCache::GetOrCreateShader(const VPath& shader_key, SDL_Shade
         return nullptr;
     }
 
-    graphics_cache[shader_key] = result.shader;
-    reflection_cache[shader_key] = std::move(result.reflection);
+    graphics_cache.Insert(shader_key, result.shader);
+    reflection_cache.Insert(shader_key, std::move(result.reflection));
     return result.shader;
 }
 
@@ -61,8 +61,8 @@ void ShaderCache::LoadShaderFromMemory(const VPath& shader_key, SDL_ShaderCross_
         return;
     }
 
-    graphics_cache[shader_key] = result.shader;
-    reflection_cache[shader_key] = std::move(result.reflection);
+    graphics_cache.Insert(shader_key, result.shader);
+    reflection_cache.Insert(shader_key, std::move(result.reflection));
 }
 
 void ShaderCache::Invalidate(const VPath& shader_key)

--- a/EngineCore/Source/Graphics/RenderGraph/FrameResourcePool.cpp
+++ b/EngineCore/Source/Graphics/RenderGraph/FrameResourcePool.cpp
@@ -108,7 +108,7 @@ FrameResourcePool::~FrameResourcePool()
 SDL_GPUTexture* FrameResourcePool::AcquireTexture(const SDL_GPUTextureCreateInfo& info)
 {
     SE_MEM_SCOPE("GPU:Transient");
-    return AcquireResourceInternal(texture_pool[info], [this, &info = std::as_const(info)]
+    return AcquireResourceInternal(texture_pool.Entry(info).OrDefault(), [this, &info = std::as_const(info)]
     {
         PooledResource<SDL_GPUTexture> pooled;
         pooled.resource = SDL_CreateGPUTexture(render_device->GetRawDevice(), &info);
@@ -126,13 +126,13 @@ SDL_GPUTexture* FrameResourcePool::AcquireTexture(const SDL_GPUTextureCreateInfo
 
 void FrameResourcePool::ReleaseTexture(const SDL_GPUTextureCreateInfo& info, SDL_GPUTexture* texture)
 {
-    ReleaseResourceInternal(texture_pool[info], texture);
+    ReleaseResourceInternal(texture_pool.Entry(info).OrDefault(), texture);
 }
 
 SDL_GPUBuffer* FrameResourcePool::AcquireBuffer(const SDL_GPUBufferCreateInfo& info)
 {
     SE_MEM_SCOPE("GPU:Transient");
-    return AcquireResourceInternal(buffer_pool[info], [this, &info = std::as_const(info)]
+    return AcquireResourceInternal(buffer_pool.Entry(info).OrDefault(), [this, &info = std::as_const(info)]
     {
         PooledResource<SDL_GPUBuffer> pooled;
         pooled.resource = SDL_CreateGPUBuffer(render_device->GetRawDevice(), &info);
@@ -150,7 +150,7 @@ SDL_GPUBuffer* FrameResourcePool::AcquireBuffer(const SDL_GPUBufferCreateInfo& i
 
 void FrameResourcePool::ReleaseBuffer(const SDL_GPUBufferCreateInfo& info, SDL_GPUBuffer* buffer)
 {
-    ReleaseResourceInternal(buffer_pool[info], buffer);
+    ReleaseResourceInternal(buffer_pool.Entry(info).OrDefault(), buffer);
 }
 
 void FrameResourcePool::IncrementIdleCounters()

--- a/EngineCore/Source/Graphics/RenderGraph/RenderGraphBuilder.cpp
+++ b/EngineCore/Source/Graphics/RenderGraph/RenderGraphBuilder.cpp
@@ -97,7 +97,7 @@ RGTextureHandle RenderGraphBuilder::RegisterTextureSlot(const StringName& name)
     node.name = name;
     const u32 index = static_cast<u32>(resource_nodes.Len());
     resource_nodes.Push(std::move(node));
-    resource_name_map[name] = index;
+    resource_name_map.Insert(name, index);
     return RGTextureHandle{ .index = index };
 }
 
@@ -112,7 +112,7 @@ RGBufferHandle RenderGraphBuilder::RegisterBufferSlot(const StringName& name)
     node.name = name;
     const u32 index = static_cast<u32>(resource_nodes.Len());
     resource_nodes.Push(std::move(node));
-    resource_name_map[name] = index;
+    resource_name_map.Insert(name, index);
     return RGBufferHandle{ .index = index };
 }
 } // namespace se

--- a/EngineCore/Source/Graphics/RenderGraph/RenderGraphExecutor.cpp
+++ b/EngineCore/Source/Graphics/RenderGraph/RenderGraphExecutor.cpp
@@ -180,8 +180,8 @@ void RenderGraphExecutor::Compile(RenderGraphBuilder& builder)
             current_versions[res_idx] = out_version; // 버전 리스트 업데이트
 
             // 해당 버전을 '이 패스가 생성(Write)했다'고 기록
-            pass_node.write_map[res_idx] = out_version;
-            builder.resource_nodes[res_idx].version_to_writer[out_version] = static_cast<u32>(pass_idx);
+            pass_node.write_map.Insert(res_idx, out_version);
+            builder.resource_nodes[res_idx].version_to_writer.Insert(out_version, static_cast<u32>(pass_idx));
 
             // WAW(Write-After-Write) 의존성 보장 및 암묵적 Read
             // 명시적인 Read 선언이 없더라도, 동일 리소스에 대한 쓰기 작업(AddPass) 순서가 보장되도록

--- a/EngineTest/Source/UnitTests/ContainerTests.cpp
+++ b/EngineTest/Source/UnitTests/ContainerTests.cpp
@@ -894,11 +894,11 @@ TEST_F(HashMapAPI_Test, Construction)
 TEST_F(HashMapAPI_Test, AccessAndModification)
 {
     HashMap<String, int> map;
-    map["one"] = 1;
+    map.Insert("one", 1);
     EXPECT_EQ(map.Len(), 1);
     EXPECT_EQ(map["one"], 1);
 
-    map["one"] = 11;
+    map.Insert("one", 11);
     EXPECT_EQ(map["one"], 11);
 
     EXPECT_TRUE(map.Contains("one"));
@@ -935,14 +935,14 @@ TEST_F(HashMapAPI_Test, CapacityAndReserve)
     // EXPECT_EQ(map.Capacity(), 0);
     map.Reserve(10);
     EXPECT_GE(map.Capacity(), 10);
-    map["one"] = 1;
+    map.Insert("one", 1);
     EXPECT_EQ(map.Len(), 1);
 }
 
 TEST_F(HashMapAPI_Test, EntryAPI)
 {
     HashMap<String, int> map;
-    map["existing"] = 10;
+    map.Insert("existing", 10);
 
     // Insert new entry
     auto entry1 = map.Entry("new");
@@ -1054,11 +1054,11 @@ TEST_F(MapAPI_Test, Construction)
 TEST_F(MapAPI_Test, AccessAndModification)
 {
     Map<String, int> map;
-    map["one"] = 1;
+    map.Insert("one", 1);
     EXPECT_EQ(map.Len(), 1);
     EXPECT_EQ(map["one"], 1);
 
-    map["one"] = 11;
+    map.Insert("one", 11);
     EXPECT_EQ(map["one"], 11);
 
     EXPECT_TRUE(map.Contains("one"));
@@ -1091,7 +1091,7 @@ TEST_F(MapAPI_Test, RemoveAndClear)
 TEST_F(MapAPI_Test, EntryAPI)
 {
     Map<String, int> map;
-    map["existing"] = 10;
+    map.Insert("existing", 10);
 
     // Insert new entry
     auto entry1 = map.Entry("new");

--- a/EngineTest/Source/UnitTests/ContainerTests.cpp
+++ b/EngineTest/Source/UnitTests/ContainerTests.cpp
@@ -476,6 +476,38 @@ TEST_F(ArrayAPI_Test, CopyAndMoveSemantics)
     EXPECT_TRUE(arr3.IsEmpty());
 }
 
+TEST_F(ArrayAPI_Test, Partition)
+{
+    Array<int> arr = { 1, 2, 3, 4, 5, 6 };
+    auto [evens, odds] = arr.Partition([](int v) { return v % 2 == 0; });
+    EXPECT_EQ(evens.Len(), 3);
+    EXPECT_EQ(odds.Len(), 3);
+    EXPECT_EQ(evens[0], 2);
+    EXPECT_EQ(evens[1], 4);
+    EXPECT_EQ(evens[2], 6);
+    EXPECT_EQ(odds[0], 1);
+    EXPECT_EQ(odds[1], 3);
+    EXPECT_EQ(odds[2], 5);
+
+    // 모두 조건 통과
+    Array<int> arr2 = { 2, 4, 6 };
+    auto [all_pass, none] = arr2.Partition([](int v) { return v % 2 == 0; });
+    EXPECT_EQ(all_pass.Len(), 3);
+    EXPECT_EQ(none.Len(), 0);
+
+    // 아무것도 조건 미통과
+    Array<int> arr3 = { 1, 3, 5 };
+    auto [no_pass, all_fail] = arr3.Partition([](int v) { return v % 2 == 0; });
+    EXPECT_EQ(no_pass.Len(), 0);
+    EXPECT_EQ(all_fail.Len(), 3);
+
+    // 빈 배열
+    Array<int> empty;
+    auto [e1, e2] = empty.Partition([](int v) { return v > 0; });
+    EXPECT_EQ(e1.Len(), 0);
+    EXPECT_EQ(e2.Len(), 0);
+}
+
 TEST_F(StringAPI_Test, Construction)
 {
     String s1;
@@ -871,6 +903,32 @@ TEST_F(DequeAPI_Test, CopyAndMoveSemantics)
     EXPECT_TRUE(d3.IsEmpty());
 }
 
+TEST_F(DequeAPI_Test, Partition)
+{
+    Deque<int> d = { 1, 2, 3, 4, 5, 6 };
+    auto [evens, odds] = d.Partition([](int v) { return v % 2 == 0; });
+    EXPECT_EQ(evens.Len(), 3);
+    EXPECT_EQ(odds.Len(), 3);
+    EXPECT_EQ(evens[0], 2);
+    EXPECT_EQ(evens[1], 4);
+    EXPECT_EQ(evens[2], 6);
+    EXPECT_EQ(odds[0], 1);
+    EXPECT_EQ(odds[1], 3);
+    EXPECT_EQ(odds[2], 5);
+
+    // 모두 조건 통과
+    Deque<int> d2 = { 2, 4, 6 };
+    auto [all_pass, none] = d2.Partition([](int v) { return v % 2 == 0; });
+    EXPECT_EQ(all_pass.Len(), 3);
+    EXPECT_EQ(none.Len(), 0);
+
+    // 빈 Deque
+    Deque<int> empty;
+    auto [e1, e2] = empty.Partition([](int v) { return v > 0; });
+    EXPECT_EQ(e1.Len(), 0);
+    EXPECT_EQ(e2.Len(), 0);
+}
+
 TEST_F(HashMapAPI_Test, Construction)
 {
     HashMap<String, int> map1;
@@ -1029,6 +1087,48 @@ TEST_F(HashMapAPI_Test, Emplace)
     // Modify through returned reference
     val2 = "modified_value";
     EXPECT_EQ(*map.Find("key1"), "modified_value");
+}
+
+TEST_F(HashMapAPI_Test, FindBy)
+{
+    HashMap<String, int> map = { { "a", 1 }, { "b", 2 }, { "c", 3 } };
+
+    auto result = map.FindBy([](const String&, const int& v) { return v == 2; });
+    EXPECT_TRUE(result.HasValue());
+    EXPECT_EQ(result->second, 2);
+
+    auto no_result = map.FindBy([](const String&, const int& v) { return v == 99; });
+    EXPECT_FALSE(no_result.HasValue());
+
+    const HashMap<String, int>& const_map = map;
+    auto const_result = const_map.FindBy([](const String&, const int& v) { return v == 3; });
+    EXPECT_TRUE(const_result.HasValue());
+    EXPECT_EQ(const_result->second, 3);
+
+    // 빈 맵
+    HashMap<String, int> empty_map;
+    EXPECT_FALSE(empty_map.FindBy([](const String&, const int&) { return true; }).HasValue());
+}
+
+TEST_F(HashMapAPI_Test, ToArray)
+{
+    HashMap<String, int> map = { { "a", 1 }, { "b", 2 }, { "c", 3 } };
+    auto arr = map.ToArray();
+    EXPECT_EQ(arr.Len(), 3);
+    bool found_a = false, found_b = false, found_c = false;
+    for (const auto& pair : arr)
+    {
+        if (pair.first == "a" && pair.second == 1) { found_a = true; }
+        if (pair.first == "b" && pair.second == 2) { found_b = true; }
+        if (pair.first == "c" && pair.second == 3) { found_c = true; }
+    }
+    EXPECT_TRUE(found_a);
+    EXPECT_TRUE(found_b);
+    EXPECT_TRUE(found_c);
+
+    // 빈 맵
+    HashMap<String, int> empty_map;
+    EXPECT_EQ(empty_map.ToArray().Len(), 0);
 }
 
 TEST_F(MapAPI_Test, Construction)
@@ -1216,6 +1316,68 @@ TEST_F(MapAPI_Test, Front_Back_Bounds)
     EXPECT_FALSE(empty_map.Back().HasValue());
     EXPECT_FALSE(empty_map.LowerBoundEntry(1).HasValue());
     EXPECT_FALSE(empty_map.UpperBoundEntry(1).HasValue());
+}
+
+TEST_F(MapAPI_Test, PopFrontAndPopBack)
+{
+    Map<int, String> map = { { 10, "ten" }, { 20, "twenty" }, { 30, "thirty" } };
+
+    auto front = map.PopFront();
+    EXPECT_TRUE(front.HasValue());
+    EXPECT_EQ(front->first, 10);
+    EXPECT_EQ(front->second, "ten");
+    EXPECT_EQ(map.Len(), 2);
+    EXPECT_FALSE(map.Contains(10));
+
+    auto back = map.PopBack();
+    EXPECT_TRUE(back.HasValue());
+    EXPECT_EQ(back->first, 30);
+    EXPECT_EQ(back->second, "thirty");
+    EXPECT_EQ(map.Len(), 1);
+
+    map.PopFront();
+    EXPECT_TRUE(map.IsEmpty());
+
+    // 빈 맵
+    EXPECT_FALSE(map.PopFront().HasValue());
+    EXPECT_FALSE(map.PopBack().HasValue());
+}
+
+TEST_F(MapAPI_Test, FindBy)
+{
+    Map<int, String> map = { { 1, "one" }, { 2, "two" }, { 3, "three" } };
+
+    auto result = map.FindBy([](const int&, const String& v) { return v == "two"; });
+    EXPECT_TRUE(result.HasValue());
+    EXPECT_EQ(result->first, 2);
+    EXPECT_EQ(result->second, "two");
+
+    auto no_result = map.FindBy([](const int&, const String& v) { return v == "four"; });
+    EXPECT_FALSE(no_result.HasValue());
+
+    const Map<int, String>& const_map = map;
+    auto const_result = const_map.FindBy([](const int&, const String& v) { return v == "one"; });
+    EXPECT_TRUE(const_result.HasValue());
+    EXPECT_EQ(const_result->first, 1);
+
+    // 빈 맵
+    Map<int, String> empty_map;
+    EXPECT_FALSE(empty_map.FindBy([](const int&, const String&) { return true; }).HasValue());
+}
+
+TEST_F(MapAPI_Test, ToArray)
+{
+    Map<int, String> map = { { 3, "three" }, { 1, "one" }, { 2, "two" } };
+    auto arr = map.ToArray();
+    EXPECT_EQ(arr.Len(), 3);
+    // Map은 정렬된 순서 보장
+    EXPECT_EQ(arr[0].first, 1);
+    EXPECT_EQ(arr[1].first, 2);
+    EXPECT_EQ(arr[2].first, 3);
+
+    // 빈 맵
+    Map<int, String> empty_map;
+    EXPECT_EQ(empty_map.ToArray().Len(), 0);
 }
 
 TEST_F(HashSetAPI_Test, DefaultConstruction)

--- a/EngineTest/Source/UnitTests/ContainerTests.cpp
+++ b/EngineTest/Source/UnitTests/ContainerTests.cpp
@@ -1184,17 +1184,17 @@ TEST_F(MapAPI_Test, Emplace)
     EXPECT_EQ(*map.Find("key1"), "modified_value");
 }
 
-TEST_F(MapAPI_Test, First_Last_Bounds)
+TEST_F(MapAPI_Test, Front_Back_Bounds)
 {
     Map<int, String> map = { { 10, "ten" }, { 20, "twenty" }, { 30, "thirty" } };
 
-    EXPECT_TRUE(map.First().HasValue());
-    EXPECT_EQ(map.First()->first, 10);
-    EXPECT_EQ(map.First()->second, "ten");
+    EXPECT_TRUE(map.Front().HasValue());
+    EXPECT_EQ(map.Front()->first, 10);
+    EXPECT_EQ(map.Front()->second, "ten");
 
-    EXPECT_TRUE(map.Last().HasValue());
-    EXPECT_EQ(map.Last()->first, 30);
-    EXPECT_EQ(map.Last()->second, "thirty");
+    EXPECT_TRUE(map.Back().HasValue());
+    EXPECT_EQ(map.Back()->first, 30);
+    EXPECT_EQ(map.Back()->second, "thirty");
 
     auto lower = map.LowerBoundEntry(20);
     EXPECT_TRUE(lower.HasValue());
@@ -1212,8 +1212,8 @@ TEST_F(MapAPI_Test, First_Last_Bounds)
     EXPECT_FALSE(upper2.HasValue());
 
     Map<int, String> empty_map;
-    EXPECT_FALSE(empty_map.First().HasValue());
-    EXPECT_FALSE(empty_map.Last().HasValue());
+    EXPECT_FALSE(empty_map.Front().HasValue());
+    EXPECT_FALSE(empty_map.Back().HasValue());
     EXPECT_FALSE(empty_map.LowerBoundEntry(1).HasValue());
     EXPECT_FALSE(empty_map.UpperBoundEntry(1).HasValue());
 }
@@ -1654,18 +1654,6 @@ TEST_F(PriorityQueueAPI_Test, Clear)
     EXPECT_TRUE(pq.IsEmpty());
     EXPECT_EQ(pq.Len(), 0);
     EXPECT_FALSE(pq.Peek().HasValue());
-}
-
-TEST_F(PriorityQueueAPI_Test, ToUnderlyingContainer)
-{
-    PriorityQueue<int> pq = { 10, 30, 20 };
-    Array<int> arr = pq.ToUnderlyingContainer();
-    EXPECT_EQ(arr.Len(), 3);
-    // The underlying container is a heap, not necessarily sorted
-    // So we EXPECT_TRUE if the elements are present
-    EXPECT_TRUE(arr.Contains(10));
-    EXPECT_TRUE(arr.Contains(20));
-    EXPECT_TRUE(arr.Contains(30));
 }
 
 TEST_F(PriorityQueueAPI_Test, Min_Heap_CustomCompare)

--- a/EngineTest/Source/UnitTests/FlatContainerTests.cpp
+++ b/EngineTest/Source/UnitTests/FlatContainerTests.cpp
@@ -22,7 +22,7 @@ TEST_F(FlatSetAPI_Test, InitializerListConstruction)
     FlatSet<int> set = { 3, 1, 4, 1, 5, 9, 2, 6, 5 };
     // 중복 제거 및 정렬 확인: {1, 2, 3, 4, 5, 6, 9}
     EXPECT_EQ(set.Len(), 7);
-    
+
     int expected[] = { 1, 2, 3, 4, 5, 6, 9 };
     int i = 0;
     for (int val : set)
@@ -37,7 +37,7 @@ TEST_F(FlatSetAPI_Test, InsertAndContains)
     EXPECT_TRUE(set.Insert(10));
     EXPECT_TRUE(set.Insert(20));
     EXPECT_FALSE(set.Insert(10)); // 중복 삽입
-    
+
     EXPECT_EQ(set.Len(), 2);
     EXPECT_TRUE(set.Contains(10));
     EXPECT_TRUE(set.Contains(20));
@@ -78,7 +78,7 @@ TEST_F(FlatMapAPI_Test, InitializerListConstruction)
         { 2, "Two" },
         { 1, "Duplicate" } // 중복 키
     };
-    
+
     // 정렬 확인 (키 기준)
     EXPECT_EQ(map.Len(), 3);
     EXPECT_TRUE(map.Contains(1));
@@ -91,11 +91,11 @@ TEST_F(FlatMapAPI_Test, InsertAndAccess)
     FlatMap<int, String> map;
     map.Insert(1, "One");
     map.Emplace(2, "Two");
-    
+
     EXPECT_EQ(map[1], "One");
     EXPECT_EQ(map[2], "Two");
-    
-    map[3] = "Three"; // operator[]를 통한 삽입
+
+    map.Insert(3, "Three");
     EXPECT_EQ(map.Len(), 3);
     EXPECT_EQ(map.FindChecked(3), "Three");
 }
@@ -103,11 +103,11 @@ TEST_F(FlatMapAPI_Test, InsertAndAccess)
 TEST_F(FlatMapAPI_Test, Find)
 {
     FlatMap<int, String> map = { { 10, "Ten" } };
-    
+
     auto result = map.Find(10);
     EXPECT_TRUE(result.HasValue());
     EXPECT_EQ(*result, "Ten");
-    
+
     auto fail = map.Find(20);
     EXPECT_FALSE(fail.HasValue());
 }
@@ -124,13 +124,13 @@ TEST_F(FlatMapAPI_Test, Remove)
 TEST_F(FlatMapAPI_Test, EntryAPI)
 {
     FlatMap<int, int> map;
-    
+
     // Vacant Entry
     auto entry = map.Entry(10);
     EXPECT_TRUE(entry.IsVacant());
     entry.OrInsert(100);
     EXPECT_EQ(map[10], 100);
-    
+
     // Occupied Entry
     auto entry2 = map.Entry(10);
     EXPECT_TRUE(entry2.IsOccupied());
@@ -141,12 +141,12 @@ TEST_F(FlatMapAPI_Test, EntryAPI)
 TEST_F(FlatMapAPI_Test, KeysAndValues)
 {
     FlatMap<int, String> map = { { 1, "A" }, { 2, "B" }, { 3, "C" } };
-    
+
     auto keys = map.Keys();
     EXPECT_EQ(keys.Len(), 3);
     EXPECT_EQ(keys[0], 1);
     EXPECT_EQ(keys[2], 3);
-    
+
     auto values = map.Values();
     EXPECT_EQ(values.Len(), 3);
     EXPECT_EQ(values[0], "A");
@@ -156,15 +156,15 @@ TEST_F(FlatMapAPI_Test, KeysAndValues)
 TEST_F(FlatMapAPI_Test, LowerUpperBound)
 {
     FlatMap<int, String> map = { { 10, "Ten" }, { 30, "Thirty" }, { 50, "Fifty" } };
-    
+
     auto lb = map.LowerBoundEntry(20); // 30 기대
     EXPECT_TRUE(lb.HasValue());
     EXPECT_EQ(lb->first, 30);
-    
+
     auto lb2 = map.LowerBoundEntry(30); // 30 기대
     EXPECT_TRUE(lb2.HasValue());
     EXPECT_EQ(lb2->first, 30);
-    
+
     auto ub = map.UpperBoundEntry(30); // 50 기대
     EXPECT_TRUE(ub.HasValue());
     EXPECT_EQ(ub->first, 50);

--- a/EngineTest/Source/UnitTests/FlatContainerTests.cpp
+++ b/EngineTest/Source/UnitTests/FlatContainerTests.cpp
@@ -169,3 +169,65 @@ TEST_F(FlatMapAPI_Test, LowerUpperBound)
     EXPECT_TRUE(ub.HasValue());
     EXPECT_EQ(ub->first, 50);
 }
+
+TEST_F(FlatMapAPI_Test, PopFrontAndPopBack)
+{
+    FlatMap<int, String> map = { { 10, "ten" }, { 20, "twenty" }, { 30, "thirty" } };
+
+    auto front = map.PopFront();
+    EXPECT_TRUE(front.HasValue());
+    EXPECT_EQ(front->first, 10);
+    EXPECT_EQ(front->second, "ten");
+    EXPECT_EQ(map.Len(), 2);
+    EXPECT_FALSE(map.Contains(10));
+
+    auto back = map.PopBack();
+    EXPECT_TRUE(back.HasValue());
+    EXPECT_EQ(back->first, 30);
+    EXPECT_EQ(back->second, "thirty");
+    EXPECT_EQ(map.Len(), 1);
+
+    map.PopFront();
+    EXPECT_TRUE(map.IsEmpty());
+
+    // 빈 맵
+    EXPECT_FALSE(map.PopFront().HasValue());
+    EXPECT_FALSE(map.PopBack().HasValue());
+}
+
+TEST_F(FlatMapAPI_Test, FindBy)
+{
+    FlatMap<int, String> map = { { 1, "one" }, { 2, "two" }, { 3, "three" } };
+
+    auto result = map.FindBy([](const int&, const String& v) { return v == "two"; });
+    EXPECT_TRUE(result.HasValue());
+    EXPECT_EQ(result->first, 2);
+    EXPECT_EQ(result->second, "two");
+
+    auto no_result = map.FindBy([](const int&, const String& v) { return v == "four"; });
+    EXPECT_FALSE(no_result.HasValue());
+
+    const FlatMap<int, String>& const_map = map;
+    auto const_result = const_map.FindBy([](const int&, const String& v) { return v == "one"; });
+    EXPECT_TRUE(const_result.HasValue());
+    EXPECT_EQ(const_result->first, 1);
+
+    // 빈 맵
+    FlatMap<int, String> empty_map;
+    EXPECT_FALSE(empty_map.FindBy([](const int&, const String&) { return true; }).HasValue());
+}
+
+TEST_F(FlatMapAPI_Test, ToArray)
+{
+    FlatMap<int, String> map = { { 3, "three" }, { 1, "one" }, { 2, "two" } };
+    auto arr = map.ToArray();
+    EXPECT_EQ(arr.Len(), 3);
+    // FlatMap은 정렬된 순서 보장
+    EXPECT_EQ(arr[0].first, 1);
+    EXPECT_EQ(arr[1].first, 2);
+    EXPECT_EQ(arr[2].first, 3);
+
+    // 빈 맵
+    FlatMap<int, String> empty_map;
+    EXPECT_EQ(empty_map.ToArray().Len(), 0);
+}

--- a/EngineTest/Source/UnitTests/IterChainTests.cpp
+++ b/EngineTest/Source/UnitTests/IterChainTests.cpp
@@ -1,0 +1,222 @@
+#include "gtest/gtest.h"
+
+#include "SimpleEngine/Core/Container/Array.h"
+#include "SimpleEngine/Core/Container/Deque.h"
+#include "SimpleEngine/Core/Container/FlatMap.h"
+#include "SimpleEngine/Core/Container/HashMap.h"
+#include "SimpleEngine/Core/Container/IterChain.h"
+#include "SimpleEngine/Core/Container/Map.h"
+
+#include <tuple>
+#include <vector>
+
+class IterChainTest : public ::testing::Test {};
+
+using namespace se;
+
+// -------------------------------------------------------------------------
+// Array 기반 기본 체인
+// -------------------------------------------------------------------------
+
+TEST_F(IterChainTest, MapAndFilter)
+{
+    Array<int> arr = { 1, 2, 3, 4, 5 };
+
+    const auto result = arr
+        .Iter()
+        .Filter([](int x) { return x % 2 == 0; })
+        .Map([](int x) { return x * 10; })
+        .Collect<Array<int>>();
+
+    ASSERT_EQ(result.Len(), 2u);
+    EXPECT_EQ(result[0], 20);
+    EXPECT_EQ(result[1], 40);
+}
+
+TEST_F(IterChainTest, CollectIntoArray)
+{
+    Array<int> arr = { 3, 1, 4, 1, 5 };
+    const auto result = arr.Iter().Collect<Array<int>>();
+
+    ASSERT_EQ(result.Len(), 5u);
+    EXPECT_EQ(result[0], 3);
+    EXPECT_EQ(result[4], 5);
+}
+
+TEST_F(IterChainTest, CollectIntoStdVector)
+{
+    Array<int> arr = { 1, 2, 3 };
+    const auto result = arr.Iter().Collect<std::vector<int>>();
+
+    ASSERT_EQ(result.size(), 3u);
+    EXPECT_EQ(result[0], 1);
+}
+
+TEST_F(IterChainTest, FlatMap)
+{
+    Array<Array<int>> arr = { Array<int>{ 1, 2 }, Array<int>{ 3, 4 } };
+
+    const auto result = arr
+        .Iter()
+        .FlatMap([](const Array<int>& inner) -> const Array<int>& { return inner; })
+        .Collect<Array<int>>();
+
+    ASSERT_EQ(result.Len(), 4u);
+    EXPECT_EQ(result[0], 1);
+    EXPECT_EQ(result[3], 4);
+}
+
+TEST_F(IterChainTest, TakeAndSkip)
+{
+    Array<int> arr = { 0, 1, 2, 3, 4 };
+
+    const auto taken = arr.Iter().Take(3).Collect<Array<int>>();
+    ASSERT_EQ(taken.Len(), 3u);
+    EXPECT_EQ(taken[2], 2);
+
+    const auto skipped = arr.Iter().Skip(2).Collect<Array<int>>();
+    ASSERT_EQ(skipped.Len(), 3u);
+    EXPECT_EQ(skipped[0], 2);
+}
+
+TEST_F(IterChainTest, Enumerate)
+{
+    Array<int> arr = { 10, 20, 30 };
+
+    usize sum_idx = 0;
+    int  sum_val  = 0;
+    arr.Iter().Enumerate().ForEach([&](auto pair)
+    {
+        auto [idx, val] = pair;
+        sum_idx += static_cast<usize>(idx);
+        sum_val += val;
+    });
+
+    EXPECT_EQ(sum_idx, 3u);  // 0+1+2
+    EXPECT_EQ(sum_val, 60);  // 10+20+30
+}
+
+TEST_F(IterChainTest, Reverse)
+{
+    Array<int> arr = { 1, 2, 3 };
+    const auto result = arr.Iter().Reverse().Collect<Array<int>>();
+
+    ASSERT_EQ(result.Len(), 3u);
+    EXPECT_EQ(result[0], 3);
+    EXPECT_EQ(result[2], 1);
+}
+
+TEST_F(IterChainTest, Zip)
+{
+    Array<int> a = { 1, 2, 3 };
+    Array<int> b = { 10, 20, 30 };
+
+    int sum = 0;
+    a.Iter().Zip(b.Iter()).ForEach([&](auto pair)
+    {
+        auto [x, y] = pair;
+        sum += x + y;
+    });
+
+    EXPECT_EQ(sum, 66);  // (1+10)+(2+20)+(3+30)
+}
+
+TEST_F(IterChainTest, Fold)
+{
+    Array<int> arr = { 1, 2, 3, 4, 5 };
+    const int result = arr.Iter().Fold(0, [](int acc, int x) { return acc + x; });
+    EXPECT_EQ(result, 15);
+}
+
+TEST_F(IterChainTest, AnyAll)
+{
+    Array<int> arr = { 2, 4, 6, 8 };
+    EXPECT_TRUE(arr.Iter().All([](int x) { return x % 2 == 0; }));
+    EXPECT_FALSE(arr.Iter().Any([](int x) { return x % 2 != 0; }));
+
+    Array<int> mixed = { 1, 2, 3 };
+    EXPECT_TRUE(mixed.Iter().Any([](int x) { return x == 2; }));
+    EXPECT_FALSE(mixed.Iter().All([](int x) { return x > 2; }));
+}
+
+TEST_F(IterChainTest, Count)
+{
+    Array<int> arr = { 1, 2, 3, 4, 5 };
+    EXPECT_EQ(arr.Iter().Filter([](int x) { return x > 2; }).Count(), 3u);
+}
+
+TEST_F(IterChainTest, Find)
+{
+    Array<int> arr = { 1, 2, 3, 4, 5 };
+    const Optional<int> found = arr.Iter().Find([](int x) { return x > 3; });
+    EXPECT_TRUE(found.HasValue());
+    EXPECT_EQ(found.Value(), 4);
+
+    const Optional<int> not_found = arr.Iter().Find([](int x) { return x > 10; });
+    EXPECT_FALSE(not_found.HasValue());
+}
+
+TEST_F(IterChainTest, SumProduct)
+{
+    Array<int> arr = { 1, 2, 3, 4, 5 };
+    EXPECT_EQ(arr.Iter().Sum(), 15);
+    EXPECT_EQ(arr.Iter().Product(), 120);
+}
+
+TEST_F(IterChainTest, MinMax)
+{
+    Array<int> arr = { 3, 1, 4, 1, 5, 9, 2, 6 };
+    EXPECT_EQ(arr.Iter().Min().Value(), 1);
+    EXPECT_EQ(arr.Iter().Max().Value(), 9);
+
+    Array<int> empty_arr;
+    EXPECT_FALSE(empty_arr.Iter().Min().HasValue());
+    EXPECT_FALSE(empty_arr.Iter().Max().HasValue());
+}
+
+TEST_F(IterChainTest, RvalueOwnership)
+{
+    auto make_arr = []
+    {
+        Array<int> a;
+        a.Push(1);
+        a.Push(2);
+        a.Push(3);
+        return a;
+    };
+
+    // rvalue에서 Iter()를 호출하면 owning_view로 데이터를 소유합니다.
+    const auto result = make_arr().Iter().Map([](int x) { return x * 2; }).Collect<Array<int>>();
+    ASSERT_EQ(result.Len(), 3u);
+    EXPECT_EQ(result[0], 2);
+    EXPECT_EQ(result[2], 6);
+}
+
+// -------------------------------------------------------------------------
+// Map 기반 체인
+// -------------------------------------------------------------------------
+
+TEST_F(IterChainTest, MapContainerIter)
+{
+    Map<int, int> m;
+    m.Insert(1, 10);
+    m.Insert(2, 20);
+    m.Insert(3, 30);
+
+    // Map의 Iter()는 pair<const int, int>를 순회합니다.
+    const int sum_keys = m.Iter()
+        .Map([](const auto& kv) { return kv.first; })
+        .Fold(0, [](int acc, int k) { return acc + k; });
+
+    EXPECT_EQ(sum_keys, 6);
+}
+
+TEST_F(IterChainTest, HashMapContainerIter)
+{
+    HashMap<int, int> hm;
+    hm.Insert(1, 100);
+    hm.Insert(2, 200);
+
+    const bool all_positive = hm.Iter().All([](const auto& kv) { return kv.second > 0; });
+    EXPECT_TRUE(all_positive);
+}

--- a/EngineTest/Source/UnitTests/RangesConceptTests.cpp
+++ b/EngineTest/Source/UnitTests/RangesConceptTests.cpp
@@ -1,0 +1,29 @@
+#include "gtest/gtest.h"
+
+#include "SimpleEngine/Core/Container/Array.h"
+#include "SimpleEngine/Core/Container/Deque.h"
+#include "SimpleEngine/Core/Container/FlatMap.h"
+#include "SimpleEngine/Core/Container/FlatSet.h"
+#include "SimpleEngine/Core/Container/HashMap.h"
+#include "SimpleEngine/Core/Container/HashSet.h"
+#include "SimpleEngine/Core/Container/Map.h"
+#include "SimpleEngine/Core/Container/Set.h"
+
+// 컴파일 타임 정적 검증
+// 모든 컨테이너가 기대하는 ranges concept을 만족하는지 확인합니다.
+static_assert(std::ranges::contiguous_range<se::Array<int>>);
+static_assert(std::ranges::random_access_range<se::Array<int>>);
+static_assert(std::ranges::random_access_range<se::Deque<int>>);
+static_assert(std::ranges::bidirectional_range<se::Map<int, int>>);
+static_assert(std::ranges::bidirectional_range<se::FlatMap<int, int>>);
+static_assert(std::ranges::forward_range<se::HashMap<int, int>>);
+static_assert(std::ranges::bidirectional_range<se::Set<int>>);
+static_assert(std::ranges::bidirectional_range<se::FlatSet<int>>);
+static_assert(std::ranges::forward_range<se::HashSet<int>>);
+
+// 빈 테스트 스위트
+// static_assert가 통과하면 빌드 성공
+TEST(RangesConceptTest, StaticAssertionsPass)
+{
+    SUCCEED();
+}

--- a/EngineTest/Source/UnitTests/SerializationTest.cpp
+++ b/EngineTest/Source/UnitTests/SerializationTest.cpp
@@ -376,9 +376,9 @@ TEST_F(SerializationTest, DeepNesting)
     MemoryWriter writer(buffer);
 
     Outer original;
-    original.middles[1].inners.Push({10});
-    original.middles[1].inners.Push({20});
-    original.middles[2].inners.Push({30});
+    original.middles.Entry(1).OrDefault().inners.Push({10});
+    original.middles.Entry(1).OrDefault().inners.Push({20});
+    original.middles.Entry(2).OrDefault().inners.Push({30});
 
     writer << original;
 
@@ -474,8 +474,8 @@ TEST_F(SerializationTest, MixedContainers)
     MemoryWriter writer(buffer);
 
     HashMap<String, Array<i32>> map_of_arrays;
-    map_of_arrays["first"] = Array<i32>{1, 2, 3};
-    map_of_arrays["second"] = Array<i32>{10, 20};
+    map_of_arrays.Insert("first", Array<i32>{1, 2, 3});
+    map_of_arrays.Insert("second", Array<i32>{10, 20});
 
     Array<HashMap<String, String>> array_of_maps;
     array_of_maps.Push(HashMap<String, String>{ {"a", "A"}, {"b", "B"} });

--- a/EngineTest/Source/UnitTests/TomlArchiveTest.cpp
+++ b/EngineTest/Source/UnitTests/TomlArchiveTest.cpp
@@ -764,8 +764,8 @@ TEST_F(TomlArchiveTest, SpecialStringCharacters)
 TEST_F(TomlArchiveTest, DeepNesting)
 {
     DeepNestingLevel1 original_data;
-    original_data.children["first"] = DeepNestingLevel2{ .items = { {1}, {2}, {3} } };
-    original_data.children["second"] = DeepNestingLevel2{ .items = { {10}, {20}, {30} } };
+    original_data.children.Insert("first",  DeepNestingLevel2{ .items = { {1}, {2}, {3} } });
+    original_data.children.Insert("second", DeepNestingLevel2{ .items = { {10}, {20}, {30} } });
 
     toml::table tbl;
     {
@@ -834,7 +834,7 @@ TEST_F(TomlArchiveTest, LargeData)
     // Create large map with 500 entries
     for (i32 i = 0; i < 500; ++i)
     {
-        original_data.large_map[i] = String::Format("Value_{}", i);
+        original_data.large_map.Insert(i, String::Format("Value_{}", i));
     }
 
     toml::table tbl;
@@ -867,8 +867,8 @@ TEST_F(TomlArchiveTest, NestedEmptyContainers)
     original_data.nested_arrays.Push(Array<i32>{1, 2, 3});
     original_data.nested_arrays.Push(Array<i32>{}); // Another empty array
 
-    original_data.map_with_empty_arrays["empty"] = Array<i32>{};
-    original_data.map_with_empty_arrays["filled"] = Array<i32>{10, 20};
+    original_data.map_with_empty_arrays.Insert("empty",  Array<i32>{});
+    original_data.map_with_empty_arrays.Insert("filled", Array<i32>{10, 20});
 
     original_data.array_of_empty_maps.Push(HashMap<String, i32>{});
     original_data.array_of_empty_maps.Push(HashMap<String, i32>{ {"key", 42} });
@@ -931,14 +931,14 @@ TEST_F(TomlArchiveTest, TripleNestedArrays)
 TEST_F(TomlArchiveTest, HeterogeneousContainers)
 {
     HeteroData original_data;
-    original_data.map_of_arrays["first"] = Array<i32>{1, 2, 3};
-    original_data.map_of_arrays["second"] = Array<i32>{10, 20};
+    original_data.map_of_arrays.Insert("first", Array<i32>{1, 2, 3});
+    original_data.map_of_arrays.Insert("second", Array<i32>{10, 20});
 
     original_data.array_of_maps.Push(HashMap<String, String>{ {"a", "A"}, {"b", "B"} });
     original_data.array_of_maps.Push(HashMap<String, String>{ {"x", "X"} });
 
-    original_data.nested_maps[1] = HashMap<String, f32>{ {"pi", 3.14f}, {"e", 2.71f} };
-    original_data.nested_maps[2] = HashMap<String, f32>{ {"sqrt2", 1.41f} };
+    original_data.nested_maps.Insert(1, HashMap<String, f32>{ {"pi", 3.14f}, {"e", 2.71f} });
+    original_data.nested_maps.Insert(2, HashMap<String, f32>{ {"sqrt2", 1.41f} });
 
     toml::table tbl;
     {
@@ -1156,7 +1156,7 @@ TEST_F(TomlArchiveTest, ManyMapIterations)
     // Create map with many entries to verify iterator-based approach is O(N)
     for (i32 i = 0; i < 200; ++i)
     {
-        original_data.map[i] = String::Format("Item_{}", i);
+        original_data.map.Insert(i, String::Format("Item_{}", i));
     }
 
     toml::table tbl;
@@ -1207,7 +1207,7 @@ TEST_F(TomlArchiveTest, SingleElementContainers)
 {
     SingleElementData original_data;
     original_data.single_array.Push(42);
-    original_data.single_map["only"] = 123;
+    original_data.single_map.Insert("only", 123);
     original_data.single_set.Insert("unique");
 
     toml::table tbl;
@@ -1325,9 +1325,9 @@ TEST_F(TomlArchiveTest, GuidAsMapKey)
     Guid g2 = Guid::NewGuid();
     Guid g3 = Guid::NewGuid();
 
-    original_data.guid_map[g1] = "First";
-    original_data.guid_map[g2] = "Second";
-    original_data.guid_map[g3] = "Third";
+    original_data.guid_map.Insert(g1, "First");
+    original_data.guid_map.Insert(g2, "Second");
+    original_data.guid_map.Insert(g3, "Third");
 
     toml::table tbl;
     {
@@ -1355,8 +1355,8 @@ TEST_F(TomlArchiveTest, GuidAsMapKeyWithNestedValue)
     Guid g1 = Guid::NewGuid();
     Guid g2 = Guid::NewGuid();
 
-    original_data.guid_nested_map[g1] = NestedData{ "nested_g1", 1.1f };
-    original_data.guid_nested_map[g2] = NestedData{ "nested_g2", 2.2f };
+    original_data.guid_nested_map.Insert(g1, NestedData{ "nested_g1", 1.1f });
+    original_data.guid_nested_map.Insert(g2, NestedData{ "nested_g2", 2.2f });
 
     toml::table tbl;
     {
@@ -1382,9 +1382,9 @@ TEST_F(TomlArchiveTest, StringNameAsMapKey)
 {
     StringNameKeyMapData original_data;
 
-    original_data.sn_map["alpha"] = 100;
-    original_data.sn_map["beta"] = 200;
-    original_data.sn_map["gamma"] = 300;
+    original_data.sn_map.Insert("alpha", 100);
+    original_data.sn_map.Insert("beta", 200);
+    original_data.sn_map.Insert("gamma", 300);
 
     toml::table tbl;
     {
@@ -1412,8 +1412,8 @@ TEST_F(TomlArchiveTest, TypeIdAsMapKey)
     const TypeId transform_id = TypeId::Get<TransformComponent>();
     const TypeId subsystem_id = TypeId::Get<SubsystemBase>();
 
-    original_data.type_map[transform_id] = "transform_value";
-    original_data.type_map[subsystem_id] = "subsystem_value";
+    original_data.type_map.Insert(transform_id, "transform_value");
+    original_data.type_map.Insert(subsystem_id, "subsystem_value");
 
     toml::table tbl;
     {
@@ -1440,8 +1440,8 @@ TEST_F(TomlArchiveTest, TypeIdAsMapKeyWithNestedValue)
     const TypeId transform_id = TypeId::Get<TransformComponent>();
     const TypeId subsystem_id = TypeId::Get<SubsystemBase>();
 
-    original_data.type_nested_map[transform_id] = NestedData{ "nested_transform", 1.5f };
-    original_data.type_nested_map[subsystem_id] = NestedData{ "nested_subsystem", 2.5f };
+    original_data.type_nested_map.Insert(transform_id, NestedData{ "nested_transform", 1.5f });
+    original_data.type_nested_map.Insert(subsystem_id, NestedData{ "nested_subsystem", 2.5f });
 
     toml::table tbl;
     {


### PR DESCRIPTION
> 아래 PR 메시지는 Claude Sonnet 4.6을 사용하여 작성되었습니다.

## 개요

컨테이너 API 전반을 리팩토링하여 일관성을 높이고, Rust 스타일의 메서드 체인 API(`IterChain`)를 새롭게 추가합니다. 모든 변경사항은 빌드 및 유닛 테스트를 통과했습니다.

---

## 주요 변경사항

### 1. `IterChain` 신규 추가 (`IterChain.h`)
- `std::ranges::view`를 감싸는 Rust 스타일 메서드 체인 래퍼 클래스
- 지연 평가: `Map`, `Filter`, `FlatMap`, `Take`, `Skip`, `Enumerate`, `Reverse`, `Zip`
- 즉시 실행: `Collect`, `ForEach`, `Find`, `Any`, `All`, `Count`, `Fold`, `Sum`, `Product`, `Min`, `Max`
- 모든 컨테이너의 `Iter()` 메서드로 생성하며, rvalue에서 호출 시 컨테이너를 소유하는 `owning_view` 사용
- `Deducing This` 기반으로 const/non-const 오버로드를 단일 구현으로 통일

### 2. 컨테이너 공통 API 추가

| 메서드 | 대상 컨테이너 | 설명 |
|---|---|---|
| `Iter()` | 전체 | `IterChain` 반환 |
| `FindBy(pred)` | `Map`, `HashMap`, `FlatMap` | 조건자 기반 O(N) 검색, Pair& 반환 |
| `PopFront()` / `PopBack()` | `Map`, `FlatMap` | 최솟/최댓 키 요소 제거 후 반환 |
| `Front()` / `Back()` | `Map`, `FlatMap` | 최솟/최댓 키 요소 참조 반환 |
| `ToArray()` | `Map`, `HashMap`, `FlatMap` | 전체 요소를 `Array`로 복사 |
| `Keys()` / `Values()` | `Map`, `HashMap`, `FlatMap` | 키/값만 추출한 `Array` 반환 |
| `LowerBoundEntry()` / `UpperBoundEntry()` | `Map`, `FlatMap` | 경계 요소 참조 반환 |
| `Partition(pred)` | `Array`, `Deque` | 조건자로 두 컨테이너로 분할 |
| `Inspect()` / `InspectError()` | `Optional`, `Expected` | side-effect 체인용 콜백 메서드 |
| Reverse iterator | `Map`, `Set`, `PriorityQueue` | `rbegin()` / `rend()` |

### 3. 리팩토링

- `BaseString::ResizeForOverwrite` → `ResizeUninitialized` 로 rename (4개 호출 사이트 일괄 수정)
- `Queue::Front()` → `PeekFront()`, `Stack::Top()` → `Peek()` rename
- `PriorityQueue` 구현 로직을 `.inl` 파일로 분리
- `FixedString` 편의 함수 추가

### 4. `FlatMap::FindBy` 반환 타입 수정 (코드 리뷰 반영)
- mutable 오버로드: `Optional<ValueType&>` → `Optional<PairType&>`
- const 오버로드: `Optional<const PairType&>` (유지)
- `Front()` / `Back()`과 동일한 패턴으로 통일, Key 접근 가능
- 주석에 O(N) 선형 탐색 명시

---

## 테스트

- `IterChainTests.cpp` — IterChain 전체 API 테스트 추가
- `RangesConceptTests.cpp` — ranges/concepts 기반 API 동작 검증
- `ContainerTests.cpp` — `Array::Partition`, `Deque::Partition`, `Map::PopFront/PopBack/FindBy/ToArray`, `HashMap::FindBy/ToArray` 테스트 추가
- `FlatContainerTests.cpp` — `FlatMap::PopFront/PopBack/FindBy/ToArray` 테스트 추가