### PR TITLE
[Optimize] AsyncFileIO의 IOResult를 Zero-Copy로 넘기도록 개선

### DIFF
--- a/EngineCore/Include/SimpleEngine/Core/Concurrency/AsyncFileIO.h
+++ b/EngineCore/Include/SimpleEngine/Core/Concurrency/AsyncFileIO.h
@@ -16,6 +16,17 @@ template <typename T>
 class JobTask;
 class Path;
 
+namespace detail
+{
+struct SDLFreeDeleter
+{
+    void operator()(void* ptr) const noexcept
+    {
+        SDL_free(ptr);
+    }
+};
+} // namespace detail
+
 /**
  * 비동기 I/O 결과를 담는 구조체
  *
@@ -25,19 +36,22 @@ class Path;
 struct IOResult
 {
     /** 읽어들인 파일 데이터 */
-    std::unique_ptr<u8[], decltype(&SDL_free)> data_ptr = { nullptr, SDL_free };
+    std::unique_ptr<u8[], detail::SDLFreeDeleter> data_ptr = nullptr;
 
     /** 데이터 byte 사이즈 */
     usize data_len = 0;
 
 public:
-    /** I/O 작업이 성공했는지 확인합니다. */
+    /**
+     * 파일 데이터가 정상적으로 읽혔는지 확인합니다.
+     * @note 빈 파일(0바이트) 읽기는 실패와 동일하게 취급합니다.
+     */
     [[nodiscard]] bool Success() const noexcept
     {
         return data_ptr != nullptr;
     }
 
-    /** I/O 작업이 실패했는지 확인합니다. */
+    /** 파일 데이터 읽기에 실패했는지 확인합니다. */
     [[nodiscard]] bool Fail() const noexcept
     {
         return data_ptr == nullptr;
@@ -52,8 +66,10 @@ public:
     /** 데이터 View를 반환합니다. */
     [[nodiscard]] ArrayView<const u8> AsView() const noexcept
     {
-        return ArrayView<const u8>(data_ptr.get(), data_len);
+        return { data_ptr.get(), data_len };
     }
+
+    explicit operator bool() const noexcept { return Success(); }
 };
 
 

--- a/EngineCore/Include/SimpleEngine/Core/Concurrency/AsyncFileIO.h
+++ b/EngineCore/Include/SimpleEngine/Core/Concurrency/AsyncFileIO.h
@@ -1,10 +1,11 @@
 ﻿#pragma once
 
-#include "SimpleEngine/Core/Container/Array.h"
+#include "SimpleEngine/Core/Container/ArrayView.h"
 #include "SimpleEngine/Core/Functional/UniqueFunction.h"
 
 #include "SDL3/SDL.h"
 
+#include <memory>
 #include <thread>
 
 
@@ -24,10 +25,35 @@ class Path;
 struct IOResult
 {
     /** 읽어들인 파일 데이터 */
-    Array<u8> data;
+    std::unique_ptr<u8[], decltype(&SDL_free)> data_ptr = { nullptr, SDL_free };
 
-    /** I/O 작업의 성공 여부 */
-    bool success = false;
+    /** 데이터 byte 사이즈 */
+    usize data_len = 0;
+
+public:
+    /** I/O 작업이 성공했는지 확인합니다. */
+    [[nodiscard]] bool Success() const noexcept
+    {
+        return data_ptr != nullptr;
+    }
+
+    /** I/O 작업이 실패했는지 확인합니다. */
+    [[nodiscard]] bool Fail() const noexcept
+    {
+        return data_ptr == nullptr;
+    }
+
+    /** 데이터가 비어있는지 확인합니다. */
+    [[nodiscard]] bool IsEmpty() const noexcept
+    {
+        return data_len == 0;
+    }
+
+    /** 데이터 View를 반환합니다. */
+    [[nodiscard]] ArrayView<const u8> AsView() const noexcept
+    {
+        return ArrayView<const u8>(data_ptr.get(), data_len);
+    }
 };
 
 

--- a/EngineCore/Source/Asset/AssetSubsystem.cpp
+++ b/EngineCore/Source/Asset/AssetSubsystem.cpp
@@ -454,8 +454,7 @@ JobTask<HandleData> AssetSubsystem::LoadAsyncInternal(TypeId expected_type, Asse
 
         if (AsyncFileIO::IsInitialized())
         {
-            IOResult io_result = co_await AsyncFileIO::Get().ReadFileAsync(cache_path);
-            if (io_result.Success() && !io_result.IsEmpty())
+            if (const IOResult io_result = co_await AsyncFileIO::Get().ReadFileAsync(cache_path))
             {
                 if (const auto cache_entry = DerivedDataCache::ParseFromBuffer(io_result.AsView()))
                 {

--- a/EngineCore/Source/Asset/AssetSubsystem.cpp
+++ b/EngineCore/Source/Asset/AssetSubsystem.cpp
@@ -455,14 +455,13 @@ JobTask<HandleData> AssetSubsystem::LoadAsyncInternal(TypeId expected_type, Asse
         if (AsyncFileIO::IsInitialized())
         {
             IOResult io_result = co_await AsyncFileIO::Get().ReadFileAsync(cache_path);
-
-            if (io_result.success && !io_result.data.IsEmpty())
+            if (io_result.Success() && !io_result.IsEmpty())
             {
-                if (Optional<CacheEntry> entry_opt = DerivedDataCache::ParseFromBuffer(io_result.data))
+                if (const auto cache_entry = DerivedDataCache::ParseFromBuffer(io_result.AsView()))
                 {
-                    if (AssetPayload payload = DeserializeAssetPayload(expected_type, entry_opt->payload))
+                    if (AssetPayload payload = DeserializeAssetPayload(expected_type, cache_entry->payload))
                     {
-                        CommitLoadedPayload(handle_data, std::move(payload), entry_opt->payload.Len(), scope);
+                        CommitLoadedPayload(handle_data, std::move(payload), cache_entry->payload.Len(), scope);
                         ConsoleLog(ELogLevel::Debug, "LoadAsync: Loaded from DDC (async I/O): {}", source_path.ToString());
                         co_return handle_data;
                     }

--- a/EngineCore/Source/Core/Concurrency/AsyncFileIO.cpp
+++ b/EngineCore/Source/Core/Concurrency/AsyncFileIO.cpp
@@ -79,7 +79,6 @@ struct AsyncReadAwaitable
         if (!SDL_LoadFileAsync(path.CStr(), queue, ctx))
         {
             // SDL이 요청을 시작조차 하지 못한 경우, suspend하지 않고 즉시 복귀
-            result.success = false;
             return false;
         }
 
@@ -103,19 +102,19 @@ IOResult BuildIOResult(SDL_AsyncIOOutcome&& outcome)
     SE_SCOPE_DEFER {
         if (outcome.buffer)
         {
-            SDL_free(outcome.buffer);
-            outcome.buffer = nullptr;
+            SDL_free(std::exchange(outcome.buffer, nullptr));
         }
     };
 
     IOResult result;
-    result.success = outcome.result == SDL_ASYNCIO_COMPLETE;
+    const bool success = outcome.result == SDL_ASYNCIO_COMPLETE;
 
-    if (result.success && outcome.buffer && outcome.bytes_transferred > 0)
+    if (success && outcome.buffer && outcome.bytes_transferred > 0)
     {
-        const usize size = static_cast<usize>(outcome.bytes_transferred);
-        result.data.ResizeUninitialized(size);
-        std::memcpy(result.data.Data(), outcome.buffer, size);
+        result.data_len = static_cast<usize>(outcome.bytes_transferred);
+        result.data_ptr.reset(
+            static_cast<u8*>(std::exchange(outcome.buffer, nullptr))
+        );
     }
 
     return result;
@@ -193,7 +192,6 @@ void AsyncFileIO::ReadFile(const Path& path, UniqueFunction<void(IOResult)>&& ca
         JobSystem::Get().Dispatch([ctx]
         {
             IOResult error_result;
-            error_result.success = false;
 
             const UniqueFunction<void(IOResult)> cb = std::move(ctx->callback);
             delete ctx;

--- a/EngineTest/Source/UnitTests/AsyncFileIOTest.cpp
+++ b/EngineTest/Source/UnitTests/AsyncFileIOTest.cpp
@@ -81,9 +81,9 @@ TEST_F(AsyncFileIOTest, ReadFile_Callback_Success)
     ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
     const IOResult result = future.get();
 
-    EXPECT_TRUE(result.success);
-    EXPECT_EQ(result.data.Len(), std::strlen(TEST_CONTENT));
-    EXPECT_EQ(std::memcmp(result.data.Data(), TEST_CONTENT, result.data.Len()), 0);
+    EXPECT_TRUE(result.Success());
+    EXPECT_EQ(result.data_len, std::strlen(TEST_CONTENT));
+    EXPECT_EQ(std::memcmp(result.data_ptr.get(), TEST_CONTENT, result.data_len), 0);
 }
 
 TEST_F(AsyncFileIOTest, ReadFile_Callback_NonExistent)
@@ -99,7 +99,7 @@ TEST_F(AsyncFileIOTest, ReadFile_Callback_NonExistent)
     ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
     const IOResult result = future.get();
 
-    EXPECT_FALSE(result.success);
+    EXPECT_FALSE(result.Success());
 }
 
 TEST_F(AsyncFileIOTest, ReadFile_Callback_ExecutedOnWorker)
@@ -140,9 +140,9 @@ TEST_F(AsyncFileIOTest, ReadFileAsync_Success)
 
     h.Wait();
 
-    EXPECT_TRUE(captured_result.success);
-    EXPECT_EQ(captured_result.data.Len(), std::strlen(TEST_CONTENT));
-    EXPECT_EQ(std::memcmp(captured_result.data.Data(), TEST_CONTENT, captured_result.data.Len()), 0);
+    EXPECT_TRUE(captured_result.Success());
+    EXPECT_EQ(captured_result.data_len, std::strlen(TEST_CONTENT));
+    EXPECT_EQ(std::memcmp(captured_result.data_ptr.get(), TEST_CONTENT, captured_result.data_len), 0);
 }
 
 TEST_F(AsyncFileIOTest, ReadFileAsync_NonExistent)
@@ -170,7 +170,7 @@ TEST_F(AsyncFileIOTest, ReadFileAsync_NonExistent)
 
     h.Wait();
 
-    EXPECT_FALSE(captured_result.success);
+    EXPECT_FALSE(captured_result.Success());
 }
 
 
@@ -187,7 +187,7 @@ TEST_F(AsyncFileIOTest, ReadFile_MultipleRequests)
     {
         async_io->ReadFile(Path{ test_file_path.c_str() }, [&completed_count](IOResult result)
         {
-            if (result.success)
+            if (result.Success())
             {
                 completed_count.fetch_add(1, std::memory_order_relaxed);
             }
@@ -221,7 +221,7 @@ TEST_F(AsyncFileIOTest, ReadFileAsync_MultipleCoroutines)
             [](std::string path, std::atomic<int>& count) static -> JobTask<void>
             {
                 IOResult result = co_await AsyncFileIO::Get().ReadFileAsync(Path{ path.c_str() });
-                if (result.success)
+                if (result.Success())
                 {
                     count.fetch_add(1, std::memory_order_relaxed);
                 }

--- a/EngineTest/Source/UnitTests/AsyncFileIOTest.cpp
+++ b/EngineTest/Source/UnitTests/AsyncFileIOTest.cpp
@@ -82,8 +82,9 @@ TEST_F(AsyncFileIOTest, ReadFile_Callback_Success)
     const IOResult result = future.get();
 
     EXPECT_TRUE(result.Success());
-    EXPECT_EQ(result.data_len, std::strlen(TEST_CONTENT));
-    EXPECT_EQ(std::memcmp(result.data_ptr.get(), TEST_CONTENT, result.data_len), 0);
+    const auto view = result.AsView();
+    EXPECT_EQ(view.Len(), std::strlen(TEST_CONTENT));
+    EXPECT_EQ(std::memcmp(view.Data(), TEST_CONTENT, view.Len()), 0);
 }
 
 TEST_F(AsyncFileIOTest, ReadFile_Callback_NonExistent)
@@ -100,6 +101,29 @@ TEST_F(AsyncFileIOTest, ReadFile_Callback_NonExistent)
     const IOResult result = future.get();
 
     EXPECT_FALSE(result.Success());
+}
+
+TEST_F(AsyncFileIOTest, ReadFile_Callback_EmptyFile)
+{
+    const std::string empty_path = (std::filesystem::temp_directory_path() / "se_asyncio_empty.txt").string();
+    std::ofstream{ empty_path }.close();
+
+    std::promise<IOResult> promise;
+    auto future = promise.get_future();
+
+    async_io->ReadFile(Path{ empty_path.c_str() }, [&promise](IOResult result)
+    {
+        promise.set_value(std::move(result));
+    });
+
+    ASSERT_EQ(future.wait_for(5s), std::future_status::ready);
+    const IOResult result = future.get();
+
+    std::filesystem::remove(empty_path);
+
+    // 빈 파일(0바이트)은 데이터가 없으므로 Success() == false
+    EXPECT_FALSE(result.Success());
+    EXPECT_EQ(result.data_len, 0u);
 }
 
 TEST_F(AsyncFileIOTest, ReadFile_Callback_ExecutedOnWorker)
@@ -141,8 +165,9 @@ TEST_F(AsyncFileIOTest, ReadFileAsync_Success)
     h.Wait();
 
     EXPECT_TRUE(captured_result.Success());
-    EXPECT_EQ(captured_result.data_len, std::strlen(TEST_CONTENT));
-    EXPECT_EQ(std::memcmp(captured_result.data_ptr.get(), TEST_CONTENT, captured_result.data_len), 0);
+    const auto view = captured_result.AsView();
+    EXPECT_EQ(view.Len(), std::strlen(TEST_CONTENT));
+    EXPECT_EQ(std::memcmp(view.Data(), TEST_CONTENT, view.Len()), 0);
 }
 
 TEST_F(AsyncFileIOTest, ReadFileAsync_NonExistent)


### PR DESCRIPTION
## 요약

기존에는 SDL에서 할당한 `outcome.buffer`를 매번 `Array`로 복사했었으나, `std::unique_ptr<u8>`로 소유권을 넘겨받아서 `ArrayView<const u8>`로 반환하도록 하여 복사 오버헤드를 제거하였습니다.